### PR TITLE
Preserve list index records through forced recompute

### DIFF
--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -730,6 +730,44 @@ actor restore_structural_list_round_trip(t: testing.EnvT):
     restored.edit_config(struct_tree, after_initial_commit)
 
 
+actor restore_survives_forced_recompute(t: testing.EnvT):
+    # A forced recompute (as StartupBootstrap runs after every restore) must
+    # preserve each list element's #keys index record. Regression: db_ops used
+    # to delete every element's record when the refresh recomputed no leaves,
+    # so the next restore lost the list.
+    fc = file.FileCap(t.env.cap)
+    fs = file.FS(fc)
+    db_path = fs.mktmpdir("test_ttt_recompute_survive_")
+    cap = file.WriteFileCap(fc)
+    var db = lmdb.Db(cap, db_path)
+    var restored = ttt.Layer("struct", struct_root, None, db)
+
+    def after_second_restore() -> None:
+        testing.assertEqual(restored.get(), struct_tree)
+        await async db.close()
+        await async fs.rmtree(db_path)
+        await async fs.rmdir(db_path)
+        t.success()
+
+    def after_recompute(result: value) -> None:
+        if isinstance(result, Exception):
+            raise result
+        await async db.close()
+        db = lmdb.Db(cap, db_path)
+        restored = ttt.Layer("struct", struct_root, None, db)
+        await async restored.load_from_db()
+        after_second_restore()
+
+    def after_initial_commit(_r: value) -> None:
+        await async db.close()
+        db = lmdb.Db(cap, db_path)
+        restored = ttt.Layer("struct", struct_root, None, db)
+        await async restored.load_from_db()
+        restored.newsession().recompute(after_recompute, force=True)
+
+    restored.edit_config(struct_tree, after_initial_commit)
+
+
 actor restore_structural_list_delete_round_trip(t: testing.EnvT):
     fc = file.FileCap(t.env.cap)
     fs = file.FS(fc)

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -1450,15 +1450,19 @@ class _ListTransaction(_Transaction):
         return res
 
     def db_ops(self, leaves_by_key) -> list[swdb.BufferOp]:
-
-        def op(key, res):
+        # A list element's key leaves are immutable for its lifetime, so its
+        # #keys record is written once at creation and deleted at removal.
+        # A configure that only refreshes an existing element (force recompute,
+        # wildcard) recomputes no leaves for it; emitting no op leaves the
+        # existing record intact rather than deleting the element's index entry.
+        ops = []
+        for key, res in self.accum.items():
             path = _db_path(self.path) + [key]
-            if not res.errors and not res.empty and key in leaves_by_key:
-                return swdb.put_op(path, swdb.ATTR_KEYS, gdata.Container(leaves_by_key[key]))
-            else:
-                return swdb.del_op(path, swdb.ATTR_KEYS)
-
-        return [ op(key,res) for key, res in self.accum.items() ]
+            if res.empty:
+                ops.append(swdb.del_op(path, swdb.ATTR_KEYS))
+            elif not res.errors and key in leaves_by_key:
+                ops.append(swdb.put_op(path, swdb.ATTR_KEYS, gdata.Container(leaves_by_key[key])))
+        return ops
 
     def _analyze(self, results: dict[str,CfgResult]):
         self.accum.update(results.items())


### PR DESCRIPTION
I think this stems from my misunderstanding of TTT transaction behavior.

A list element's key leaves are immutable, so its #keys record only needs writing at creation and deleting at removal. _ListTransaction.db_ops instead keyed the choice on whether this configure recomputed leaves for the element, and a refresh that recomputes none — a forced recompute or a wildcard edit over existing elements — took the delete branch for every element. StartupBootstrap runs exactly such a forced recompute after every restore, so restoring a persisted list and reconciling it deleted all the list's index records while the element data remained. The next restore then found element data with no index entry.

Delete an element's record only when the element is actually removed, and otherwise leave the existing record untouched by emitting no op.