### PR TITLE
Replay transforms on runtime fetched schemas

### DIFF
--- a/docs/developer/system-spec.md
+++ b/docs/developer/system-spec.md
@@ -5,11 +5,7 @@ layers the system has, their order, and what the schemas is for each layer.
 
 The system specification definition for SORESPO looks as follows:
 ```acton title="spec/src/sorespo_gen.act"
-spec = stratoweave.build.SysSpec("sorespo", [
-    cfs_layer,
-    inter_layer,
-    rfs_layer,
-], [
+spec = stratoweave.build.SysSpec("sorespo", [cfs_layer, inter_layer, rfs_layer], [
     stratoweave.build.DeviceType.from_dir(fc, "CiscoIosXr_25_3_1", "yang/CiscoIosXr_25_3_1"),
     stratoweave.build.DeviceType.from_dir(fc, "JuniperCRPD_24_4R1_9", "yang/JuniperCRPD_24_4R1_9"),
     stratoweave.build.DeviceType.from_dir(fc, "NokiaSRLinux_25_3_2", "yang/NokiaSRLinux_25_3_2"),
@@ -28,7 +24,7 @@ The `#!acton SysSpec` takes 3 arguments:
 * The system name
 * A list of [transform layers](#transform-layers) in the system, in descending order of abstraction
     * A StratoWeave system must have at least one layer, but can have
-    as many as are needed to cleanly separate different levels of abstraction 
+    as many as are needed to cleanly separate different levels of abstraction
     in the transform stack.
     * The top-most layer is the **customer-facing service (CFS)** layer, which
     defines the schema that users will interact with over the northbound APIs
@@ -78,34 +74,61 @@ StratoWeave is designed to support various device types but at present,
 SORESPO only contains NETCONF/YANG-based device types. Each YANG-based device
 type is built from a directory of YANG models.
 
-### Schema pruning
+### Schema transforms
 Router vendors have made great efforts to model their entire devices with YANG,
 every knob and feature is configurable and observable through YANG. As a result,
 the full set of YANG models for some of these operating systems are several
 hundred megabytes and include tens of thousands of nodes. To have access to
 completely typed device models, StratoWeave transpiles the YANG to Acton types.
 
-At present, this means that the full device models are too large to transpile 
+At present, this means that the full device models are too large to transpile
 and subsequently compile in a reasonable time. The current recommendation for
 developers is to prune the device models down to a manageable size by only
 including the YANG nodes that you require for configuration and telemetry in
 your use cases.
 
-In SORESPO, all three device types have been pruned in this way.
+Pruning is only one of the schema transforms that can be applied to the device
+schema, but it is arguably the most common. Transforms are listed on the device
+type and applied to the compiled schema tree in the order given.
+
 ```acton title="spec/src/sorespo_gen.act"
+import stratoweave.device_schema as swds
+
+spec = stratoweave.build.SysSpec("sorespo", [cfs_layer, inter_layer, rfs_layer], [
+    stratoweave.build.DeviceType.from_dir(fc, "CiscoIosXr_25_3_1", "yang/CiscoIosXr_25_3_1",
+        transforms=[
+            swds.filter_schema(xr_paths),
+        ]),
+    stratoweave.build.DeviceType.from_dir(fc, "JuniperCRPD_24_4R1_9", "yang/JuniperCRPD_24_4R1_9",
+        transforms=[
+            swds.filter_schema(crpd_paths),
+            swds.remove_list_user_order(crpd_order_paths),
+        ]),
+    stratoweave.build.DeviceType.from_dir(fc, "NokiaSRLinux_25_3_2", "yang/NokiaSRLinux_25_3_2",
+        transforms=[
+            swds.filter_schema(srl_paths),
+        ]),
+])
 compiled_spec = spec.compile(broken_leafrefs)
-transform_list_order(transform_filter_crpd(compiled_spec.dev_types["JuniperCRPD_24_4R1_9"]))
-transform_filter_srl(compiled_spec.dev_types["NokiaSRLinux_25_3_2"])
-transform_filter_xr(compiled_spec.dev_types["CiscoIosXr_25_3_1"])
 compiled_spec.gen_app(fc, "../src/")
 ```
 
-These filter functions each contain a list of YANG paths that should be
-retained.
+The available transforms come from `stratoweave.device_schema`:
+
+* `filter_schema(paths)` prunes the tree down to the listed YANG paths. A node
+  is kept when its path is listed or when it is an ancestor of a listed path,
+  so list keys have to be listed explicitly.
+* `remove_list_user_order(paths)` rewrites `ordered-by user` (leaf-)lists to
+  `ordered-by system`. JUNOS uses `ordered-by user` in many places where the
+  order has no effect on the applied configuration, which otherwise shows up as
+  spurious reordering whenever a transform writes the elements in a different
+  order.
+
+In SORESPO, all three device types are pruned this way, each with a list of the
+YANG paths to retain.
 ```acton title="spec/src/sorespo_gen.act"
-def transform_filter_xr(dt):
-    # Keep only the XR nodes that sorespo actively uses.
-    paths = [
+# Keep only the XR nodes that sorespo actively uses.
+xr_paths = [
 "/um-hostname-cfg:hostname",
 "/um-hostname-cfg:hostname/system-network-name",
 "/um-interface-cfg:interfaces",
@@ -124,7 +147,7 @@ def transform_filter_xr(dt):
     the Acton compiler, and support for shipping binary type libraries that
     can be imported directly without needing to compile the device types
     locally.
-    
+
     The goal of these improvements is to allow for the use of full device
     models without pruning, while still maintaining a fast development
     workflow.
@@ -203,7 +226,7 @@ a northbound NETCONF client downloads the YANG schemas from the system.
 
 ## Defining TMF Service/Resource mappings
 StratoWeave implements the YANG to TM Forum mapping defined in
-[draft-lambrechts-onsen-yang-tmf-mapping-00](https://datatracker.ietf.org/doc/html/draft-lambrechts-onsen-yang-tmf-mapping-00). 
+[draft-lambrechts-onsen-yang-tmf-mapping-00](https://datatracker.ietf.org/doc/html/draft-lambrechts-onsen-yang-tmf-mapping-00).
 To annotate your YANG models with TMF mapping instructions,
 import the `ietf-yang-tmf-map` module from the StratoWeave YANG extensions
 and use the `tmf:cfs-service` annotation to indicate which CFS service

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -806,9 +806,9 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             else:
                 _log.debug("Device._on_connect: finished downloading schemas", {"duration": sw.elapsed().to_float()})
                 sw.reset()
-                result = schema_registry.add_schema(schemas)
+                result = schema_registry.add_schema(schemas, bundled_schema.transforms)
                 if result.error is not None:
-                    _log.error("Device._on_connect: failed to compile schemas", {"error": str(result.error)})
+                    _log.error("Device._on_connect: failed to build device schema", {"error": str(result.error)})
                     finish_connect(schema_modset)
                 else:
                     schema_hash = result.hash

--- a/src/build.act
+++ b/src/build.act
@@ -8,6 +8,8 @@ import swyang as swyang
 import yang.transform_unions as transform_unions
 import yang.parser as yparser
 
+from device_schema import SchemaTreeTransform
+
 _SW_NS = "http://stratoweave.org/yang/stratoweave"
 _SW_EXCLUDE_EXT = [("dynstate", _SW_NS), ("memory", _SW_NS)]
 
@@ -65,7 +67,10 @@ class SysSpec(object):
         def _compile_dev_type(dev_type: DeviceType, idx: int) -> CompiledDeviceType:
             print("Compiling device type {dev_type.name} ({idx+1}/{num_dev_types})...", end='', flush=True)
             sw = time.Stopwatch()
-            r = CompiledDeviceType(yang.compile(dev_type.models, strict_quoting=False, allow_failure=allow_failure), dev_type.models, dev_type.name)
+            root = yang.compile(dev_type.models, strict_quoting=False, allow_failure=allow_failure)
+            for t in dev_type.transforms:
+                t.apply(root)
+            r = CompiledDeviceType(root, dev_type.models, dev_type.name, dev_type.transforms)
             print(" {sw.elapsed().to_float():.3f}s")
             return r
         compiled_layers = [_compile_layer(l, idx) for (idx, l) in enumerate(self.layers)]
@@ -180,8 +185,10 @@ class CompiledSysSpec(object):
         device_typesrc += "import stratoweave.device as swdev\n"
         device_typesrc += "\n\n"
         device_typesrc += "device_types: dict[str, swdev.DeviceType] = {{}}\n"
+        if any([len(dt.transforms) > 0 for dt in self.dev_types.values()]):
+            syssrc += "import stratoweave.device_schema as swds\n"
         for dev_type in self.dev_types.values():
-            print("Generating device type {dev_type.name}")
+            print("Generating device type {dev_type.name} ({len(dev_type.transforms)} schema transform(s))")
             modname = "{self.name}.devices.{dev_type.name}"
             # schema.prdaclass mutates the compiled tree when it strips
             # config-false nodes. Emit the oper view first so the subsequent
@@ -213,8 +220,12 @@ class CompiledSysSpec(object):
             adapter_type=swna.NetconfAdapter,
             src_dnode={dev_alias}.SRC_DNODE,
             oper_src_dnode={dev_oper_alias}.SRC_DNODE,
-        ),
 """
+            if len(dev_type.transforms) > 0:
+                tlines = "".join(["                swds.{t.prsrc(16)},\n" for t in dev_type.transforms])
+                syssrc_devtypes += "            schema_transforms=[\n{tlines}            ],\n"
+            syssrc_devtypes += "        ),\n"
+
         print("Generating app sysspec.act")
         syssrc += "\n{syssrc_getlayers}\n"
         syssrc += "\n{syssrc_schema_for_layer}\n"
@@ -342,10 +353,11 @@ class CompiledLayer(CompiledLayerBase):
         self.name = name
 
 class CompiledDeviceType(CompiledLayerBase):
-    def __init__(self, root: yschema.DRoot, src: list[str], name: str):
+    def __init__(self, root: yschema.DRoot, src: list[str], name: str, transforms: list[SchemaTreeTransform]=[]):
         self.root = root
         self.src = src
         self.name = name
+        self.transforms = transforms
 
 def apply_schema_transforms_to_dir(fc: file.FileCap, dir: str, transforms: list[SchemaTransformChain]=[]) -> None:
     """Apply schema transformations to YANG files in a directory.
@@ -379,12 +391,13 @@ def apply_schema_transforms_to_dir(fc: file.FileCap, dir: str, transforms: list[
             await async wf.write(yang_text.encode())
 
 class DeviceType(object):
-    def __init__(self, name: str, models: list[str]):
+    def __init__(self, name: str, models: list[str], transforms: list[SchemaTreeTransform]=[]):
         self.name = name
         self.models = models
+        self.transforms = transforms
 
     @staticmethod
-    def from_dir(fc: file.FileCap, name: str, dir: str) -> DeviceType:
+    def from_dir(fc: file.FileCap, name: str, dir: str, transforms: list[SchemaTreeTransform]=[]) -> DeviceType:
         """Create a DeviceType DTO from YANG models in a directory
 
         This method simply loads all .yang files from the specified directory
@@ -397,4 +410,4 @@ class DeviceType(object):
         sw = time.Stopwatch()
         models = [file.ReadFile(rfc, "{dir}/{f}").read().decode() for f in yang_files]
         print(" {sw.elapsed().to_float():.3f}s")
-        return DeviceType(name, models)
+        return DeviceType(name, models, transforms)

--- a/src/device.act
+++ b/src/device.act
@@ -16,7 +16,7 @@ from device_meta_config import \
     stratoweave_rfs__device_entry as DeviceMetaConfig, \
     stratoweave_rfs__device__credentials as Credentials
 
-from device_schema import DeviceSchema
+from device_schema import DeviceSchema, SchemaTreeTransform
 
 from adapters.adapter import \
     DeviceAdapter, NoAdapter, MockAdapter, MockRoot, \
@@ -38,10 +38,10 @@ class DeviceType(object):
 
     bundled_schema: DeviceSchema
 
-    def __init__(self, name: str, adapter_type, src_dnode, oper_src_dnode: ?yschema.DRoot=None):
+    def __init__(self, name: str, adapter_type, src_dnode, oper_src_dnode: ?yschema.DRoot=None, schema_transforms: list[SchemaTreeTransform]=[]):
         self.name = name
         self.adapter_type = adapter_type
-        self.bundled_schema = DeviceSchema(name, src_dnode, oper_src_dnode)
+        self.bundled_schema = DeviceSchema(name, src_dnode, oper_src_dnode, schema_transforms)
 
 actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnectCap=None, log_handler: logging.Handler):
     """Device Registry keeps track of all devices and hands out references to
@@ -103,20 +103,23 @@ actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPC
 actor SchemaRegistry():
     var store: dict[u64, yschema.DRoot] = {}
 
-    def _list_hash(l: list[str]) -> u64:
+    def _schema_hash(yang_src: list[str], transforms: list[SchemaTreeTransform]) -> u64:
         h = hasher()
-        for le in l:
+        for le in yang_src:
             h.update(le.encode())
+        for t in transforms:
+            t.hash(h)
         return h.finalize()
 
-    def add_schema(yang_src: list[str]) -> (hash: ?u64, error: ?Exception):
-        content_hash = _list_hash(yang_src)
+    def add_schema(yang_src: list[str], transforms: list[SchemaTreeTransform]=[]) -> (hash: ?u64, error: ?Exception):
+        content_hash = _schema_hash(yang_src, transforms)
         if content_hash not in store:
             try:
                 compiled_schema = yang.compile(yang_src, strict_quoting=False)
+                for t in transforms:
+                    t.apply(compiled_schema)
                 store[content_hash] = compiled_schema
             except Exception as e:
-                # Schema compilation failed, return error
                 return (hash=None, error=e)
         return (hash=content_hash, error=None)
 

--- a/src/device_schema.act
+++ b/src/device_schema.act
@@ -1,4 +1,48 @@
 import yang.schema as yschema
+import yang.transform_filter_schema as ytfs
+import yang.transform_list_order as ytlo
+
+
+class SchemaTreeTransform(object):
+    name: str
+    paths: list[str]
+    @property
+    fn: mut(yschema.DNode, list[str]) -> None
+
+    def __init__(self, name: str, fn, paths: list[str]=[]):
+        self.name = name
+        self.fn = fn
+        self.paths = paths
+
+    mut def apply(self, root: yschema.DRoot) -> None:
+        self.fn(root, self.paths)
+
+    def prsrc(self, indent: int=0) -> str:
+        if len(self.paths) == 0:
+            return "{self.name}()"
+        pad = " " * indent
+        plines = "".join(["{pad}    {repr(p)},\n" for p in self.paths])
+        return "{self.name}([\n{plines}{pad}])"
+
+
+extension SchemaTreeTransform(Hashable):
+    def __eq__(self, other: SchemaTreeTransform) -> bool:
+        return self.name == other.name and self.paths == other.paths
+
+    def hash(self, h: hasher) -> None:
+        h.update(self.name.encode())
+        for p in self.paths:
+            h.update(p.encode())
+
+
+# Wrap the yang.* transform functions in an object that carries the factory
+# function name so that we only have to import this (stratoweave.device_schema)
+# module in the generated sysspec.act
+def filter_schema(paths: list[str]) -> SchemaTreeTransform:
+    return SchemaTreeTransform("filter_schema", ytfs.filter_schema, paths)
+
+def remove_list_user_order(paths: list[str]=[]) -> SchemaTreeTransform:
+    return SchemaTreeTransform("remove_list_user_order", ytlo.remove_list_user_order, paths)
 
 
 class DeviceSchema(object):
@@ -6,11 +50,13 @@ class DeviceSchema(object):
 
     src_dnode: yschema.DRoot
     oper_src_dnode: yschema.DRoot
+    transforms: list[SchemaTreeTransform]
 
-    def __init__(self, name, src_dnode, oper_src_dnode: ?yschema.DRoot=None):
+    def __init__(self, name, src_dnode, oper_src_dnode: ?yschema.DRoot=None, transforms: list[SchemaTreeTransform]=[]):
         self.name = name
         self.src_dnode = src_dnode
         self.oper_src_dnode = oper_src_dnode if oper_src_dnode is not None else src_dnode
+        self.transforms = transforms
 
     @staticmethod
     def mock():

--- a/src/test_device_schema_transform.act
+++ b/src/test_device_schema_transform.act
@@ -1,0 +1,83 @@
+import testing
+
+import yang
+import yang.schema as yschema
+
+import device as swdev
+import device_schema as swds
+
+
+BASE_YANG = r"""module base {
+  yang-version 1.1;
+  namespace "urn:base";
+  prefix base;
+  container system {
+    leaf hostname { type string; }
+    leaf location { type string; }
+  }
+  list interface {
+    key name;
+    leaf name { type string; }
+    leaf description { type string; }
+    leaf mtu { type uint16; }
+  }
+  list route {
+    key prefix;
+    ordered-by user;
+    leaf prefix { type string; }
+  }
+}"""
+
+# A module the bundled device type does not know about
+EXTRA_YANG = r"""module extra {
+  yang-version 1.1;
+  namespace "urn:extra";
+  prefix extra;
+  container telemetry {
+    leaf enabled { type boolean; }
+  }
+}"""
+
+# The nodes the application actually models
+KEEP_PATHS = [
+    "/base:system/hostname",
+    "/base:interface/name",
+    "/base:interface/description",
+]
+
+
+def _src(schema: yschema.DRoot) -> str:
+    # Only print DRoot children to avoid mismatch in module_metadata (runtime
+    # fetched schema includes an extra module).
+    return "\n".join([c.prsrc() for c in schema.children])
+
+
+def _fetched_src(registry: swdev.SchemaRegistry, res: (hash: ?u64, error: ?Exception)) -> str:
+    return _src(registry.get_schema(res.hash)!)
+
+
+def _test_runtime_schema_matches_bundled():
+    """After replaying transforms, the runtime-fetched schema is shaped like the bundled one
+    """
+    root = yang.compile([BASE_YANG])
+    swds.filter_schema(KEEP_PATHS).apply(root)
+    bundled = _src(root)
+
+    registry = swdev.SchemaRegistry()
+    transformed = registry.add_schema([BASE_YANG, EXTRA_YANG], [swds.filter_schema(KEEP_PATHS)])
+    untransformed = registry.add_schema([BASE_YANG, EXTRA_YANG])
+
+    testing.assertEqual(bundled, _fetched_src(registry, transformed), "transformed runtime schema matches the bundled tree")
+    testing.assertNotEqual(bundled, _fetched_src(registry, untransformed), "untransformed runtime schema is a larger tree")
+
+
+def _test_schema_cache_separation():
+    """Device types sharing sources but not transforms get separate cache entries"""
+    registry = swdev.SchemaRegistry()
+    pruned = registry.add_schema([BASE_YANG], [swds.filter_schema(KEEP_PATHS)])
+    full = registry.add_schema([BASE_YANG])
+
+    testing.assertNotEqual(pruned.hash, full.hash, "transforms are part of the cache key")
+    testing.assertNotEqual(_fetched_src(registry, pruned), _fetched_src(registry, full),
+                           "each entry holds its own differently shaped tree")
+


### PR DESCRIPTION
At the moment the user applications still include a schema pruning transform when generating sysspec. To ensure the schema view at development time is more aligned with the runtime view, these schema transforms are now serialized in the generated sysspec.act and then replayed on the schemas fetched at runtime.