### PR TITLE
RPC error handling: never drop callbacks, distinguish rejections

### DIFF
--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -65,6 +65,13 @@ class TxidMismatchError(TransientError):
     """The device's txid doesn't match the expected txid, configuration drift detected
     """
 
+class RpcError(PermanentError):
+    """The device rejected an RPC with one or more rpc-error replies
+
+    Retrying the same RPC typically does not help; the message carries the
+    device's rpc-error summary.
+    """
+
 class ConfigError(PermanentError):
     """Configuration error, i.e. the device rejected the configuration
 

--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -314,7 +314,7 @@ class NoAdapter(DeviceAdapter):
         pass
 
     def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
-        pass
+        cb(None, NotConnectedError())
 
     def declare_subscriptions(self, owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
         cb(None, NotConnectedError())

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -1523,6 +1523,8 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         _log.debug("Device.rpc_xml", {"xml_rpc": xml_rpc})
         if client is not None:
             client.rpc(xml_rpc, rpc_reply)
+        else:
+            cb(None, NotConnectedError())
 
     def _build_subtree_filter(filt: ygdata.FNode) -> xml.Node:
         return xml.Node("filter", attributes=[("type", "subtree")], children=filt.to_filter_xml(deterministic=True))

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -23,7 +23,7 @@ from device_meta_config import \
     stratoweave_rfs__device_entry as DeviceMetaConfig
 from adapters.adapter import \
     DeviceAdapter, ModCap, DISCONNECTED, CONNECTING, CONNECTED, TRANSACTION, \
-    NotConnectedError, BusyError, LockedError, TxidMismatchError, ConfigError, \
+    NotConnectedError, BusyError, LockedError, TxidMismatchError, ConfigError, RpcError, \
     SharedSubscription, SubscriptionOwner, parse_cap, \
     subscription_delay, merge_subscription_tree, \
     SubscriptionStatus, SUBSCRIPTION_YANG_PUSH, SUBSCRIPTION_POLL, SUBSCRIPTION_CONNECTING
@@ -1518,7 +1518,16 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                 cb(None, NotConnectedError())
                 return
             _log.debug("Device.rpc_xml.rpc_reply", {"r": r, "error": error})
-            cb(r, error)
+            if error is not None:
+                # If the reply carries rpc-error content, the device actually
+                # rejected the request. Otherwise the session died with the
+                # RPC in flight.
+                if error.rpc_error is not None:
+                    cb(r, RpcError(str(error)))
+                else:
+                    cb(r, NotConnectedError(str(error)))
+                return
+            cb(r, None)
 
         _log.debug("Device.rpc_xml", {"xml_rpc": xml_rpc})
         if client is not None:


### PR DESCRIPTION
1 
If the device has no adapter yet or the NETCONF client is gone rpc_xml quietly does nothing — the callback never fires and whoever sent the RPC waits forever.

2 Tell device rejections apart from transport errors - both used to arrive as the same exception, so apps had to check message strings to decide between retrying and giving up. An  rpc-error reply now completes as RpcError (permanent), anything  else as NotConnectedError (retryable).
