### PR TITLE
Use native optional handling instead of expect() helpers

### DIFF
--- a/minisys/src/mini/cfs.act
+++ b/minisys/src/mini/cfs.act
@@ -19,7 +19,7 @@ class GlobalSettings(base.GlobalSettings):
 
 actor RouterTransform(path: ttt.Path, update_dynstate: proc(?y_0.netinfra__netinfra__router__dynstate)->None, update_oper: proc(?y0_oper.netinfra__netinfra__router_entry)->None, lower_tree_provider: ?ygdata.TreeProvider):
     oper = base.Router.new_state(path)
-    _subs = ygdata.SubscriptionManager(ttt.expect(lower_tree_provider, "Missing lower tree provider for CFS router telemetry"), str(path))
+    _subs = ygdata.SubscriptionManager(lower_tree_provider!, str(path))
 
     def on_rfs_state(root: ?y1_oper.root, err: ?Exception, router_name: str):
         if err is not None:

--- a/minisys/src/mini/layers/t_1.act
+++ b/minisys/src/mini/layers/t_1.act
@@ -23,5 +23,5 @@ def BaseConfigTransformCtor(params: ttt.TransformActorParams) -> ?proc(ygdata.No
         params.update_dynstate(dynstate.to_gdata() if dynstate is not None else None)
     def update_oper_type_wrapper(oper: ?y_1_oper.stratoweave_rfs__rfs__base_config):
         params.update_oper(oper.to_gdata() if oper is not None else None)
-    act = rfs.BaseConfigTransform(params.path, update_dynstate_type_wrapper, update_oper_type_wrapper, ttt.expect(params.dev, "Missing expected DeviceMgr param to rfs.BaseConfigTransform."))
+    act = rfs.BaseConfigTransform(params.path, update_dynstate_type_wrapper, update_oper_type_wrapper, params.dev!)
     return proc lambda c, m: act.on_conf(stratoweave_rfs__rfs__base_config.from_gdata(c))

--- a/minisys/src/test_mini_subscribe_transform.act
+++ b/minisys/src/test_mini_subscribe_transform.act
@@ -127,7 +127,7 @@ actor _test_rfs_subscribe_transform(t: testing.AsyncT):
         contact = _find_contact(out, "dev1")
         if phase == 0 and contact == telemetry_time_1:
             phase = 1
-            ms = gdata.expect(mock_server, "mock server")
+            ms = mock_server!
             ms.set_oper_ds(_telemetry(telemetry_time_2))
             print("Received first telemetry update with contact:", contact)
         elif phase == 1 and contact == telemetry_time_2:
@@ -158,7 +158,7 @@ actor _test_rfs_subscribe_transform(t: testing.AsyncT):
         msg = async dev.get_adapter()
         adapter = await msg
         if isinstance(adapter, swna.NetconfAdapter):
-            ms = gdata.expect(adapter.get_mock_server(), "Netconf mock server")
+            ms = adapter.get_mock_server()!
             mock_server = ms
             ms.set_oper_ds(_telemetry(telemetry_time_1))
             kick()

--- a/snapshots/expected/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/snapshots/expected/test_ttt_gen/ttt_gen_rfs_ttt
@@ -21,5 +21,5 @@ def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: 
 def BBInterfaceTransformCtor(params: ttt.TransformActorParams) -> ?proc(ygdata.Node, ?ygdata.Node) -> None:
     def update_dynstate_type_wrapper(dynstate: ?stratoweave_rfs__rfs__backbone_interface__dynstate):
         params.update_dynstate(dynstate.to_gdata() if dynstate is not None else None)
-    act = rfs.BBInterfaceTransform(params.path, update_dynstate_type_wrapper, ttt.expect(params.dev, "Missing expected DeviceMgr param to rfs.BBInterfaceTransform."))
+    act = rfs.BBInterfaceTransform(params.path, update_dynstate_type_wrapper, params.dev!)
     return proc lambda c, m: act.on_conf(stratoweave_rfs__rfs__backbone_interface_entry.from_gdata(c), stratoweave_rfs__rfs__backbone_interface__memory.from_gdata(m) if m is not None else None)

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -1749,8 +1749,9 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             _sub_schedule_next(spec)
 
         filt_xml = None
-        if st.spec.filt is not None:
-            filt_xml = _build_subtree_filter(ygdata.expect(st.spec.filt, "subscription filter"))
+        filt = st.spec.filt
+        if filt is not None:
+            filt_xml = _build_subtree_filter(filt)
         if client is not None:
             client.get(on_get, filt_xml)
         else:

--- a/src/db.act
+++ b/src/db.act
@@ -24,11 +24,6 @@ ATTR_MEMORY = "memory"
 ATTR_OUTPUT = "output"
 ATTR_RUNNING = "running"
 
-def expect[T](t: ?T, errmsg: str) -> T:
-    if t is not None:
-        return t
-    raise ValueError(errmsg)
-
 # Qualified path segments are encoded as:
 #   namespace-id byte + encoded local name
 # Plain string path segments use namespace-id byte 0. Qualified segments use a
@@ -80,7 +75,7 @@ class KeyCodec(object):
             self.namespace_indexes[namespace] = index1
             self.namespaces.append(namespace)
             return _namespace_byte(index1)
-        return _namespace_byte(expect(index, "Missing expected namespace index for {namespace}"))
+        return _namespace_byte(index!)
 
     def decode_id(self, raw: bytes) -> ?gdata.Id:
         if len(raw) == 0 or raw[0] == PLAIN_SEGMENT_ID[0]:
@@ -134,7 +129,7 @@ def del_op(path: list[value], attr: str, qualifier: ?str=None) -> BufferOp:
 
 def opt_ops(path: list[value], attr: str, node: ?gdata.Node, qualifier: ?str=None) -> list[BufferOp]:
     if node is not None:
-        return [put_op(path, attr, expect(node, "Missing expected node for DB buffer op"), qualifier)]
+        return [put_op(path, attr, node, qualifier)]
     return [del_op(path, attr, qualifier)]
 
 actor Buffer():
@@ -216,9 +211,9 @@ def _encode_segment(segment: value, codec: ?KeyCodec=None) -> bytes:
     if isinstance(segment, str):
         return PLAIN_SEGMENT_ID + _encode_text(segment)
     if isinstance(segment, gdata.Id):
-        if codec is None:
-            raise ValueError("Missing DB key codec for qualified persistence path segment {segment}")
-        return expect(codec, "Missing DB key codec for persistence path encoding").get_nsid_prefix(segment.q) + _encode_text(segment.name)
+        if codec is not None:
+            return codec.get_nsid_prefix(segment.q) + _encode_text(segment.name)
+        raise ValueError("Missing DB key codec for qualified persistence path segment {segment}")
     raise ValueError("Unsupported path component in persistence key: {type(segment)}")
 
 def to_key(path: list[value], codec: ?KeyCodec=None) -> bytes:
@@ -381,7 +376,7 @@ def _decode_namespaces(record: dict[str, ?value]) -> list[str]:
 def _key_codec_from_raw(raw: ?bytes) -> KeyCodec:
     if raw is None:
         return KeyCodec([])
-    record = _decode_record(expect(raw, "Missing persistence metadata bytes"))
+    record = _decode_record(raw!)
     version = record.get("version")
     if isinstance(version, int):
         if version != VERSION:
@@ -420,14 +415,14 @@ def parse_attr_key(key: bytes, codec: ?KeyCodec=None) -> (list[str], str, ?str):
     for segment_bytes in path_bytes:
         decoded_id = codec1.decode_id(segment_bytes)
         if decoded_id is not None:
-            path.append(qualified_name(expect(decoded_id, "Missing decoded Id persistence path segment")))
+            path.append(qualified_name(decoded_id))
         else:
             if len(segment_bytes) == 0 or segment_bytes[0] != PLAIN_SEGMENT_ID[0]:
                 raise ValueError("Missing plain-string segment namespace id byte in TTT persistence key")
             path.append(_decode_text(segment_bytes[1:]))
     if qualifier_bytes is None:
         return path, _decode_text(attr_bytes), None
-    return path, _decode_text(attr_bytes), _decode_text(expect(qualifier_bytes, "Missing persistence qualifier bytes"))
+    return path, _decode_text(attr_bytes), _decode_text(qualifier_bytes!)
 
 def format_key_debug(key: bytes, codec: ?KeyCodec=None) -> str:
     if key == META_KEY:

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -584,7 +584,7 @@ actor _test_subscription_manager_declare(t: testing.EnvT):
 
         if phase == 1 and dt == mock_current_datetime_1 and not has_boot:
             phase = 2
-            ygdata.expect(mock_server, "mock server").set_oper_ds(_mock_oper_ds(mock_current_datetime_2, mock_boot_datetime))
+            mock_server!.set_oper_ds(_mock_oper_ds(mock_current_datetime_2, mock_boot_datetime))
             return
 
         if phase == 2 and dt == mock_current_datetime_2 and not has_boot:
@@ -593,20 +593,20 @@ actor _test_subscription_manager_declare(t: testing.EnvT):
 
     def declare_both():
         want = {
-            ygdata.expect(dst, "subscription destination").deliver({
+            dst!.deliver({
                 ygdata.SubscriptionSpec(_current_datetime_filter(), period=0.05),
                 ygdata.SubscriptionSpec(_boot_datetime_filter(), period=0.05),
             })
         }
-        ygdata.expect(subs, "subscription manager").declare(want)
+        subs!.declare(want)
 
     def declare_current_only():
         want = {
-            ygdata.expect(dst, "subscription destination").deliver({
+            dst!.deliver({
                 ygdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)
             })
         }
-        ygdata.expect(subs, "subscription manager").declare(want)
+        subs!.declare(want)
 
     def start():
         adapter = dev.get_adapter()
@@ -615,7 +615,7 @@ actor _test_subscription_manager_declare(t: testing.EnvT):
             if ms0 is None:
                 fail("Expected NetconfMockServer from NetconfAdapter")
                 return
-            ms = ygdata.expect(ms0, "mock server")
+            ms = ms0!
             mock_server = ms
             ms.set_oper_ds(_mock_oper_ds(mock_current_datetime_1, mock_boot_datetime))
             dst = ygdata.Dst(on_update)
@@ -687,11 +687,11 @@ actor _test_subscription_manager_idempotent(t: testing.EnvT):
 
     def declare_current_only():
         want = {
-            ygdata.expect(dst, "subscription destination").deliver({
+            dst!.deliver({
                 ygdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)
             })
         }
-        ygdata.expect(subs, "subscription manager").declare(want)
+        subs!.declare(want)
 
     def start():
         adapter = dev.get_adapter()
@@ -700,7 +700,7 @@ actor _test_subscription_manager_idempotent(t: testing.EnvT):
             if ms0 is None:
                 fail("Expected NetconfMockServer from NetconfAdapter")
                 return
-            ms = ygdata.expect(ms0, "mock server")
+            ms = ms0!
             ms.set_oper_ds(_mock_oper_ds(mock_current_datetime, mock_boot_datetime))
             dst = ygdata.Dst(on_update)
             subs = ygdata.SubscriptionManager(dev.tree_provider(), "test-subscription-manager-idempotent")

--- a/src/test_rig.act
+++ b/src/test_rig.act
@@ -29,11 +29,6 @@ def _sanitize_ident(name: str) -> str:
         res = "dev_" + res
     return res
 
-def expect[T](a: ?T, msg: str) -> T:
-    if a is not None:
-        return a
-    raise ValueError(msg)
-
 def device_config_adata_snapshot(dev_registry: swdev.DeviceRegistry, dev_types: ?dict[str, swdev.DeviceType]=None) -> str:
     names = sorted([n for n in dev_registry.list()])
     parts = []
@@ -42,7 +37,7 @@ def device_config_adata_snapshot(dev_registry: swdev.DeviceRegistry, dev_types: 
         conf_opt = dev.get_running_conf()
         if conf_opt is None:
             conf_opt = dev.get_target_conf()
-        conf = expect(conf_opt, f"Missing device config for {name}")
+        conf = conf_opt!
 
         schema_opt = dev.get_fetched_schema()
         if schema_opt is None and dev_types is not None:
@@ -58,7 +53,7 @@ def device_config_adata_snapshot(dev_registry: swdev.DeviceRegistry, dev_types: 
                     schema_opt = dev_type.bundled_schema.src_dnode
         if schema_opt is None:
             schema_opt = dev.get_bundled_schema().src_dnode
-        schema = expect(schema_opt, f"Missing schema for {name}")
+        schema = schema_opt!
 
         self_name = _sanitize_ident(name)
         adata = ydata.pradata(schema, conf, self_name=self_name, loose=True)

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -33,11 +33,6 @@ def qold_removed(n: str) -> gdata.Id:
 def qlive_removed(n: str) -> gdata.Id:
     return gdata.Id(REMOVED_NS_LIVE, n)
 
-def expect[T](t: ?T, errmsg: str) -> T:
-    if t is not None:
-        return t
-    raise ValueError(errmsg)
-
 def is_ttt_db_key(key: bytes) -> bool:
     return key == swdb.META_KEY or key.startswith(swdb.META_KEY + swdb.PATH_SEPARATOR)
 
@@ -47,7 +42,7 @@ def ttt_db_snapshot(read_txn: lmdb.ReadTransaction) -> str:
     lines = []
     kv = cursor.seek_prefix(b"ttt")
     while kv is not None:
-        entry = expect(kv, "Missing expected LMDB cursor entry")
+        entry = kv!
         if not is_ttt_db_key(entry.key):
             break
         lines.append(swdb.format_key_debug(entry.key, codec))
@@ -302,7 +297,7 @@ actor db_key_codec_escapes_reserved_bytes(t: testing.AsyncT):
     parsed = swdb.parse_attr_key(key)
     testing.assertEqual(parsed.0, path)
     testing.assertEqual(parsed.1, escaped_attr)
-    testing.assertEqual(expect(parsed.2, "Missing escaped qualifier"), escaped_src)
+    testing.assertEqual(parsed.2!, escaped_src)
     testing.assertEqual(key.find(swdb.ESCAPE) != -1, True)
     t.success()
 
@@ -313,7 +308,7 @@ actor db_key_codec_round_trips_qualified_segments(t: testing.AsyncT):
     parsed = swdb.parse_attr_key(key, codec)
     testing.assertEqual(parsed.0, ["qualified", swdb.qualified_name(qa_shift("branch")), "list-key", swdb.qualified_name(qb_shift("value"))])
     testing.assertEqual(parsed.1, swdb.ATTR_RUNNING)
-    testing.assertEqual(expect(parsed.2, "Missing expected running source"), "_")
+    testing.assertEqual(parsed.2!, "_")
     t.success()
 
 actor TransformWriteFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: lmdb.Db, layer: ttt.Layer):
@@ -448,8 +443,8 @@ actor dbuffer_refreshes_on_lock_reconfigure(t: testing.EnvT):
         read_txn = db.begin_read()
         running_raw = read_txn.get(swdb.to_attr_key(["single"], swdb.ATTR_RUNNING, "_"))
         output_raw = read_txn.get(swdb.to_attr_key(["single"], swdb.ATTR_OUTPUT))
-        testing.assertEqual(expect(running_raw, "Missing buffered running record").decode(), overlap_expected_cfg.to_json_str(pretty=False))
-        testing.assertEqual(expect(output_raw, "Missing buffered output record").decode(), overlap_expected_cfg.to_json_str(pretty=False))
+        testing.assertEqual(running_raw!.decode(), overlap_expected_cfg.to_json_str(pretty=False))
+        testing.assertEqual(output_raw!.decode(), overlap_expected_cfg.to_json_str(pretty=False))
         await async read_txn.commit()
 
         tr.commit("1", True)
@@ -515,7 +510,7 @@ actor persist_transform_state_snapshot(t: testing.EnvT):
 
     def rootgen(path, lower):
         root = ttt.Transform(PersistDynstateTransform)(path, lower)
-        return expect(root, "Missing captured stateful transform root")
+        return root!
 
     def after_recompute(r: value) -> None:
         if not (isinstance(r, str) and r == "Ok"):
@@ -525,7 +520,7 @@ actor persist_transform_state_snapshot(t: testing.EnvT):
     def after_initial_commit(r: value) -> None:
         if not isinstance(r, str):
             raise AssertionError("Expected successful initial stateful completion, got {r}")
-        root1 = expect(root, "Missing captured stateful transform root")
+        root1 = root!
         root1.newtrans().restore(swdb.ATTR_DYNSTATE, None, gdata.Leaf(41).to_json_str(pretty=False).encode())
         ttt.Session("persist_stateful", root1, None, db).recompute(after_recompute)
 
@@ -672,7 +667,7 @@ actor restore_transform_dynstate_round_trip(t: testing.EnvT):
 
     def rootgen(path, lower):
         root = ttt.Transform(PersistDynstateTransform)(path, lower)
-        return expect(root, "Missing captured stateful transform root")
+        return root!
 
     def after_recommit(r: value) -> None:
         if not isinstance(r, str):
@@ -696,7 +691,7 @@ actor restore_transform_dynstate_round_trip(t: testing.EnvT):
     def after_initial_commit(r: value) -> None:
         if not isinstance(r, str):
             raise AssertionError("Expected successful initial dynstate completion, got {r}")
-        root1 = expect(root, "Missing captured stateful transform root")
+        root1 = root!
         root1.newtrans().restore(swdb.ATTR_DYNSTATE, None, gdata.Leaf(41).to_json_str(pretty=False).encode())
         ttt.Session("restore_stateful", root1, None, db).recompute(after_seed_recompute)
 

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -8,13 +8,10 @@ import std.xml as xml
 import logging
 import lmdb
 
-def expect[T](t: ?T, errmsg: str) -> T:
+def unwrap[T](t: ?T) -> T:
     if t is not None:
         return t
-    raise ValueError(errmsg)
-
-def unwrap[T](t: ?T) -> T:
-    return expect(t, "unwrap called on None")
+    raise ValueError("unwrap called on None")
 
 
 NS_stratoweave_device = "http://stratoweave.org/yang/stratoweave-device"
@@ -631,7 +628,7 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
     var sub_owners: dict[str, LayerSubscriptionOwner] = {}
 
     def load_from_db(top_only=False):
-        db = expect(db_arg, "Missing db for TTT persistence restore in layer {name}")
+        db = db_arg!
         read_txn = db.begin_read()
         try:
             codec = swdb.read_key_codec(read_txn)
@@ -648,7 +645,7 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
         cursor = read_txn.cursor()
         kv = cursor.seek_prefix(prefix)
         while kv is not None:
-            entry = expect(kv, "Missing expected LMDB cursor entry during restore")
+            entry = kv!
             if not entry.key.startswith(prefix):
                 break
             boundary = entry.key[len(prefix)] if len(entry.key) > len(prefix) else None
@@ -805,7 +802,7 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
 
     def _flush_dbuffer_then_commit():
         def finish(ok: bool, result: value) -> None:
-            commit(expect(tid_state, "Missing active TTT transaction during DB commit"), ok)
+            commit(tid_state!, ok)
             edit_config_finish(result)
 
         proc def write_txn_ready(dbuf: swdb.Buffer, error: ?Exception, txn: ?lmdb.WriteTransaction):
@@ -1026,7 +1023,7 @@ class _Container(_Node):
                     if data is not None:
                         res[tag] = data
         else:
-            res = {tag: expect(node.get_data(), "container child data") for tag, node in self.elems.items()}
+            res = {tag: node.get_data()! for tag, node in self.elems.items()}
         path = self.path
         if isinstance(path, PathKey):
             res.update(path.keyvals.items())
@@ -1228,7 +1225,7 @@ class _ContainerTransaction(_Transaction):
                     if data is not None:
                         res[tag] = data
         else:
-            res = {tag: expect(elem.get_data(), "container child data") for tag, elem in self.elems.items()}
+            res = {tag: elem.get_data()! for tag, elem in self.elems.items()}
         path = self.path
         if isinstance(path, PathKey):
             res.update(path.keyvals.items())
@@ -1926,7 +1923,7 @@ class _TransformTransactionBase(_Transaction):
 
     def restore(self, attr: str, qualifier: ?str, raw: bytes) -> None:
         if attr == swdb.ATTR_RUNNING:
-            src = expect(qualifier, "Missing persistence qualifier for transform running source at {_format_path(self.path)}")
+            src = qualifier!
             self.running[src] = swdb.decode_node_bytes(raw)
             return
         if attr == swdb.ATTR_OUTPUT:

--- a/src/ttt_gen.act
+++ b/src/ttt_gen.act
@@ -188,7 +188,7 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
             state_classes.append(input_class)
             transform_actor_fq = transform.fqname + "Transform"
             transform_actor_ctor = transform.name + "TransformCtor"
-            transform_actor_handle = "ttt.expect(params.dev, \"Missing expected DeviceMgr param to {transform_actor_fq}.\")" if ext.name == "rfs-transform" else "params.lower_tree_provider"
+            transform_actor_handle = "params.dev!" if ext.name == "rfs-transform" else "params.lower_tree_provider"
             memory_conv = ", {memory_class}.from_gdata(m) if m is not None else None" if memory_class is not None else ""
 
             wrappers = ""


### PR DESCRIPTION
Replace the per-file expect[T] helpers and all call sites with native forms: narrowing where a branch already exists, postfix ! where absence is an invariant violation. ttt_gen now emits params.dev! in generated TransformCtors; regenerated files.