### PR TITLE
Report accumulated emptiness on an empty container refresh

### DIFF
--- a/minisys/src/test_mini_subscribe_transform.act
+++ b/minisys/src/test_mini_subscribe_transform.act
@@ -152,7 +152,7 @@ actor _test_rfs_subscribe_transform(t: testing.AsyncT):
         if modset_id is None:
             after 0: kick()
             return
-        rfs.edit_config(_rfs_for_device("dev1"), on_config, None, True)
+        rfs.edit_config(_rfs_for_device("dev1"), on_config, None)
 
     def start():
         msg = async dev.get_adapter()

--- a/src/app.act
+++ b/src/app.act
@@ -96,7 +96,7 @@ actor RfsReconf(dev_registry: swdev.DeviceRegistry, cfs: ttt.Layer):
             break
         _rfs = _next
 
-    dev_registry.on_reconf(lambda dev: _rfs.edit_config(_rfs_for_device(dev), force=True))
+    dev_registry.on_reconf(lambda dev: _rfs.edit_config(_rfs_for_device(dev)))
 
 
 actor StartupConfigApplier(config_files: list[str], exit_on_done: bool, top_schema: yschema.DRoot, cfs: ttt.Layer, exit: action(int) -> None, rfcap: file.ReadFileCap, log_handler: logging.Handler):
@@ -155,7 +155,7 @@ actor StartupBootstrap(cfs: ttt.Layer, restore_from_db: bool, netconf_host_key_p
             exit(1)
             return
         log.info("Recomputing restored TTT state")
-        cfs.newsession().recompute(_recompute_done, force=True)
+        cfs.newsession().recompute(_recompute_done)
 
     def _run():
         # The NETCONF SSH layer wants host-key material, not a path, so read the

--- a/src/test_ttt_callbacks.act
+++ b/src/test_ttt_callbacks.act
@@ -119,7 +119,7 @@ actor complete(t: testing.AsyncT):
 
     def reconf_cb(dev):
         cfg = rfs_for_device(dev)
-        stack.edit_config(cfg, force=True)
+        stack.edit_config(cfg)
         
     dev_registry.on_reconf(reconf_cb)
     

--- a/src/test_ttt_container.act
+++ b/src/test_ttt_container.act
@@ -579,3 +579,38 @@ actor spurious_config(t: testing.AsyncT):
 
 
 ########################
+
+# A transaction can configure the same node several times before locking:
+# late transform output — resolved links, a rebase under lock after a
+# competing commit — makes the Session re-apply, so a container configured
+# by source A earlier in the transaction can see a later reconfigure arrive
+# with nothing for it: an empty diff, without force.
+# _ListTransaction.configure calls this a refresh: every element already
+# configured in the transaction but not mentioned by the current diff gets
+# configure(tid, {}).
+#
+# The refresh answer matters because the list treats empty=True as "this
+# element's configuration is gone": at commit it deletes the element and
+# stages a delete of its on-disk index record. So an empty refresh must
+# report the emptiness the transaction has accumulated so far.
+actor empty_refresh(t: testing.AsyncT):
+    container = ttt.Container({
+        q('left'): ttt.Transform(ttt.PassThrough)
+    })(ttt.PathRoot("0:"), None)
+    t1 = container.newtrans()
+
+    r1 = t1.configure("1", {'srcA': gdata.Container({q('left'): gdata.Leaf(1)})}, None)
+    testing.assertEqual(r1.empty, False, "configured container must not be empty")
+
+    # A later reconfigure has nothing for this container. Its configuration
+    # is still what the earlier configure made it: non-empty.
+    r2 = t1.configure("1", {}, None)
+    testing.assertEqual(r2.empty, False, "empty refresh must report the accumulated state")
+
+    # The mirror case: srcA explicitly clears its config. A refresh must now
+    # keep reporting empty=True — the configuration really is gone.
+    r3 = t1.configure("1", {'srcA': gdata.Absent({})}, None)
+    testing.assertEqual(r3.empty, True, "explicitly cleared container must be empty")
+    r4 = t1.configure("1", {}, None)
+    testing.assertEqual(r4.empty, True, "empty refresh must report accumulated emptiness too")
+    t.success()

--- a/src/test_ttt_container.act
+++ b/src/test_ttt_container.act
@@ -584,15 +584,9 @@ actor spurious_config(t: testing.AsyncT):
 # late transform output — resolved links, a rebase under lock after a
 # competing commit — makes the Session re-apply, so a container configured
 # by source A earlier in the transaction can see a later reconfigure arrive
-# with nothing for it: an empty diff, without force.
-# _ListTransaction.configure calls this a refresh: every element already
-# configured in the transaction but not mentioned by the current diff gets
-# configure(tid, {}).
-#
-# The refresh answer matters because the list treats empty=True as "this
-# element's configuration is gone": at commit it deletes the element and
-# stages a delete of its on-disk index record. So an empty refresh must
-# report the emptiness the transaction has accumulated so far.
+# with nothing for it: an empty diff. All transforms now treat an empty diff
+# as a request to recompute its output, which in the list and container case
+# means the output of its complete transform subtree.
 actor empty_refresh(t: testing.AsyncT):
     container = ttt.Container({
         q('left'): ttt.Transform(ttt.PassThrough)

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -544,15 +544,15 @@ actor dbuffer_refreshes_on_lock_reconfigure(t: testing.EnvT):
         if not is_cfg_ok(r):
             raise AssertionError("Expected successful seed lock, got {r}")
         tr.commit("0", True)
-        r1 = tr.configure("1", {"_": overlap_t1_diff}, None, False, t1buf)
+        r1 = tr.configure("1", {"_": overlap_t1_diff}, None, t1buf)
         if not is_cfg_ok(r1):
             raise AssertionError("Expected successful t1 configure, got {r1}")
-        r2 = tr.configure("2", {"_": overlap_t2_diff}, None, False, t2buf)
+        r2 = tr.configure("2", {"_": overlap_t2_diff}, None, t2buf)
         if not is_cfg_ok(r2):
             raise AssertionError("Expected successful t2 configure, got {r2}")
         tr.lock("2", None, after_t2_lock, t2buf)
 
-    r0 = tr.configure("0", {"_": overlap_base_cfg}, None, False, seedbuf)
+    r0 = tr.configure("0", {"_": overlap_base_cfg}, None, seedbuf)
     if not is_cfg_ok(r0):
         raise AssertionError("Expected successful seed configure, got {r0}")
     tr.lock("0", None, after_seed_lock, seedbuf)
@@ -864,7 +864,7 @@ actor restore_survives_forced_recompute(t: testing.EnvT):
         def restored_then_recompute(error: ?Exception) -> None:
             if error is not None:
                 raise error
-            restored.newsession().recompute(after_recompute, force=True)
+            restored.newsession().recompute(after_recompute)
 
         restored.load_from_db(restored_then_recompute)
 

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -1124,7 +1124,7 @@ class CountingLinkedSubscriber(ttt.TransformFunction):
 # Subscribing must not re-run existing subscribers: when a transaction only
 # adds a new subscriber (a new link request), the publisher's state is
 # unchanged, so existing subscribers already hold the correct linked input
-# and must not be force-recomputed. Without targeted link updates the
+# and must not be recomputed. Without targeted link updates the
 # publisher answers every new link request by broadcasting its full state to
 # ALL subscribers, so creating subscriber N re-runs all N-1 existing
 # subscriber transforms; with one service created per transaction that makes

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -561,8 +561,8 @@ class _Node(object):
 
 
 actor Transaction(impl: _Transaction):
-    def configure(tid, diff, out, force=False, dbuf: ?swdb.Buffer=None):
-        return impl.configure(tid, diff, out, force, dbuf)
+    def configure(tid, diff, out, dbuf: ?swdb.Buffer=None):
+        return impl.configure(tid, diff, out, dbuf)
 
     def linkage(tid, requests, updates, out, dbuf: ?swdb.Buffer=None):
         return impl.linkage(tid, requests, updates, out, dbuf)
@@ -609,7 +609,7 @@ actor Transaction(impl: _Transaction):
 
 class _Transaction(object):
     path: Path
-    configure:  proc(tid: str, diff: dict[str,gdata.Node], out: ?Session, force: ?bool, dbuf: ?swdb.Buffer) -> CfgResult
+    configure:  proc(tid: str, diff: dict[str,gdata.Node], out: ?Session, dbuf: ?swdb.Buffer) -> CfgResult
     linkage: proc(tid: str, requests: list[LinkRequest], updates: list[LinkUpdate], out: ?Session, dbuf: ?swdb.Buffer) -> CfgResult
     # yield action
     lock : proc(actself: Transaction, tid: str, out: ?Session, done: action(CfgResult) -> None, dbuf: ?swdb.Buffer) -> None
@@ -752,8 +752,8 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
     def below():
         return lower if lower is not None else self
 
-    def edit_config(diff, done=None, complete=None, force=False):
-        newsession().edit_config(diff, done, complete, force)
+    def edit_config(diff, done=None, complete=None):
+        newsession().edit_config(diff, done, complete)
 
     def get():
         return root.get()
@@ -902,11 +902,11 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?swdb.Store, db
             edit_config_finish("Ok")
 
     # yield action
-    def edit_config(diff, done: ?action(value)->None=None, complete: ?action(value)->None=None, force=False):
+    def edit_config(diff, done: ?action(value)->None=None, complete: ?action(value)->None=None):
         tid = 'tr' + actorid()
         #print('####', tid, '(Layer)', name, 'edit_config', actorid(), err=True)
         configure(tid, {'_': diff})
-        res = apply(tid, force)
+        res = apply(tid)
         #print('   #', tid, '(Layer)', name, 'EDIT_CONFIG', 'PREP RESULT', res, err=True)
         if not res.errors:
             done_cont = done
@@ -945,12 +945,12 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?swdb.Store, db
         #print('####', tid, '(Layer)', name, 'configure', list(diff_per_source.keys()), err=True)
         buf.update(diff_per_source.items())
 
-    def apply(tid, force=False):
+    def apply(tid):
         #print('####', tid, '(Layer)', name, 'apply', err=True)
         diff = buf
         buf = {}
         #print('   #', tid, '(Layer)', name, 'APPLY\n' + per_src(diff), err=True)
-        res = root.configure(tid, diff, lower, force, dbuf)
+        res = root.configure(tid, diff, lower, dbuf)
         while res.requests or res.updates:
             #print('----', tid, '(Layer)', name, 'LINKAGE', len(res.requests), len(res.updates), err=True)
             #for r in res.requests: print('    ', r, err=True)
@@ -958,7 +958,7 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?swdb.Store, db
             res = root.linkage(tid, res.requests, res.updates, lower, dbuf)
         #print('   #', tid, '(Layer)', name, 'APPLY RESULT', res, err=True)
         if not res.errors and lower is not None:
-            lowres = lower.apply(tid, force=False)
+            lowres = lower.apply(tid)
             if lowres.errors:
                 res = CfgResult(res.empty, res.requests, res.updates, res.errors+lowres.errors)
         return res
@@ -968,7 +968,7 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?swdb.Store, db
         #print('####', tid, '(Layer)', name, 'lock', err=True)
         if buf:                                         # An upper layer has re-configured
             #print('####', tid, '(Layer)', name, 'LOCK RE-APPLY', err=True)
-            res = apply(tid, force=False)
+            res = apply(tid)
             if res.errors:
                 if done is not None:
                     done(res)
@@ -1007,10 +1007,10 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?swdb.Store, db
             else:
                 root.wait_complete(tid_state, lambda res: done((res.errors[0] if res.errors else "Ok") if isinstance(res, CfgResult) else res))
     
-    def recompute(done: ?action(value)->None=None, complete: ?action(value)->None=None, force=False):
+    def recompute(done: ?action(value)->None=None, complete: ?action(value)->None=None):
         tid = 'tr' + actorid()
         #print('####', tid, '(Layer)', name, 'recompute', actorid(), err=True)
-        res = apply(tid, force)
+        res = apply(tid)
         if not res.errors:
             done_cont = done
             comp_cont = complete
@@ -1201,8 +1201,8 @@ class _ContainerTransaction(_Transaction):
         self.elems = {key: node.newtrans() for key, node in contents.items()}
         self.module = module
 
-    def configure(self, tid, diff, out, force=False, dbuf: ?swdb.Buffer=None):
-        #print('####', tid, '(Container)', _format_path(self.path), 'configure force:', force, actorid(), err=True)
+    def configure(self, tid, diff, out, dbuf: ?swdb.Buffer=None):
+        #print('####', tid, '(Container)', _format_path(self.path), actorid(), err=True)
         diff_by_child = transpose_container(diff)
         # Extra nodes present in diff_by_child represent configuration that is
         # not any of our embedded transforms. These may be key leaf values, or
@@ -1212,17 +1212,6 @@ class _ContainerTransaction(_Transaction):
             del diff_by_child[k]
 
         if len(diff_by_child) == 0:
-            if not force:
-                # An empty diff without force is a refresh: nothing changes
-                # for any child, so the answer comes from the results
-                # accumulated so far. The normal path below only sees the
-                # children named in the diff - here none - so it would report
-                # even a fully configured container as empty, and a list
-                # deletes elements that report empty.
-                empty = True
-                for r in self.accum.values():
-                    empty = empty and r.empty
-                return CfgResult(empty, [], [], [])
             for k in self.elems.keys():
                 diff_by_child[k] = {}
         elif WILDID in diff_by_child:
@@ -1237,7 +1226,7 @@ class _ContainerTransaction(_Transaction):
         for child,subdiff in diff_by_child.items():
             if child in self.elems:
                 #print('   #', tid, '(Container)', _format_path(self.path), 'CONFIGURE CHILD', child, err=True)
-                msgs[child] = async self.elems[child].configure(tid, subdiff, out, force, dbuf)
+                msgs[child] = async self.elems[child].configure(tid, subdiff, out, dbuf)
         results = {}
         for child,msg in msgs.items():
             results[child] = await msg
@@ -1601,7 +1590,7 @@ class _ListTransaction(_Transaction):
         self.state = None
         self.reset = False
 
-    def configure(self, tid, diff, out: ?Session, force=False, dbuf: ?swdb.Buffer=None):
+    def configure(self, tid, diff, out: ?Session, dbuf: ?swdb.Buffer=None):
         #print('####', tid, '(List)', _format_path(self.path), 'configure', actorid(), err=True)
         if self.reset:
             self.elems = {}
@@ -1609,7 +1598,7 @@ class _ListTransaction(_Transaction):
             self.reset = False
         diff_by_key = transpose_list(diff)
         leaves_by_key = {}
-        if len(diff_by_key) == 0 and force:
+        if len(diff_by_key) == 0:
             for key,node in self.liststate.acquire(tid, None).items():
                 diff_by_key[key] = {}
                 if key not in self.elems:
@@ -1635,10 +1624,10 @@ class _ListTransaction(_Transaction):
         msgs = {}
         for key,subdiff in diff_by_key.items():
             #print('   #', tid, '(List)', _format_path(self.path), 'CONFIGURE ELEMENT', key, err=True)
-            msgs[key] = async self.elems[key].configure(tid, subdiff, out, force, dbuf)
+            msgs[key] = async self.elems[key].configure(tid, subdiff, out, dbuf)
         for key in self.accum.keys():
             if key not in diff_by_key:
-                msgs[key] = async self.elems[key].configure(tid, {}, out, force, dbuf)
+                msgs[key] = async self.elems[key].configure(tid, {}, out, dbuf)
         results = {}
         for key,msg in msgs.items():
             results[key] = await msg
@@ -1652,7 +1641,7 @@ class _ListTransaction(_Transaction):
     def db_ops(self, leaves_by_key) -> list[swdb.BufferOp]:
         # A list element's key leaves are immutable for its lifetime, so its
         # keys record is written once at creation and deleted at removal. A
-        # configure that only refreshes an existing element (force recompute,
+        # configure that only refreshes an existing element (recompute,
         # wildcard) recomputes no leaves for it; emitting no op leaves the
         # existing record intact rather than deleting the element's index entry.
         ops = []
@@ -1970,7 +1959,7 @@ class _TransformTransactionBase(_Transaction):
         self.me = ''  # Initialize first before any self reference
         self.me = '(src_' + str(self)[-10:-1] + ')'  # Now safe to use str(self)
 
-    def configure(self, tid, diff, out: ?Session, force=False, dbuf: ?swdb.Buffer=None):
+    def configure(self, tid, diff, out: ?Session, dbuf: ?swdb.Buffer=None):
         #print('####', tid, '(Transform)', _format_path(self.path), 'configure', actorid(), self.me, err=True)
 
         if tid not in self.diffs:
@@ -2060,7 +2049,7 @@ class _TransformTransactionBase(_Transaction):
                 # subscriber set changed, so its published state is unchanged
                 # and existing subscribers already hold it. Deliver the
                 # current state to the new subscribers only and skip the
-                # forced recompute. Without this, every link
+                # recompute. Without this, every link
                 # subscribe/unsubscribe (e.g. each service create or delete)
                 # fans a full state broadcast out to every subscriber, making
                 # such transactions cost O(existing subscribers) transform
@@ -2083,7 +2072,7 @@ class _TransformTransactionBase(_Transaction):
                     # prune the existing config subtree at its path and merge the new one
                     linked = gdata.merge(prune(linked, u.publisher), u.config)
             self.candidate_linked[tid] = linked
-        return self.configure(tid, {}, out, True, dbuf)
+        return self.configure(tid, {}, out, dbuf)
 
     # yield action
     def lock(self, actself, tid, out: ?Session, done, dbuf: ?swdb.Buffer=None):          # yield await
@@ -2100,7 +2089,7 @@ class _TransformTransactionBase(_Transaction):
         self.locker = tid
         if tid not in self.candidates:
             #print('   #', tid, '(Transform)', _format_path(self.path), 'LOCK - RE-CONFIGURING', err=True)
-            res = self.configure(tid, {}, out, False, dbuf)
+            res = self.configure(tid, {}, out, dbuf)
             done(res)
         else:
             #print('   #', tid, '(Transform)', _format_path(self.path), 'LOCKED', err=True)

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -1194,7 +1194,18 @@ class _ContainerTransaction(_Transaction):
         for k in set(diff_by_child.keys()) - set(self.elems.keys()) - set([WILDID]):
             del diff_by_child[k]
 
-        if len(diff_by_child) == 0 and force:
+        if len(diff_by_child) == 0:
+            if not force:
+                # An empty diff without force is a refresh: nothing changes
+                # for any child, so the answer comes from the results
+                # accumulated so far. The normal path below only sees the
+                # children named in the diff - here none - so it would report
+                # even a fully configured container as empty, and a list
+                # deletes elements that report empty.
+                empty = True
+                for r in self.accum.values():
+                    empty = empty and r.empty
+                return CfgResult(empty, [], [], [])
             for k in self.elems.keys():
                 diff_by_child[k] = {}
         elif WILDID in diff_by_child:

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -140,6 +140,23 @@ class LinkUpdate():
                "\n            config=" + self.config.prsrc() + ")"
 
 class CfgResult():
+    """Result of one transaction operation (configure/linkage/lock) on a subtree.
+
+    empty means committing the transaction would leave this subtree with no
+    configuration. A transform is empty when the transaction's changes so
+    far, applied on top of its running config, leave nothing; a container or
+    list is empty when all of its children are. Lists act on the flag at
+    commit: an element whose result is empty is deleted, together with its
+    on-disk index record. (The nodes' is_empty() is different: it reports
+    the state a node already holds.)
+
+    requests are emitted by transforms that want to read another transform's
+    state, and updates carry that state from publisher to subscriber; the
+    linkage loop routes both until none remain.
+
+    errors collects transform failures. A transaction with errors is aborted
+    rather than committed.
+    """
     empty: bool
     requests: list[LinkRequest]
     updates: list[LinkUpdate]


### PR DESCRIPTION
A transaction can configure a node several times before locking, and list elements not mentioned by a later diff get a refresh: configure(tid, {}) without force. The container answered a refresh by inspecting the children the diff names - none - so a fully configured element reported itself empty, and the list staged a delete of its on-disk index record: the element's data was orphaned and the element lost at the next restore.

The refresh now answers from the results the transaction has accumulated. First commit is the failing test, second the fix, third a docstring stating what CfgResult.empty means.