### PR TITLE
Remove devices cleanly when they are deleted from the configuration

### DIFF
--- a/minisys/src/test_mini.act
+++ b/minisys/src/test_mini.act
@@ -1,5 +1,7 @@
 import testing
 
+import yang.gdata as ygdata
+
 import mini.layers.y_0 as cfs_layer
 import mini.layers.y_0_oper as cfs_oper
 import mini.sysspec as sysspec
@@ -43,6 +45,68 @@ actor _test_netinfra_router_oper(t: testing.AsyncT):
         after 0: poll()
 
     tr.edit_config(root.to_gdata(), cont)
+
+
+actor _test_router_delete(t: testing.AsyncT):
+    """Deleting a router must clean up all layers and the device registry"""
+    root = cfs_layer.root()
+    root.netinfra.global_settings.asn = 123
+    router = root.netinfra.router.create("rtr1", 1, "ietf")
+    router.mock = True
+
+    tr = stratoweave.test_main(sysspec.SYSSPEC, t.log_handler)
+
+    def q(n: str) -> ygdata.Id:
+        return ygdata.Id("http://example.com/netinfra", n)
+
+    delete_config = ygdata.Container({
+        q("netinfra"): ygdata.Container({
+            q("router"): ygdata.List([q("name")], [
+                ygdata.Absent({q("name"): ygdata.Leaf("rtr1")})
+            ])
+        })
+    })
+
+    var attempts = 0
+
+    def leftovers() -> ?str:
+        names = [n for n in tr.dev_registry.list()]
+        if len(names) > 0:
+            return "device registry still tracks {names}"
+        for depth in [0, 1, 2]:
+            layer_str = tr.layer_config(depth).to_yang_jsonstr()
+            if "rtr1" in layer_str:
+                return "layer {depth} still contains rtr1: {layer_str}"
+        return None
+
+    def poll():
+        attempts += 1
+        problem = leftovers()
+        if problem is not None:
+            if attempts >= 20:
+                t.failure(ValueError("Device not cleaned up after delete: {problem}"))
+                return
+            after 0.01: poll()
+            return
+        t.success()
+
+    def deleted(r: value):
+        if isinstance(r, Exception):
+            t.failure(r)
+            return
+        after 0: poll()
+
+    def created(r: value):
+        if isinstance(r, Exception):
+            t.failure(r)
+            return
+        names = [n for n in tr.dev_registry.list()]
+        if "rtr1" not in names:
+            t.failure(ValueError("Device rtr1 not tracked after create"))
+            return
+        tr.edit_config(delete_config, deleted)
+
+    tr.edit_config(root.to_gdata(), created)
 
 
 actor _test_l3vpn1(t: testing.AsyncT):

--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -246,6 +246,12 @@ class DeviceAdapter(object):
     def supports_mocking(self) -> bool:
         return False
 
+    ## Close any connection to the device. Adapters that hold no connection
+    ## inherit this no-op.
+    def close(self, on_close: ?action() -> None=None):
+        if on_close is not None:
+            on_close()
+
     set_dmc: proc(new_dmc: DeviceMetaConfig) -> None
 
     ## Configure the device with the given configuration

--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -246,8 +246,11 @@ class DeviceAdapter(object):
     def supports_mocking(self) -> bool:
         return False
 
-    ## Close any connection to the device. Adapters that hold no connection
-    ## inherit this no-op.
+    ## Permanently shut the adapter down. Called when the device is removed
+    ## from the system or the adapter is replaced; the adapter is never used
+    ## again afterwards. Implementations must close their device connection
+    ## and cancel any reconnect and subscription machinery for good, then
+    ## call on_close. Adapters that hold no connection inherit this no-op.
     def close(self, on_close: ?action() -> None=None):
         if on_close is not None:
             on_close()

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -639,6 +639,10 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
 
     var state: int = DISCONNECTED
 
+    # Set when the device has been removed from the system, see shutdown().
+    # A stopped driver must not reconnect or reschedule subscription work.
+    var stopped = False
+
     var modset: dict[str, ModCap] = {}
     var schema_hash = None
 
@@ -700,6 +704,15 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             return c is not cur
         return True
 
+    def _scheduled_restart(c: netconf.Client):
+        # Runs from `after` timers: by the time it fires the driver may have
+        # been shut down or the client replaced. Restarting then would reopen
+        # a connection that nothing manages.
+        if stopped or _is_stale(c):
+            _log.debug("Device._scheduled_restart: skipping restart of stale or stopped client")
+            return
+        c.restart()
+
     def _on_connect(c: netconf.Client, err):
         if _is_stale(c):
             _log.debug("Device._on_connect: ignoring callback from stale client")
@@ -739,7 +752,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                 if _supports_schema_discovery(c.get_capabilities()):
                     _log.error("Device._on_connect: schema discovery failed", {"error": str(error)})
                     modset = {}
-                    after 1: c.restart()
+                    after 1: _scheduled_restart(c)
                 else:
                     details = {"reason": "no schema discovery method advertised", "error": str(error)}
                     _log.warning("Device._on_connect: falling back to YANG module capabilities", details)
@@ -802,7 +815,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             if error is not None:
                 _log.error("Device._on_connect: error downloading schemas", {"error": str(error)})
                 modset = {}
-                after 1: c.restart()
+                after 1: _scheduled_restart(c)
             else:
                 _log.debug("Device._on_connect: finished downloading schemas", {"duration": sw.elapsed().to_float()})
                 sw.reset()
@@ -823,7 +836,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             modset = {}
             schema_hash = None
             if client is not None:
-                after 1: client.restart()
+                after 1: _scheduled_restart(c)
             return
         else:
             _log.info("Device._on_connect: connected to device")
@@ -899,6 +912,8 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         dmc = new_dmc
 
     def _connect(new_dmc):
+        if stopped:
+            return
         use_mock_server = system_mock or new_dmc.mock.enabled or len(new_dmc.mock.module.elements) > 0
 
         username = new_dmc.credentials.username
@@ -964,6 +979,31 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             _log.debug("Device.close: No client, nothing to close")
         if on_close is not None:
             on_close()
+
+    def shutdown(on_close: ?action() -> None=None):
+        """Permanently shut down the device driver
+
+        Used when the device is removed from the system. Unlike close(),
+        which is part of the reconnect cycle, shutdown() also cancels all
+        subscriptions and invalidates scheduled reconnect retries, so the
+        driver goes permanently quiet.
+        """
+        if stopped:
+            if on_close is not None:
+                on_close()
+            return
+        stopped = True
+        _log.info("Device.shutdown")
+        # Notify subscription owners once, then drop all subscription state.
+        # Pending _sub_start/_sub_tick timers die against the empty subs dict.
+        for owner_id in sub_owners.keys():
+            _owner_publish(owner_id, NotConnectedError("device removed"))
+        subs = {}
+        sub_owners = {}
+        yp_subid_spec = {}
+        yp_spec_subid = {}
+        yp_pending = set()
+        close(on_close)
 
     # TODO: Restart protocol
     def restart():
@@ -1777,6 +1817,9 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             subs[spec] = st
 
     def declare_subscriptions(owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
+        if stopped:
+            cb(None, NotConnectedError("device removed"))
+            return
         old_want = set()
         last_merged = None
         if owner_id in sub_owners:
@@ -1845,9 +1888,13 @@ class NetconfAdapter(DeviceAdapter):
         return self._driver.get_config()
 
     def close(self, on_close: ?action() -> None=None):
-        """Close the connection to the device
+        """Permanently close the connection to the device
+
+        Adapter close is used when the device is removed from the system, so
+        shut the driver down for good: cancel subscriptions and reconnect
+        retries in addition to closing the connection.
         """
-        self._driver.close(on_close)
+        self._driver.shutdown(on_close)
 
     def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
         return self._driver.rpc_xml(cb, xml_rpc)

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -1890,9 +1890,10 @@ class NetconfAdapter(DeviceAdapter):
     def close(self, on_close: ?action() -> None=None):
         """Permanently close the connection to the device
 
-        Adapter close is used when the device is removed from the system, so
-        shut the driver down for good: cancel subscriptions and reconnect
-        retries in addition to closing the connection.
+        Adapter close is used when the device is removed from the system or
+        the adapter is replaced, so shut the driver down for good: cancel
+        subscriptions and reconnect retries in addition to closing the
+        connection.
         """
         self._driver.shutdown(on_close)
 

--- a/src/app.act
+++ b/src/app.act
@@ -96,7 +96,14 @@ actor RfsReconf(dev_registry: swdev.DeviceRegistry, cfs: ttt.Layer):
             break
         _rfs = _next
 
-    dev_registry.on_reconf(lambda dev: _rfs.edit_config(_rfs_for_device(dev), force=True))
+    def _reconf(dev: str):
+        # A reconf event may arrive after the device has been removed from
+        # the registry; re-injecting the rfs entry would resurrect state for
+        # a deleted device.
+        if dev_registry.get(dev) is not None:
+            _rfs.edit_config(_rfs_for_device(dev), force=True)
+
+    dev_registry.on_reconf(_reconf)
 
 
 actor StartupConfigApplier(config_files: list[str], exit_on_done: bool, top_schema: yschema.DRoot, cfs: ttt.Layer, exit: action(int) -> None, rfcap: file.ReadFileCap, log_handler: logging.Handler):

--- a/src/device.act
+++ b/src/device.act
@@ -84,8 +84,8 @@ actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPC
         dev = devices.get(name)
         if dev is not None:
             del devices[name]
-            if name in devices_needing_approval:
-                del devices_needing_approval[name]
+            # stop() unregisters the device from devices_needing_approval
+            # through _update_approval_state().
             dev.stop()
 
     def on_reconf(on_reconf: action(str) -> None):
@@ -100,9 +100,11 @@ actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPC
     def unregister_needs_approval(name: str):
         """Unregister a device from needing approval
 
-        For example when all configs are approved or rejected or approval-required has been disabled
+        For example when all configs are approved or rejected or approval-required has been disabled.
+        Unknown names are ignored: a registration can race a device removal.
         """
-        del devices_needing_approval[name]
+        if name in devices_needing_approval:
+            del devices_needing_approval[name]
 
     def get_devices_needing_approval() -> dict[str, DeviceMgr]:
         """Get devices that have pending approvals
@@ -380,7 +382,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
         confq = {}
         current_tids = set()
         reconf_tids = set()
-        needs_approval = False
+        _update_approval_state()
 
     def get_state():
         """Get the device state information"""

--- a/src/device.act
+++ b/src/device.act
@@ -362,7 +362,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
         """Stop managing the device
 
         Called when the device is removed from the system. Closes the adapter
-        connection and unblocks any transactions waiting for completion. The
+        connection and fails any transactions waiting for completion. The
         configuration last sent to the device is left in place; nothing is
         wiped from the device itself.
         """
@@ -371,11 +371,11 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
         stopped = True
         _log.info("DeviceMgr stopping", {"name": name})
         adapter.close()
-        # Unblock waiting transactions. Consistent with wait_complete() for
-        # unknown tids, they complete rather than error: there is nothing
-        # left to wait for on a removed device.
+        # Fail waiting transactions: their configuration is discarded here
+        # unpushed (or unconfirmed), so completing with success would falsely
+        # report it as committed to the device.
         for tid, cb in callbacks.items():
-            cb(True)
+            cb(NotConnectedError("device removed"))
         callbacks = {}
         confq = {}
         current_tids = set()

--- a/src/device.act
+++ b/src/device.act
@@ -74,6 +74,20 @@ actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPC
     def list():
         return devices.keys()
 
+    def remove(name: str) -> None:
+        """Remove a device from the registry and stop its DeviceMgr
+
+        Used when the device is deleted from the configuration. The DeviceMgr
+        is stopped: its adapter connection is closed and it no longer accepts
+        configuration. Unknown device names are ignored.
+        """
+        dev = devices.get(name)
+        if dev is not None:
+            del devices[name]
+            if name in devices_needing_approval:
+                del devices_needing_approval[name]
+            dev.stop()
+
     def on_reconf(on_reconf: action(str) -> None):
         reconf_cb = on_reconf
 
@@ -340,6 +354,34 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
     var needs_approval = False
     var conf_log: list[LogItem] = []
 
+    # Set when the device has been removed from the system. A stopped
+    # DeviceMgr ignores new configuration and device events.
+    var stopped = False
+
+    def stop():
+        """Stop managing the device
+
+        Called when the device is removed from the system. Closes the adapter
+        connection and unblocks any transactions waiting for completion. The
+        configuration last sent to the device is left in place; nothing is
+        wiped from the device itself.
+        """
+        if stopped:
+            return
+        stopped = True
+        _log.info("DeviceMgr stopping", {"name": name})
+        adapter.close()
+        # Unblock waiting transactions. Consistent with wait_complete() for
+        # unknown tids, they complete rather than error: there is nothing
+        # left to wait for on a removed device.
+        for tid, cb in callbacks.items():
+            cb(True)
+        callbacks = {}
+        confq = {}
+        current_tids = set()
+        reconf_tids = set()
+        needs_approval = False
+
     def get_state():
         """Get the device state information"""
         has_running = False
@@ -399,10 +441,14 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
         return target_conf
 
     def on_modset_update(new_modset: dict[str, ModCap]):
+        if stopped:
+            return
         _log.debug("Modset updated", {"new_modset": new_modset})
         on_reconf(name)
 
     def on_connect(new_modset: dict[str, ModCap], new_schema_hash: ?u64):
+        if stopped:
+            return
         _log.debug("Device connected", {"new_modset": new_modset, "new_schema_hash": new_schema_hash})
         resync()
         if modset_eq(modset, new_modset):
@@ -416,6 +462,10 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
             return
 
     def set_dmc(new_dmc: DeviceMetaConfig) -> None:
+        if stopped:
+            _log.debug("DeviceMgr.set_dmc: device stopped, ignoring")
+            return
+
         def is_mock_device(new_dmc: DeviceMetaConfig) -> bool:
             if new_dmc.mock.enabled:
                 return True
@@ -510,6 +560,8 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
         This function manages the transaction queue and calls the adapter's
         configure method with the current target configuration.
         """
+        if stopped:
+            return
         # Check if we already have a transaction in progress
         if len(current_tids) > 0:
             _log.debug("DeviceMgr._send_config: there is currently an outstanding configuration, skipping", {"current_tids": current_tids})
@@ -668,6 +720,9 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
                 _log.debug("No send config, cannot compute diff")
 
     def configure(new_conf: ?ygdata.Node, conf_modset_id: ?str, tid: str="0"):
+        if stopped:
+            _log.debug("DeviceMgr.configure: device stopped, ignoring configuration", {"tid": tid})
+            return
         if new_conf is not None and conf_modset_id is not None:
             if conf_modset_id != modset_id:
                 _log.debug("DeviceMgr.configure: modset_id mismatch, ignoring configuration", {"conf_modset_id": str(conf_modset_id), "modset_id": str(modset_id)})
@@ -690,6 +745,9 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
         txid matches our cached version. If the device does not support txid,
         we have to fetch the full config and diff it against our cached version.
         """
+        if stopped:
+            return
+
         def on_fetch_config_done(new_conf: ?ygdata.Node, err: ?Exception) -> None:
             if err is not None:
                 _log.error("Error fetching config from device", {"error": err})

--- a/src/device.act
+++ b/src/device.act
@@ -508,6 +508,10 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
                         "effective_mock": effective_mock,
                         "use_generic_mock_adapter": use_generic_mock_adapter
                     })
+                    # The replaced adapter is never used again: shut it down
+                    # for good so its driver stops polling, reconnecting and
+                    # feeding device events into this DeviceMgr.
+                    adapter.close()
                     adapter = new_adapter
                     _log.info("DeviceMgr.set_dmc: using adapter", {"adapter": adapter})
                     bundled_schema = device_type.bundled_schema

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -533,6 +533,98 @@ actor _test_subscribe_periodic_yang_push(t: testing.EnvT):
     after 2.0: fail("Timed out waiting for periodic yang-push subscription updates")
 
 
+actor _test_stop_silences_device(t: testing.EnvT):
+    """DeviceMgr.stop() shuts the NETCONF driver down for good.
+
+    1. DeviceMgr in NETCONF mock mode with a periodic poll subscription.
+    2. On the first update, stop the device.
+    3. After a settle delay, require silence for several would-be poll
+       periods: pending poll ticks must die against the cleared
+       subscription state instead of rescheduling forever.
+    4. declare_subscriptions on the stopped device must error immediately.
+    """
+    mock_current_datetime = "2026-02-21T10:11:12Z"
+    mock_boot_datetime = "2025-12-31T00:00:00Z"
+
+    var done = False
+    var stop_sent = False
+    var settled = False
+    var updates_after_settle = 0
+
+    def noop_on_reconf(name: str):
+        pass
+    dev = new_netconf_mock_device_mgr(t, "dev-stop", noop_on_reconf)
+
+    def fail(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(ValueError(msg))
+
+    def succeed():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def on_late_update(n: ?ygdata.Node, err: ?Exception):
+        if done:
+            return
+        if err is None:
+            fail("declare_subscriptions on stopped device delivered data")
+            return
+        succeed()
+
+    def check_quiet():
+        if done:
+            return
+        if updates_after_settle > 0:
+            fail("Subscription updates continued after stop: {updates_after_settle}")
+            return
+        want = set([ygdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)])
+        dev.declare_subscriptions("late-owner", on_late_update, want)
+
+    def settle():
+        if done:
+            return
+        settled = True
+        after 0.3: check_quiet()
+
+    def on_update(n: ?ygdata.Node, err: ?Exception):
+        if done:
+            return
+        if settled:
+            updates_after_settle += 1
+            return
+        if stop_sent:
+            # Deliveries racing the stop, including the final shutdown error
+            # notice, are tolerated until the settle point.
+            return
+        if err is not None:
+            fail("Subscription update error before stop: {err}")
+            return
+        stop_sent = True
+        dev.stop()
+        after 0.15: settle()
+
+    def start():
+        adapter = dev.get_adapter()
+        if isinstance(adapter, swna.NetconfAdapter):
+            ms0 = adapter.get_mock_server()
+            if ms0 is None:
+                fail("Expected NetconfMockServer from NetconfAdapter")
+                return
+            ygdata.expect(ms0, "mock server").set_oper_ds(_mock_oper_ds(mock_current_datetime, mock_boot_datetime))
+            want = set([ygdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)])
+            dev.declare_subscriptions("test-stop", on_update, want)
+        else:
+            fail("Expected NetconfAdapter from DeviceMgr")
+
+    start()
+
+    after 2.0: fail("Timed out waiting for stop test")
+
+
 actor _test_subscription_manager_declare(t: testing.EnvT):
     """Declarative subscription manager over NETCONF mock subscriptions."""
     mock_current_datetime_1 = "2026-02-21T10:11:12Z"

--- a/src/test_ttt_layers.act
+++ b/src/test_ttt_layers.act
@@ -262,6 +262,277 @@ class WriteDevs(ttt.TransformFunction):
     def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory, dynstate):
         return out5, None
 
+class FanF(ttt.TransformFunction):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
+        """Emit one lower-layer list element per non-key child leaf.
+
+        Dropping a leaf from the input must retract the corresponding element
+        from the transform's contribution in the layer below.
+        """
+        elems = []
+        if isinstance(cfg, gdata.Container):
+            name = cfg.get_leaf(q("name")).val
+            for cid, child in cfg.children.items():
+                if cid == q("name"):
+                    continue
+                if isinstance(child, gdata.Leaf):
+                    elems.append(gdata.Container({
+                        q("id"): gdata.Leaf("{name}-{cid.name}"),
+                        q("data"): gdata.Container({
+                            q("val"): gdata.Leaf(child.val)
+                        })
+                    }))
+        return gdata.Container({
+            q('devices'): gdata.List([q("id")], elems)
+        }), None
+
+
+fan_cfg = gdata.List([q("name")], [
+    gdata.Container({
+        q("name"): gdata.Leaf("k1"),
+        q("n1"): gdata.Leaf(1),
+        q("n2"): gdata.Leaf(2)
+    })
+])
+
+fan_out_full = gdata.Container({
+    q('devices'): gdata.List([q("id")], [
+        gdata.Container({
+            q("id"): gdata.Leaf("k1-n1"),
+            q("data"): gdata.Container({
+                q("val"): gdata.Leaf(1)
+            })
+        }),
+        gdata.Container({
+            q("id"): gdata.Leaf("k1-n2"),
+            q("data"): gdata.Container({
+                q("val"): gdata.Leaf(2)
+            })
+        })
+    ])
+})
+
+fan_retract_n2 = gdata.List([q("name")], [
+    gdata.Container({
+        q("name"): gdata.Leaf("k1"),
+        q("n2"): gdata.Absent()
+    })
+])
+
+fan_out_reduced = gdata.Container({
+    q('devices'): gdata.List([q("id")], [
+        gdata.Container({
+            q("id"): gdata.Leaf("k1-n1"),
+            q("data"): gdata.Container({
+                q("val"): gdata.Leaf(1)
+            })
+        })
+    ])
+})
+
+actor transform_output_element_retraction(t: testing.AsyncT):
+    # A transform whose new output no longer contains a list element must
+    # retract that element from its contribution in the layer below. The
+    # lower layer is structural (container of keyed list entries), like the
+    # rfs/device layers, so the retraction must survive the list routing.
+    stack = ttt.Layer("top",
+                ttt.List(ttt.Transform(FanF), [q("name")]),
+                ttt.Layer("bottom",
+                    ttt.Container({
+                        q("devices"): ttt.List(
+                            ttt.Container({q("data"): ttt.Transform(ttt.PassThrough)}),
+                            [q("id")])
+                    }),
+                    None))
+
+    sess = stack.newsession()
+
+    var sess2 = stack.newsession()
+
+    def cont1(r: value):
+        if isinstance(r, Exception):
+            t.failure(AssertionError("Initial config failed: {r}"))
+            return
+        r1 = sess.below().get()
+        testing.assertEqual(r1.prsrc(True), fan_out_full.prsrc(True))
+        sess2 = stack.newsession()
+        sess2.edit_config(fan_retract_n2, cont2)
+
+    def cont2(r: value):
+        if isinstance(r, Exception):
+            t.failure(AssertionError("Retraction config failed: {r}"))
+            return
+        # Read through sess2's own lower session so the read is ordered after
+        # this transaction's commit.
+        r2 = sess2.below().get()
+        testing.assertEqual(r2.prsrc(True), fan_out_reduced.prsrc(True))
+        t.success()
+
+    sess.edit_config(fan_cfg, cont1)
+
+
+class FanOwn(ttt.TransformFunction):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
+        """Per-router transform: contributes the router's own device entry."""
+        elems = []
+        if isinstance(cfg, gdata.Container):
+            name = cfg.get_leaf(q("name")).val
+            elems.append(gdata.Container({
+                q("id"): gdata.Leaf(name),
+                q("own"): gdata.Container({
+                    q("o"): gdata.Leaf(1)
+                })
+            }))
+        return gdata.Container({
+            q('devices'): gdata.List([q("id")], elems)
+        }), None
+
+
+class FanHub(ttt.TransformFunction):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
+        """Fullmesh-style transform: contributes to every member's device
+        entry, including a nested list of the other members."""
+        elems = []
+        if isinstance(cfg, gdata.Container):
+            members = []
+            for cid, child in cfg.children.items():
+                if cid == q("name"):
+                    continue
+                if isinstance(child, gdata.Leaf):
+                    members.append(cid.name)
+            for m in sorted(members):
+                nbrs = []
+                for o in sorted(members):
+                    if o != m:
+                        nbrs.append(gdata.Container({
+                            q("addr"): gdata.Leaf(o)
+                        }))
+                elems.append(gdata.Container({
+                    q("id"): gdata.Leaf(m),
+                    q("extra"): gdata.Container({
+                        q("x"): gdata.Leaf(1)
+                    }),
+                    q("nbrs"): gdata.List([q("addr")], nbrs)
+                }))
+        return gdata.Container({
+            q('devices'): gdata.List([q("id")], elems)
+        }), None
+
+
+hub_cfg = gdata.List([q("name")], [
+    gdata.Container({
+        q("name"): gdata.Leaf("r1")
+    }),
+    gdata.Container({
+        q("name"): gdata.Leaf("r2")
+    }),
+    gdata.Container({
+        q("name"): gdata.Leaf("hub"),
+        q("r1"): gdata.Leaf(1),
+        q("r2"): gdata.Leaf(2)
+    })
+])
+
+hub_out_full = gdata.Container({
+    q('devices'): gdata.List([q("id")], [
+        gdata.Container({
+            q("id"): gdata.Leaf("r1"),
+            q("own"): gdata.Container({q("o"): gdata.Leaf(1)}),
+            q("extra"): gdata.Container({q("x"): gdata.Leaf(1)}),
+            q("nbrs"): gdata.List([q("addr")], [
+                gdata.Container({q("addr"): gdata.Leaf("r2")})
+            ])
+        }),
+        gdata.Container({
+            q("id"): gdata.Leaf("r2"),
+            q("own"): gdata.Container({q("o"): gdata.Leaf(1)}),
+            q("extra"): gdata.Container({q("x"): gdata.Leaf(1)}),
+            q("nbrs"): gdata.List([q("addr")], [
+                gdata.Container({q("addr"): gdata.Leaf("r1")})
+            ])
+        })
+    ])
+})
+
+hub_retract_r2 = gdata.List([q("name")], [
+    gdata.Absent({
+        q("name"): gdata.Leaf("r2")
+    }),
+    gdata.Container({
+        q("name"): gdata.Leaf("hub"),
+        q("r2"): gdata.Absent()
+    })
+])
+
+hub_out_reduced = gdata.Container({
+    q('devices'): gdata.List([q("id")], [
+        gdata.Container({
+            q("id"): gdata.Leaf("r1"),
+            q("own"): gdata.Container({q("o"): gdata.Leaf(1)}),
+            q("extra"): gdata.Container({q("x"): gdata.Leaf(1)}),
+            q("nbrs"): gdata.List([q("addr")], [])
+        })
+    ])
+})
+
+
+class FanBoth(ttt.TransformFunction):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
+        """Per-entry dispatch: the 'hub' entry acts as the fullmesh transform,
+        router entries as their own-entry transform."""
+        if isinstance(cfg, gdata.Container):
+            name = cfg.get_leaf(q("name")).val
+            if isinstance(name, str) and name == "hub":
+                return FanHub().transform_wrapper(cfg, linked, memory, dynstate)
+        return FanOwn().transform_wrapper(cfg, linked, memory, dynstate)
+
+
+actor transform_retraction_multi_source(t: testing.AsyncT):
+    # A device entry co-produced by a per-router transform (deleted with its
+    # router: clear-path retraction) and a fullmesh transform (survives and
+    # drops the member from its output: compute-path retraction). Deleting
+    # the router plus its membership must remove the device entry and every
+    # fragment of both contributions, including nested list elements on the
+    # surviving entries.
+    stack = ttt.Layer("top",
+                ttt.List(ttt.Transform(FanBoth), [q("name")]),
+                ttt.Layer("bottom",
+                    ttt.Container({
+                        q("devices"): ttt.List(
+                            ttt.Container({
+                                q("own"): ttt.Transform(ttt.PassThrough),
+                                q("extra"): ttt.Transform(ttt.PassThrough),
+                                q("nbrs"): ttt.List(
+                                    ttt.Container({}),
+                                    [q("addr")])
+                            }),
+                            [q("id")])
+                    }),
+                    None))
+
+    sess = stack.newsession()
+    var sess2 = stack.newsession()
+
+    def cont1(r: value):
+        if isinstance(r, Exception):
+            t.failure(AssertionError("Initial config failed: {r}"))
+            return
+        r1 = sess.below().get()
+        testing.assertEqual(r1.prsrc(True), hub_out_full.prsrc(True))
+        sess2 = stack.newsession()
+        sess2.edit_config(hub_retract_r2, cont2)
+
+    def cont2(r: value):
+        if isinstance(r, Exception):
+            t.failure(AssertionError("Retraction config failed: {r}"))
+            return
+        r2 = sess2.below().get()
+        testing.assertEqual(r2.prsrc(True), hub_out_reduced.prsrc(True))
+        t.success()
+
+    sess.edit_config(hub_cfg, cont1)
+
+
 actor _test_redundant_config(t: testing.AsyncT):
     stack = ttt.Layer("top",
         ttt.Transform(WriteDevs),

--- a/src/test_ttt_list.act
+++ b/src/test_ttt_list.act
@@ -261,6 +261,52 @@ actor nested_delete(t: testing.AsyncT):
 
 ########################
 
+actor keyonly_entry(t: testing.AsyncT):
+    # A structural entry holding only its key leaves routes nothing to any
+    # embedded transform, so its result is empty. It must still survive
+    # commit; only an explicit retraction may delete it.
+    tlist = ttt.List(
+                ttt.Container({
+                    q("nested"): ttt.List(ttt.Transform(ttt.PassThrough), [q("iname")])
+                }), [q("name")]
+            ) (ttt.PathRoot("0:"), None)
+    t1 = tlist.newtrans()
+
+    keyonly = gdata.List([q("name")], [
+        gdata.Container({
+            q("name"): gdata.Leaf("k1")
+        })
+    ])
+
+    exp = gdata.List([q("name")], [
+        gdata.Container({
+            q("name"): gdata.Leaf("k1"),
+            q("nested"): gdata.List([q("iname")], [])
+        })
+    ])
+
+    def cont2(_r: value):
+        t1.commit("1", True)
+        out2 = t1.get()
+        testing.assertEqual(out2, gdata.List([q("name")], []))
+        t.success()
+
+    def cont1(_r: value):
+        t1.commit("1", True)
+        out1 = t1.get()
+        testing.assertEqual(out1, exp)
+        t1.configure("1", {"srcA": gdata.List([q("name")], [
+            gdata.Absent({
+                q("name"): gdata.Leaf("k1")
+            })
+        ])}, None)
+        t1.lock("1", None, cont2)
+
+    t1.configure("1", {"srcA": keyonly}, None)
+    t1.lock("1", None, cont1)
+
+########################
+
 list1a = gdata.List([q("name")], [
     gdata.Container({
         q("name"): gdata.Leaf("key1"),

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -1417,13 +1417,19 @@ class _ListTransaction(_Transaction):
         self.state = None
         self.reset = False
 
-    def configure(self, tid, diff, out: ?Session, force=False, dbuf: ?swdb.Buffer=None):
-        #print('####', tid, '(List)', _format_path(self.path), 'configure', actorid(), err=True)
+    def _maybe_reset(self):
+        # Commit defers the reset (for the benefit of wait_complete), so every
+        # transaction entry point must drop the previous transaction's state
+        # before reusing this object.
         if self.reset:
             self.elems = {}
             self.accum = {}
             self.retracted = set()
             self.reset = False
+
+    def configure(self, tid, diff, out: ?Session, force=False, dbuf: ?swdb.Buffer=None):
+        #print('####', tid, '(List)', _format_path(self.path), 'configure', actorid(), err=True)
+        self._maybe_reset()
         diff_by_key = transpose_list(diff)
         leaves_by_key = {}
         if len(diff_by_key) == 0 and force:
@@ -1501,13 +1507,8 @@ class _ListTransaction(_Transaction):
 
     def linkage(self, tid, requests, updates, out, dbuf):
         #print('####', tid, '(List)', _format_path(self.path), 'linkage', len(requests), len(updates), err=True)
-        # linkage can now be a transaction entry point, so like configure()
-        # it must clear the previous transaction stale state
-        if self.reset:
-            self.elems = {}
-            self.accum = {}
-            self.retracted = set()
-            self.reset = False
+        # linkage can be a transaction entry point, just like configure()
+        self._maybe_reset()
 
         # linkage may target list entries committed by an earlier tx and not
         # configured in this one. Acquire those existing entries so we can

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -2179,10 +2179,14 @@ class _RFSTransaction(_TransformTransactionBase):
 
     def compute(self, tid, merged, linked, out):
         #print('####', tid, '(RFSTransform)', _format_path(self.path), 'compute', actorid(), err=True)
-        # Re-resolve the DeviceMgr: a concurrent delete may have removed and
-        # stopped the instance cached at construction, and a re-created device
-        # gets a fresh DeviceMgr that must be used in its place.
-        self.dev = self.dev_registry.get_or_create(self.devname)
+        # Re-resolve the DeviceMgr: a delete and re-create replaces the
+        # instance cached at construction. Only adopt a currently registered
+        # instance; never create one here, since this transform can recompute
+        # while its entry is being torn down and creating would resurrect the
+        # removed device in the registry.
+        dev = self.dev_registry.get(self.devname)
+        if dev is not None:
+            self.dev = dev
         dev_content = {
             gdata.Id(NS_stratoweave_device, "name"): gdata.Leaf(self.devname),
         }
@@ -2392,10 +2396,18 @@ class _DeviceConfigTransaction(_TransformTransactionBase):
         #print('####', tid, '(DeviceConfig)', _format_path(self.path), 'finalize', actorid(), err=True)
         device = self.output
         if device is not None:
-            # Re-resolve the DeviceMgr: a concurrent delete may have removed
-            # and stopped the instance cached at construction; configuring the
-            # stopped one would silently discard this entry's configuration.
-            self.dev = self.dev_registry.get_or_create(self.devname)
+            # Re-resolve the DeviceMgr: a delete and re-create replaces the
+            # instance cached at construction; configuring the stopped one
+            # would silently discard this entry's configuration. Only adopt a
+            # currently registered instance; never create one here, since this
+            # entry can outlive its device while a teardown is in flight, and
+            # creating would resurrect the removed device. With no registered
+            # device there is nowhere to push this configuration.
+            dev = self.dev_registry.get(self.devname)
+            if dev is not None:
+                self.dev = dev
+            else:
+                return
             if isinstance(device, gdata.Container):
                 config = device.children.get(gdata.Id(NS_stratoweave_device, "config"))
                 if config is not None:

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -2306,11 +2306,15 @@ def devname_from_device_path(path: Path):
 
 class _DeviceTransaction(_TransformTransactionBase):
     dev: swdev.DeviceMgr
+    devname: str
+    dev_registry: swdev.DeviceRegistry
     logger: logging.Logger
 
     def __init__(self, path, dev_registry: swdev.DeviceRegistry, log_handler):
         _TransformTransactionBase.__init__(self, path, None)
-        self.dev = dev_registry.get_or_create(devname_from_device_path(path))
+        self.devname = devname_from_device_path(path)
+        self.dev_registry = dev_registry
+        self.dev = dev_registry.get_or_create(self.devname)
         self.logger = logging.Logger(log_handler)
 
     def compute(self, tid, merged, linked, out):
@@ -2325,6 +2329,10 @@ class _DeviceTransaction(_TransformTransactionBase):
         if config is not None:
             meta_config = DeviceMetaConfig.from_gdata(config)
             self.dev.set_dmc(meta_config)
+        else:
+            # The device meta-config entry was deleted: the device is no
+            # longer part of the system, so remove and stop its DeviceMgr.
+            self.dev_registry.remove(self.devname)
 
 
 ################# DeviceConfig #####################

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -1399,6 +1399,7 @@ class _ListTransaction(_Transaction):
     key_names : list[gdata.Id]
     elems : dict[str, Transaction]
     accum : dict[str, CfgResult]
+    retracted : set[str]
     state : ?YieldState[str]
     reset: bool
     ns: ?str
@@ -1412,6 +1413,7 @@ class _ListTransaction(_Transaction):
         self.module = module
         self.elems = {}
         self.accum = {}
+        self.retracted = set()
         self.state = None
         self.reset = False
 
@@ -1420,6 +1422,7 @@ class _ListTransaction(_Transaction):
         if self.reset:
             self.elems = {}
             self.accum = {}
+            self.retracted = set()
             self.reset = False
         diff_by_key = transpose_list(diff)
         leaves_by_key = {}
@@ -1446,6 +1449,13 @@ class _ListTransaction(_Transaction):
             for key,node in self.liststate.acquire(tid, leaves_by_key).items():
                 if key not in self.elems:
                     self.elems[key] = node.newtrans()
+        # Track entries explicitly retracted in this transaction. Deletion at
+        # commit requires such a retraction: an entry whose result is merely
+        # empty (e.g. holding only its key leaves) must survive.
+        for key,subdiff in diff_by_key.items():
+            for node in subdiff.values():
+                if isinstance(node, gdata.Absent) or isinstance(node, gdata.Delete):
+                    self.retracted.add(key)
         msgs = {}
         for key,subdiff in diff_by_key.items():
             #print('   #', tid, '(List)', _format_path(self.path), 'CONFIGURE ELEMENT', key, err=True)
@@ -1496,6 +1506,7 @@ class _ListTransaction(_Transaction):
         if self.reset:
             self.elems = {}
             self.accum = {}
+            self.retracted = set()
             self.reset = False
 
         # linkage may target list entries committed by an earlier tx and not
@@ -1570,7 +1581,7 @@ class _ListTransaction(_Transaction):
             tr.commit(tid, ok)
         deletes = set()
         for key,res in self.accum.items():
-            if res.empty:
+            if res.empty and key in self.retracted:
                 #print('   #', tid, '(List)', _format_path(self.path), 'DELETE ELEMENT', key, err=True)
                 deletes.add(key)
         self.liststate.release(tid, ok, deletes)

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -1158,7 +1158,11 @@ class _ContainerTransaction(_Transaction):
             tr.lock(tid, out, actself.lock_cont, dbuf)              # yield await
         except StopIteration:
             #print('   #', tid, '(Container)', _format_path(self.path), 'LOCK IMMEDIATELY DONE', err=True)
-            done(CfgOk())
+            # Nothing was configured under this node in this transaction, so
+            # the lock result must not veto emptiness: it lands in the parent's
+            # accum (replacing the configure-phase result) and list entry
+            # deletion at commit requires the entry result to remain empty.
+            done(CfgOk(empty=True))
 
     def lock_cont(self, actself, res):
         state = self.state
@@ -1532,7 +1536,13 @@ class _ListTransaction(_Transaction):
             tr.lock(tid, out, actself.lock_cont, dbuf)                  # yield await
         except StopIteration:
             #print('   #', tid, '(List)', _format_path(self.path), 'LOCK IMMEDIATELY DONE', err=True)
-            done(CfgOk())
+            # Nothing was configured in this list in this transaction, so the
+            # lock result must not veto emptiness: it lands in the parent's
+            # accum (replacing the configure-phase result) and list entry
+            # deletion at commit requires the entry result to remain empty.
+            # A deleted entry holding an empty nested list would otherwise be
+            # reported non-empty here and never removed.
+            done(CfgOk(empty=True))
 
     def lock_cont(self, actself, res):
         state = self.state

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -2189,16 +2189,20 @@ class _RFSTransaction(_TransformTransactionBase):
         return newoutmem    # TODO: dynstate for RFS?
 
     def clear(self, tid, out):
-        output = self.output
-        if out is not None and output is not None:
-            diff = difference(output, gdata.Container())
-            if isinstance(diff, gdata.Container):
-                dev_content = {
-                    gdata.Id(NS_stratoweave_device, "name"): gdata.Leaf(self.devname),
-                    gdata.Id(NS_stratoweave_device, "config"): diff
-                }
-                embedded_diff: gdata.Node = self.embed(dev_content)
-                out.configure(tid, {self.me: embedded_diff})
+        if out is not None and (self.output is not None or len(self.running) > 0):
+            # Retract this transform's entire contribution to the device entry
+            # in the lower layer, as an Absent list element, so the per-source
+            # patch collapses to nothing. Retracting only the config subtree
+            # would re-assert the name leaf and leave modset_id behind, keeping
+            # the device entry alive after all its sources are gone.
+            retraction: gdata.Node = gdata.Container({
+                gdata.Id(NS_stratoweave_device, "devices"): gdata.Container({
+                    gdata.Id(NS_stratoweave_device, "device"): gdata.List([gdata.Id(NS_stratoweave_device, "name")], [
+                        gdata.Absent({gdata.Id(NS_stratoweave_device, "name"): gdata.Leaf(self.devname)})
+                    ])
+                })
+            }, ns=NS_stratoweave_device, module="stratoweave-device")
+            out.configure(tid, {self.me: retraction})
 
     def embed(self, dev_content):
         return gdata.Container({

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -38,7 +38,12 @@ def transpose_list(cfg_per_src: dict[str, gdata.Node]) -> dict[str, dict[str, gd
                 else:
                     cfg_per_key[key] = {src: le}
         elif isinstance(conf, gdata.Absent):
-            cfg_per_key[WILDKEY] = {src: conf}
+            # Several sources can retract in the same transaction: merge them
+            # instead of letting the last one overwrite the others.
+            if WILDKEY in cfg_per_key:
+                cfg_per_key[WILDKEY][src] = conf
+            else:
+                cfg_per_key[WILDKEY] = {src: conf}
         else:
             raise NotImplementedError("Cannot transpose configuration type {type(conf)} in transpose_list")
     return cfg_per_key
@@ -54,7 +59,12 @@ def transpose_container(cfg_per_src: dict[str, gdata.Node]) -> dict[gdata.Id, di
                 else:
                     cfg_per_key[key] = {src: subconf}
         elif isinstance(conf, gdata.Absent):
-            cfg_per_key[WILDID] = {src: conf}
+            # Several sources can retract in the same transaction: merge them
+            # instead of letting the last one overwrite the others.
+            if WILDID in cfg_per_key:
+                cfg_per_key[WILDID][src] = conf
+            else:
+                cfg_per_key[WILDID] = {src: conf}
         else:
             raise NotImplementedError("Cannot transpose configuration type {type(conf)} in transpose_container")
     return cfg_per_key

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -2159,6 +2159,7 @@ class _RFSTransaction(_TransformTransactionBase):
     function: RFSFunction
     devname: str
     dev: swdev.DeviceMgr
+    dev_registry: swdev.DeviceRegistry
     memory: ?gdata.Node
     dynstate: ?gdata.Node
     node: ?Node
@@ -2171,11 +2172,16 @@ class _RFSTransaction(_TransformTransactionBase):
         self.devname = devname_from_rfs_path(path)
         _TransformTransactionBase.__init__(self, path, None)
         self.function = function(log_handler)
+        self.dev_registry = dev_registry
         self.dev = dev_registry.get_or_create(self.devname)
         self.lower = lower
 
     def compute(self, tid, merged, linked, out):
         #print('####', tid, '(RFSTransform)', _format_path(self.path), 'compute', actorid(), err=True)
+        # Re-resolve the DeviceMgr: a concurrent delete may have removed and
+        # stopped the instance cached at construction, and a re-created device
+        # gets a fresh DeviceMgr that must be used in its place.
+        self.dev = self.dev_registry.get_or_create(self.devname)
         dev_content = {
             gdata.Id(NS_stratoweave_device, "name"): gdata.Leaf(self.devname),
         }
@@ -2339,6 +2345,11 @@ class _DeviceTransaction(_TransformTransactionBase):
         config = self.output
         if config is not None:
             meta_config = DeviceMetaConfig.from_gdata(config)
+            # Re-resolve the DeviceMgr: a concurrent delete may have removed
+            # and stopped the instance cached at construction. The entry still
+            # exists, so the device must be (re-)managed under a fresh
+            # DeviceMgr rather than configured into the stopped one.
+            self.dev = self.dev_registry.get_or_create(self.devname)
             self.dev.set_dmc(meta_config)
         else:
             # The device meta-config entry was deleted: the device is no
@@ -2366,11 +2377,15 @@ def devname_from_deviceconfig_path(path: Path):
 
 class _DeviceConfigTransaction(_TransformTransactionBase):
     dev: swdev.DeviceMgr
+    devname: str
+    dev_registry: swdev.DeviceRegistry
     logger: logging.Logger
 
     def __init__(self, path, dev_registry: swdev.DeviceRegistry, log_handler):
         _TransformTransactionBase.__init__(self, path)
-        self.dev = dev_registry.get_or_create(devname_from_deviceconfig_path(path))
+        self.devname = devname_from_deviceconfig_path(path)
+        self.dev_registry = dev_registry
+        self.dev = dev_registry.get_or_create(self.devname)
         self.logger = logging.Logger(log_handler)
         self.cont = None
 
@@ -2384,6 +2399,10 @@ class _DeviceConfigTransaction(_TransformTransactionBase):
         #print('####', tid, '(DeviceConfig)', _format_path(self.path), 'finalize', actorid(), err=True)
         device = self.output
         if device is not None:
+            # Re-resolve the DeviceMgr: a concurrent delete may have removed
+            # and stopped the instance cached at construction; configuring the
+            # stopped one would silently discard this entry's configuration.
+            self.dev = self.dev_registry.get_or_create(self.devname)
             if isinstance(device, gdata.Container):
                 config = device.children.get(gdata.Id(NS_stratoweave_device, "config"))
                 if config is not None:

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -2201,7 +2201,7 @@ class _RFSTransaction(_TransformTransactionBase):
             newoutmem = gdata.Container({}), None
 
         if out is not None:
-            embedded_res = self.embed(dev_content)
+            embedded_res = self.embed(gdata.Container(dev_content))
             out.configure(tid, {self.me: embedded_res})
         return newoutmem    # TODO: dynstate for RFS?
 
@@ -2212,21 +2212,13 @@ class _RFSTransaction(_TransformTransactionBase):
             # patch collapses to nothing. Retracting only the config subtree
             # would re-assert the name leaf and leave modset_id behind, keeping
             # the device entry alive after all its sources are gone.
-            retraction: gdata.Node = gdata.Container({
-                gdata.Id(NS_stratoweave_device, "devices"): gdata.Container({
-                    gdata.Id(NS_stratoweave_device, "device"): gdata.List([gdata.Id(NS_stratoweave_device, "name")], [
-                        gdata.Absent({gdata.Id(NS_stratoweave_device, "name"): gdata.Leaf(self.devname)})
-                    ])
-                })
-            }, ns=NS_stratoweave_device, module="stratoweave-device")
+            retraction = self.embed(gdata.Absent({gdata.Id(NS_stratoweave_device, "name"): gdata.Leaf(self.devname)}))
             out.configure(tid, {self.me: retraction})
 
-    def embed(self, dev_content):
+    def embed(self, elem: gdata.Node):
         return gdata.Container({
             gdata.Id(NS_stratoweave_device, "devices"): gdata.Container({
-                gdata.Id(NS_stratoweave_device, "device"): gdata.List([gdata.Id(NS_stratoweave_device, "name")], [
-                    gdata.Container(dev_content)
-                ])
+                gdata.Id(NS_stratoweave_device, "device"): gdata.List([gdata.Id(NS_stratoweave_device, "name")], [elem])
             })
         }, ns=NS_stratoweave_device, module="stratoweave-device")
 


### PR DESCRIPTION
Deleting a router previously left most of its state behind: the device entry lingered in the RFS/device layers (the remove diff re-asserted the name leaf and left modset_id behind), the DeviceMgr stayed registered, and the NETCONF driver kept its session, subscriptions and reconnect loop running forever.

This branch makes removal actually remove:

Transaction/list semantics (ttt)
- List entries are deleted at commit only on an explicit remove (Absent/Delete); an entry whose result is merely empty (holding only its key leaves) survives.
- Lock results preserve emptiness for untouched nodes, so pending deletions aren't removed.
- Removes from several sources in the same transaction are merged when transposing diffs instead of last-writer-wins — previously one transform's remove could silently drop another's, leaving partial entries behind.

RFS layer
- On delete, the RFS transform retracts its entire device-entry contribution as an Absent list element, so the entry is removed once all sources are gone.

Device lifecycle
- Devices deleted from the configuration are removed from the registry and their DeviceMgr stopped; approval bookkeeping is cleaned up via _update_approval_state().
- The NETCONF driver is shut down for good: connection closed, subscriptions cancelled and their owners notified (NotConnectedError("device removed")), reconnects stopped. Adapters replaced by set_dmc are shut down the same way.
- Transactions waiting for completion fail instead of reporting success for configuration that was discarded unpushed.
- Transaction objects re-resolve the DeviceMgr from the registry at use time, so a delete-then-recreate picks up the fresh instance — without ever re-creating a removed device from a stale entry.