### PR TITLE
Add general callback-based DB Store interface

### DIFF
--- a/minisys/src/mini/sysspec.act
+++ b/minisys/src/mini/sysspec.act
@@ -3,9 +3,9 @@
 # WARNING WARNING WARNING WARNING WARNING
 
 import logging
-import lmdb
 
 import stratoweave.app as swapp
+import stratoweave.db as swdb
 import stratoweave.device as swdev
 import stratoweave.adapters.netconf as swna
 import stratoweave.ttt as ttt
@@ -20,7 +20,7 @@ import mini.layers.y_0 as y_0
 import mini.devices.ietf as dev_ietf
 import mini.devices.ietf_oper as dev_ietf_oper
 
-def get_layers(dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None, db: ?lmdb.Db=None):
+def get_layers(dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None, db: ?swdb.Store=None):
     layer2 = ttt.Layer('2', t_2.get_ttt(None, dev_registry, log_handler), None, db)
     layer1 = ttt.Layer('1', t_1.get_ttt(layer2, dev_registry, log_handler), layer2, db)
     layer0 = ttt.Layer('0', t_0.get_ttt(layer1, dev_registry, log_handler), layer1, db)

--- a/src/app.act
+++ b/src/app.act
@@ -1,9 +1,9 @@
 import argparse
 import file
 import logging
-import lmdb
 import std.xml as xml
 
+import db as swdb
 import device as swdev
 import ttt as ttt
 import yang.gdata as ygdata
@@ -15,7 +15,7 @@ class SysSpec(value):
     """Exportable wrapper for generated functions from sysspec.act"""
     device_types: dict[str, swdev.DeviceType]
     @property
-    get_layers: proc(swdev.DeviceRegistry, ?logging.Handler, ?lmdb.Db) -> ttt.Layer
+    get_layers: proc(swdev.DeviceRegistry, ?logging.Handler, ?swdb.Store) -> ttt.Layer
     @property
     schema_for_layer: proc(int) -> yschema.DRoot
 
@@ -149,6 +149,14 @@ actor StartupBootstrap(cfs: ttt.Layer, restore_from_db: bool, netconf_host_key_p
         log.info("Restored TTT state reconciled")
         start_runtime(_netconf_host_key)
 
+    def _restore_done(error: ?Exception) -> None:
+        if error is not None:
+            log.error("Error loading persisted TTT state", {"error": error})
+            exit(1)
+            return
+        log.info("Recomputing restored TTT state")
+        cfs.newsession().recompute(_recompute_done, force=True)
+
     def _run():
         # The NETCONF SSH layer wants host-key material, not a path, so read the
         # configured key file here (before launching the runtime) and forward it.
@@ -168,14 +176,6 @@ actor StartupBootstrap(cfs: ttt.Layer, restore_from_db: bool, netconf_host_key_p
             return
 
         log.info("Loading persisted TTT state")
-        try:
-            await async cfs.load_from_db()
-        except Exception as e:
-            log.error("Error loading persisted TTT state", {"error": e})
-            exit(1)
-            return
-
-        log.info("Recomputing restored TTT state")
-        cfs.newsession().recompute(_recompute_done, force=True)
+        cfs.load_from_db(_restore_done)
 
     after 0: _run()

--- a/src/build.act
+++ b/src/build.act
@@ -100,14 +100,15 @@ class CompiledSysSpec(object):
         syssrc += "# DO NOT MODIFY THIS FILE!! This file is generated!\n"
         syssrc += "# WARNING WARNING WARNING WARNING WARNING\n\n"
         syssrc += "import logging\n"
-        syssrc += "import lmdb\n\n"
+        syssrc += "\n"
         syssrc += "import stratoweave.app as swapp\n"
+        syssrc += "import stratoweave.db as swdb\n"
         syssrc += "import stratoweave.device as swdev\n"
         syssrc += "import stratoweave.adapters.netconf as swna\n"
         syssrc += "import stratoweave.ttt as ttt\n"
         syssrc += "\n"
         syssrc += "import {self.name}.device_types as sw_device_types\n"
-        syssrc_getlayers = "def get_layers(dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None, db: ?lmdb.Db=None):\n"
+        syssrc_getlayers = "def get_layers(dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None, db: ?swdb.Store=None):\n"
         syssrc_schema_for_layer = "def schema_for_layer(layer):\n"
         for (idx, layer) in reversed(list(enumerate(self.layers))):
             print("Generating layer {idx}")

--- a/src/db.act
+++ b/src/db.act
@@ -1,4 +1,11 @@
+"""TTT persistence keys and byte-oriented storage.
+
+TTT stores encoded paths and attributes in an ordered key/value store. The
+store interface keeps backend transactions and cursors out of TTT.
+"""
+
 import yang.gdata as gdata
+import file
 import lmdb
 import json
 
@@ -23,6 +30,181 @@ ATTR_DYNSTATE = "dynstate"
 ATTR_MEMORY = "memory"
 ATTR_OUTPUT = "output"
 ATTR_RUNNING = "running"
+
+class Scan(object):
+    """Streaming range scan handle.
+
+    `next` reads one record and reports it through its callback; a `None`
+    record means end of range. At most one `next` callback is outstanding per
+    scan. `close` releases the scan; callers close every scan, including scans
+    abandoned after an error.
+    """
+
+    @property
+    next: proc(action(?(key: bytes, value: bytes), ?Exception) -> None) -> None
+    @property
+    close: proc(action(?Exception) -> None) -> None
+
+    def __init__(
+        self,
+        next: proc(action(?(key: bytes, value: bytes), ?Exception) -> None) -> None,
+        close: proc(action(?Exception) -> None) -> None
+    ):
+        self.next = next
+        self.close = close
+
+
+class Store(object):
+    """Ordered byte key/value storage used by TTT persistence.
+
+    Database operations report completion through callbacks so implementations
+    can use asynchronous network I/O. `scan(start, end)` streams records in
+    byte-key order from the half-open range `[start, end)`; `end=None` means
+    that the range has no upper bound. Writes atomically apply `(key, value)`
+    entries, where a `None` value deletes a key.
+
+    Exactly one process owns a store: TTT alone decides transaction outcomes
+    and its in-memory state is authoritative, so writes are unconditional and
+    the store is a durable mirror, never a coordination point. Should
+    distributed failover ever need to fence out competing writers,
+    conditional writes are the extension point to reintroduce.
+    """
+
+    get: proc(bytes, action(?bytes, ?Exception) -> None) -> None
+    scan: proc(bytes, ?bytes) -> Scan
+    write: proc(
+        list[(key: bytes, value: ?bytes)],
+        action(?Exception) -> None
+    ) -> None
+    close: proc(action(?Exception) -> None) -> None
+
+
+actor LmdbAdapter(db: lmdb.Db):
+    """Adapter actor for LMDB's callback-based write acquisition."""
+
+    def write(
+        writes: list[(key: bytes, value: ?bytes)],
+        done: action(?Exception) -> None
+    ) -> None:
+        def granted(error: ?Exception, txn: ?lmdb.WriteTransaction) -> None:
+            if error is not None:
+                done(error)
+                return
+            if txn is not None:
+                try:
+                    # Submit every operation before collecting results: the ops
+                    # raise their own errors and a failed transaction must not be
+                    # committed, so each result is awaited ahead of the commit.
+                    msgs = []
+                    for row in writes:
+                        val = row.value
+                        if val is not None:
+                            msgs.append(async txn.put(row.key, val))
+                        else:
+                            msgs.append(async txn.delete(row.key))
+                    for msg in msgs:
+                        await msg
+                    await async txn.commit()
+                    done(None)
+                except Exception as e:
+                    try:
+                        await async txn.abort()
+                    except Exception:
+                        pass
+                    done(e)
+            else:
+                done(lmdb.InvalidStateError("Writer request returned neither transaction nor error"))
+                return
+
+
+        db.request_write(granted)
+
+
+actor LmdbScan(db: lmdb.Db, start: bytes, end: ?bytes):
+    """Streaming range scan over one LMDB read transaction.
+
+    The read transaction opens with the scan and holds a stable view until
+    the scan reaches end of range, fails, or is closed.
+    """
+
+    txn = db.begin_read()
+    cursor = txn.cursor()
+    var started = False
+    var released = False
+
+    def release() -> None:
+        if not released:
+            released = True
+            await async txn.abort()
+
+    def next(done: action(?(key: bytes, value: bytes), ?Exception) -> None) -> None:
+        if released:
+            done(None, None)
+            return
+        try:
+            if started:
+                record = cursor.next()
+            else:
+                started = True
+                record = cursor.seek(start)
+
+            if record is None or (end is not None and record!.key >= end):
+                release()
+                done(None, None)
+                return
+            done(record, None)
+        except Exception as e:
+            try:
+                release()
+            except Exception:
+                pass
+            done(None, e)
+
+    def close(done: action(?Exception) -> None) -> None:
+        try:
+            release()
+            done(None)
+        except Exception as e:
+            done(e)
+
+
+class LmdbStore(Store):
+    """Store backed by one LMDB database."""
+
+    db: lmdb.Db
+    adapter: LmdbAdapter
+
+    def __init__(self, cap: file.WriteFileCap, path: str, map_size: ?int=None):
+        if map_size is not None:
+            self.db = lmdb.Db(cap, path, map_size)
+        else:
+            self.db = lmdb.Db(cap, path)
+        self.adapter = LmdbAdapter(self.db)
+
+    proc def get(self, key: bytes, done: action(?bytes, ?Exception) -> None) -> None:
+        try:
+            done(self.db.get(key), None)
+        except Exception as e:
+            done(None, e)
+
+    def scan(self, start: bytes, end: ?bytes=None) -> Scan:
+        scan = LmdbScan(self.db, start, end)
+        return Scan(scan.next, scan.close)
+
+    proc def write(
+        self,
+        writes: list[(key: bytes, value: ?bytes)],
+        done: action(?Exception) -> None
+    ) -> None:
+        self.adapter.write(writes, done)
+
+    proc def close(self, done: action(?Exception) -> None) -> None:
+        try:
+            self.db.close()
+            done(None)
+        except Exception as e:
+            done(e)
+
 
 # Qualified path segments are encoded as:
 #   namespace-id byte + encoded local name
@@ -87,14 +269,6 @@ class KeyCodec(object):
         if index >= len(self.namespaces):
             raise ValueError("Unknown namespace id byte 0x{_hex_byte(prefix)} in TTT persistence key")
         return gdata.Id(self.namespaces[index], _decode_text(raw[1:]))
-
-class WriteTransaction(object):
-    txn: lmdb.WriteTransaction
-    codec: KeyCodec
-
-    def __init__(self, txn: lmdb.WriteTransaction):
-        self.txn = txn
-        self.codec = _key_codec_from_raw(txn.get(META_KEY))
 
 class BufferOp(object):
     path: list[value]
@@ -161,21 +335,33 @@ actor Buffer():
             return
         ops_by_slot[slot] = ops
 
-    def flush_to_db(wtr: WriteTransaction) -> None:
-        put_msgs = []
-        delete_msgs = []
+    def flush_to_db(store: Store, done: action(?Exception) -> None) -> None:
+        """Write the buffered operations and updated metadata.
+
+        The single owning process is the only writer, so the metadata read
+        here is current and the write is unconditional.
+        """
+        ops = []
         for slot in sorted(ops_by_slot.keys()):
             for op in ops_by_slot[slot]:
-                key = to_attr_key(op.path, op.attr, op.qualifier, wtr.codec)
-                val = op.value
-                if val is not None:
-                    put_msgs.append(async wtr.txn.put(key, val))
-                else:
-                    delete_msgs.append(async wtr.txn.delete(key))
-        for msg in put_msgs:
-            await msg
-        for msg in delete_msgs:
-            await msg
+                ops.append(op)
+
+        def got_metadata(metadata: ?bytes, error: ?Exception) -> None:
+            if error is not None:
+                done(error)
+                return
+            try:
+                codec = _key_codec_from_raw(metadata)
+                writes = []
+                for op in ops:
+                    key = to_attr_key(op.path, op.attr, op.qualifier, codec)
+                    writes.append((key=key, value=op.value))
+                writes.append((key=META_KEY, value=_encode_metadata(codec)))
+                store.write(writes, done)
+            except Exception as e:
+                done(e)
+
+        store.get(META_KEY, got_metadata)
 
 def _encode_text(text: str) -> bytes:
     raw = text.encode()
@@ -241,9 +427,6 @@ def _canonical_namespaces(namespaces: list[str]) -> list[str]:
 
 def _encode_metadata(codec: KeyCodec) -> bytes:
     return json.encode({"version": VERSION, "namespaces": _canonical_namespaces(codec.namespaces)}, pretty=False).encode()
-
-proc def write_metadata(wtr: WriteTransaction) -> None:
-    wtr.txn.put(META_KEY, _encode_metadata(wtr.codec))
 
 def _decode_record(raw: bytes) -> dict[str, ?value]:
     decoded = json.decode(raw.decode())
@@ -384,8 +567,10 @@ def _key_codec_from_raw(raw: ?bytes) -> KeyCodec:
         return KeyCodec(_decode_namespaces(record))
     raise ValueError("Invalid TTT persistence metadata: missing integer version")
 
-def read_key_codec(txn: lmdb.ReadTransaction) -> KeyCodec:
-    return _key_codec_from_raw(txn.get(META_KEY))
+
+def decode_key_codec(raw: ?bytes) -> KeyCodec:
+    """Decode key codec metadata, using an empty namespace table when absent."""
+    return _key_codec_from_raw(raw)
 
 def _parse_attr_key_bytes(key: bytes) -> (list[bytes], bytes, ?bytes):
     prefix = META_KEY + PATH_SEPARATOR

--- a/src/lib.act
+++ b/src/lib.act
@@ -1,11 +1,11 @@
 import file
 import logging
-import lmdb
 import net
 
 import tmf.cfs
 
 import app as swapp
+import db as swdb
 import device as swdev
 import http_server as swhttp
 import netconf_server as swnetconf
@@ -68,7 +68,7 @@ def main(sysspec: swapp.SysSpec, env: Env, http: bool=True, netconf: bool=True):
     top_schema = sysspec.schema_for_layer(0)
     db_path = args.db_path
     if db_path is not None:
-        db = lmdb.Db(file.WriteFileCap(fcap), db_path, TTT_DB_MAP_SIZE)
+        db = swdb.LmdbStore(file.WriteFileCap(fcap), db_path, TTT_DB_MAP_SIZE)
     else:
         db = None
 

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -36,8 +36,7 @@ def qlive_removed(n: str) -> gdata.Id:
 def is_ttt_db_key(key: bytes) -> bool:
     return key == swdb.META_KEY or key.startswith(swdb.META_KEY + swdb.PATH_SEPARATOR)
 
-def ttt_db_snapshot(read_txn: lmdb.ReadTransaction) -> str:
-    codec = swdb.read_key_codec(read_txn)
+def ttt_db_snapshot(read_txn: lmdb.ReadTransaction, codec: swdb.KeyCodec) -> str:
     cursor = read_txn.cursor()
     lines = []
     kv = cursor.seek_prefix(b"ttt")
@@ -311,17 +310,80 @@ actor db_key_codec_round_trips_qualified_segments(t: testing.AsyncT):
     testing.assertEqual(parsed.2!, "_")
     t.success()
 
-actor TransformWriteFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: lmdb.Db, layer: ttt.Layer):
+
+actor StoreCallbackFlow(t: testing.EnvT, fs: file.FS, db_path: str, store: swdb.Store):
+    var scan: ?swdb.Scan = None
+
+    def read_next(done: action(?(key: bytes, value: bytes), ?Exception) -> None) -> None:
+        scan!.next(done)
+
+    def after_store_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        await async fs.rmtree(db_path)
+        await async fs.rmdir(db_path)
+        t.success()
+
+    def after_scan_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.close(after_store_close)
+
+    def after_eof(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertNone(record)
+        scan!.close(after_scan_close)
+
+    def after_second(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        row = record!
+        testing.assertEqual(row.key, b"b")
+        testing.assertEqual(row.value, b"2")
+        read_next(after_eof)
+
+    def after_first(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        row = record!
+        testing.assertEqual(row.key, b"a")
+        testing.assertEqual(row.value, b"1")
+        read_next(after_second)
+
+    def after_get(value: ?bytes, error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(value, b"2")
+        scan = store.scan(b"a", b"c")
+        read_next(after_first)
+
+    def after_write(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.get(b"b", after_get)
+
+    store.write([(key=b"a", value=b"1"), (key=b"b", value=b"2"), (key=b"c", value=b"3")], after_write)
+
+
+actor lmdb_store_uses_callback_scan_and_write(t: testing.EnvT):
+    fc = file.FileCap(t.env.cap)
+    fs = file.FS(fc)
+    db_path = fs.mktmpdir("test_ttt_store_callbacks_")
+    store = swdb.LmdbStore(file.WriteFileCap(fc), db_path)
+    StoreCallbackFlow(t, fs, db_path, store)
+
+
+actor TransformWriteFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: swdb.LmdbStore, layer: ttt.Layer):
     def after_commit_cb(_r: value) -> None:
         after_commit()
         return None
 
     def after_commit() -> None:
-        read_txn = db.begin_read()
-        snapshot = ttt_db_snapshot(read_txn)
-
+        read_txn = db.db.begin_read()
+        snapshot = ttt_db_snapshot(read_txn, swdb.decode_key_codec(read_txn.get(swdb.META_KEY)))
         await async read_txn.commit()
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success(snapshot)
@@ -337,40 +399,38 @@ def write_structural_list_element(write_txn: lmdb.WriteTransaction, codec: swdb.
     write_txn.put(swdb.to_attr_key(element_path + [value_id], swdb.ATTR_RUNNING, "_", codec), value_node.to_json_str(pretty=False).encode())
 
 
-actor StructuralListWriteFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: lmdb.Db, layer: ttt.Layer):
+actor StructuralListWriteFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: swdb.LmdbStore, layer: ttt.Layer):
     def after_commit_cb(_r: value) -> None:
         after_commit()
         return None
 
     def after_commit() -> None:
-        read_txn = db.begin_read()
-        snapshot = ttt_db_snapshot(read_txn)
-
+        read_txn = db.db.begin_read()
+        snapshot = ttt_db_snapshot(read_txn, swdb.decode_key_codec(read_txn.get(swdb.META_KEY)))
         await async read_txn.commit()
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success(snapshot)
 
 
-actor StatefulTransformWriteFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: lmdb.Db):
+actor StatefulTransformWriteFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: swdb.LmdbStore):
     var completed = False
 
     def after_settled() -> None:
         if completed:
             return
         completed = True
-        read_txn = db.begin_read()
-        snapshot = ttt_db_snapshot(read_txn)
-
+        read_txn = db.db.begin_read()
+        snapshot = ttt_db_snapshot(read_txn, swdb.decode_key_codec(read_txn.get(swdb.META_KEY)))
         await async read_txn.commit()
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success(snapshot)
 
 
-actor BusyWriterWaitFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: lmdb.Db, layer: ttt.Layer, held_txn: lmdb.WriteTransaction):
+actor BusyWriterWaitFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: swdb.LmdbStore, layer: ttt.Layer, held_txn: lmdb.WriteTransaction):
     var released = False
 
     def release_writer() -> None:
@@ -384,10 +444,10 @@ actor BusyWriterWaitFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: lmdb.Db
             raise AssertionError("Expected successful completion after waiting for busy DB writer, got {r}")
         testing.assertEqual(released, True)
         testing.assertEqual(layer.get(), persist_cfg)
-        read_txn = db.begin_read()
+        read_txn = db.db.begin_read()
         testing.assertEqual(read_txn.get(swdb.META_KEY) is not None, True)
         await async read_txn.commit()
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
@@ -397,7 +457,7 @@ actor persist_transform_record(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_persist_transform_")
     cap = file.WriteFileCap(fc)
-    db = lmdb.Db(cap, db_path)
+    db = swdb.LmdbStore(cap, db_path)
     layer: ttt.Layer = ttt.Layer("single", ttt.Transform(ttt.PassThrough), None, db)
     flow = TransformWriteFlow(t, fs, db_path, db, layer)
     layer.edit_config(persist_cfg, flow.after_commit_cb)
@@ -408,8 +468,8 @@ actor wait_for_busy_db_writer_then_commit(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_wait_busy_writer_")
     cap = file.WriteFileCap(fc)
-    db = lmdb.Db(cap, db_path)
-    held_txn = db.begin_write()
+    db = swdb.LmdbStore(cap, db_path)
+    held_txn = db.db.begin_write()
     layer: ttt.Layer = ttt.Layer("single", ttt.Transform(ttt.PassThrough), None, db)
     flow = BusyWriterWaitFlow(t, fs, db_path, db, layer, held_txn)
     after 0.05: flow.release_writer()
@@ -421,7 +481,7 @@ actor dbuffer_refreshes_on_lock_reconfigure(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_dbuffer_refresh_")
     cap = file.WriteFileCap(fc)
-    db = lmdb.Db(cap, db_path)
+    db = swdb.LmdbStore(cap, db_path)
     node: ttt.Node = ttt.Transform(ttt.PassThrough)(ttt.PathRoot("single:"), None)
     tr: ttt.Transaction = node.newtrans()
     seedbuf: swdb.Buffer = swdb.Buffer()
@@ -431,16 +491,10 @@ actor dbuffer_refreshes_on_lock_reconfigure(t: testing.EnvT):
     def is_cfg_ok(r: ttt.CfgResult) -> bool:
         return not r.errors
 
-    def after_t1_lock(r: ttt.CfgResult) -> None:
-        if not is_cfg_ok(r):
-            raise AssertionError("Expected successful t1 lock after reconfigure, got {r}")
-        write_txn = db.begin_write()
-        dbtr = swdb.WriteTransaction(write_txn)
-        t1buf1: swdb.Buffer = t1buf
-        await async t1buf1.flush_to_db(dbtr)
-        await async write_txn.commit()
-
-        read_txn = db.begin_read()
+    def after_t1_flush(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        read_txn = db.db.begin_read()
         running_raw = read_txn.get(swdb.to_attr_key(["single"], swdb.ATTR_RUNNING, "_"))
         output_raw = read_txn.get(swdb.to_attr_key(["single"], swdb.ATTR_OUTPUT))
         testing.assertEqual(running_raw!.decode(), overlap_expected_cfg.to_json_str(pretty=False))
@@ -448,10 +502,15 @@ actor dbuffer_refreshes_on_lock_reconfigure(t: testing.EnvT):
         await async read_txn.commit()
 
         tr.commit("1", True)
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
+
+    def after_t1_lock(r: ttt.CfgResult) -> None:
+        if not is_cfg_ok(r):
+            raise AssertionError("Expected successful t1 lock after reconfigure, got {r}")
+        t1buf.flush_to_db(db, after_t1_flush)
 
     def after_t2_lock(r: ttt.CfgResult) -> None:
         if not is_cfg_ok(r):
@@ -482,7 +541,7 @@ actor persist_structural_list_snapshot(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_persist_struct_")
     cap = file.WriteFileCap(fc)
-    db = lmdb.Db(cap, db_path)
+    db = swdb.LmdbStore(cap, db_path)
     layer: ttt.Layer = ttt.Layer("struct", struct_root, None, db)
     flow = StructuralListWriteFlow(t, fs, db_path, db, layer)
     layer.edit_config(struct_tree, flow.after_commit_cb)
@@ -493,7 +552,7 @@ actor persist_structural_list_escaped_snapshot(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_persist_struct_escaped_")
     cap = file.WriteFileCap(fc)
-    db = lmdb.Db(cap, db_path)
+    db = swdb.LmdbStore(cap, db_path)
     layer: ttt.Layer = ttt.Layer(escaped_layer_name, struct_root, None, db)
     flow = StructuralListWriteFlow(t, fs, db_path, db, layer)
     layer.edit_config(escaped_struct_tree, flow.after_commit_cb)
@@ -504,7 +563,7 @@ actor persist_transform_state_snapshot(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_persist_stateful_")
     cap = file.WriteFileCap(fc)
-    db = lmdb.Db(cap, db_path)
+    db = swdb.LmdbStore(cap, db_path)
     var root: ?ttt.Node = None
     flow = StatefulTransformWriteFlow(t, fs, db_path, db)
 
@@ -533,23 +592,27 @@ actor restore_transform_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_transform_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored = ttt.Layer("single", ttt.Transform(ttt.PassThrough), None, db)
 
     def after_recommit(_r: value) -> None:
         testing.assertEqual(restored.get(), persist_cfg_updated)
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
-    def after_initial_commit(_r: value) -> None:
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
-        restored = ttt.Layer("single", ttt.Transform(ttt.PassThrough), None, db)
-        await async restored.load_from_db()
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
         testing.assertEqual(restored.get(), persist_cfg)
         restored.edit_config(persist_cfg_updated, None, after_recommit)
+
+    def after_initial_commit(_r: value) -> None:
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
+        restored = ttt.Layer("single", ttt.Transform(ttt.PassThrough), None, db)
+        restored.load_from_db(after_restore)
 
     restored.edit_config(persist_cfg, after_initial_commit)
 
@@ -559,36 +622,36 @@ actor reject_restore_into_nonempty_tree(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_nonempty_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored = ttt.Layer("single", ttt.Transform(ttt.PassThrough), None, db)
 
     def cleanup_success() -> None:
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
-    def after_second_load_failure(e: Exception) -> None:
-        testing.assertEqual(str(e), "ValueError: TTT restore requires an empty tree in layer single")
-        cleanup_success()
-
-    def after_first_load() -> None:
-        testing.assertEqual(restored.get(), persist_cfg)
-        try:
-            await async restored.load_from_db()
-            await async db.close()
+    def after_second_load(error: ?Exception) -> None:
+        if error is None:
+            await async db.db.close()
             await async fs.rmtree(db_path)
             await async fs.rmdir(db_path)
             t.failure(AssertionError("Expected second load_from_db to reject a non-empty tree"))
-        except ValueError as e:
-            after_second_load_failure(e)
+            return
+        testing.assertEqual(str(error), "ValueError: TTT restore requires an empty tree in layer single")
+        cleanup_success()
+
+    def after_first_load(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(restored.get(), persist_cfg)
+        restored.load_from_db(after_second_load)
 
     def after_initial_commit(_r: value) -> None:
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
         restored = ttt.Layer("single", ttt.Transform(ttt.PassThrough), None, db)
-        await async restored.load_from_db()
-        after_first_load()
+        restored.load_from_db(after_first_load)
 
     restored.edit_config(persist_cfg, after_initial_commit)
 
@@ -598,27 +661,32 @@ actor reject_map_full_without_committing_memory(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_map_full_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path, 256 * 1024)
+    var db = swdb.LmdbStore(cap, db_path, 256 * 1024)
     layer = ttt.Layer("struct", struct_root, None, db)
 
     def after_recovery(r: value) -> None:
         if not isinstance(r, str):
             raise AssertionError("Expected successful recovery completion after DB persist failure, got {r}")
         testing.assertEqual(layer.get(), struct_tree)
-        await async db.close()
-        db = lmdb.Db(cap, db_path, 256 * 1024)
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path, 256 * 1024)
         restored = ttt.Layer("struct", struct_root, None, db)
-        await async restored.load_from_db()
-        testing.assertEqual(restored.get(), struct_tree)
-        await async db.close()
-        await async fs.rmtree(db_path)
-        await async fs.rmdir(db_path)
-        t.success()
+
+        def after_restore(error: ?Exception) -> None:
+            if error is not None:
+                raise error
+            testing.assertEqual(restored.get(), struct_tree)
+            await async db.db.close()
+            await async fs.rmtree(db_path)
+            await async fs.rmdir(db_path)
+            t.success()
+
+        restored.load_from_db(after_restore)
 
     def after_failure(r: value) -> None:
         testing.assertEqual(isinstance(r, lmdb.MapFullError), True)
         testing.assertEqual(layer.get(), empty_struct_tree)
-        read_txn = db.begin_read()
+        read_txn = db.db.begin_read()
         testing.assertEqual(read_txn.cursor().seek_prefix(swdb.META_KEY), None)
         await async read_txn.commit()
         layer.edit_config(struct_tree, None, after_recovery)
@@ -631,27 +699,31 @@ actor restore_transform_memory_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_memory_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored = ttt.Layer("memory", ttt.Transform(PersistMemoryTransform), None, db)
 
     def after_recommit(r: value) -> None:
         if not isinstance(r, str):
             raise AssertionError("Expected successful recommit completion after restore, got {r}")
         testing.assertEqual(restored.get(), memory_cfg_updated)
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(restored.get(), memory_cfg)
+        restored.edit_config(memory_cfg_updated, None, after_recommit)
+
     def after_initial_commit(r: value) -> None:
         if not (isinstance(r, str) and r == "Ok"):
             raise AssertionError("Expected successful initial commit for memory restore, got {r}")
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
         restored = ttt.Layer("memory", ttt.Transform(PersistMemoryTransform), None, db)
-        await async restored.load_from_db()
-        testing.assertEqual(restored.get(), memory_cfg)
-        restored.edit_config(memory_cfg_updated, None, after_recommit)
+        restored.load_from_db(after_restore)
 
     restored.edit_config(memory_cfg, after_initial_commit)
 
@@ -661,7 +733,7 @@ actor restore_transform_dynstate_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_dynstate_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var root: ?ttt.Node = None
     var restored = ttt.Layer("stateful", ttt.Transform(PersistDynstateTransform), None, db)
 
@@ -673,20 +745,24 @@ actor restore_transform_dynstate_round_trip(t: testing.EnvT):
         if not isinstance(r, str):
             raise AssertionError("Expected successful dynstate recommit completion after restore, got {r}")
         testing.assertEqual(restored.get(), stateful_cfg_updated)
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(restored.get(), stateful_cfg)
+        restored.edit_config(stateful_cfg_updated, None, after_recommit)
+
     def after_seed_recompute(r: value) -> None:
         if not (isinstance(r, str) and r == "Ok"):
             raise AssertionError("Expected successful dynstate seed recompute, got {r}")
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
         restored = ttt.Layer("stateful", ttt.Transform(PersistDynstateTransform), None, db)
-        await async restored.load_from_db()
-        testing.assertEqual(restored.get(), stateful_cfg)
-        restored.edit_config(stateful_cfg_updated, None, after_recommit)
+        restored.load_from_db(after_restore)
 
     def after_initial_commit(r: value) -> None:
         if not isinstance(r, str):
@@ -704,23 +780,27 @@ actor restore_structural_list_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_struct_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored = ttt.Layer("struct", struct_root, None, db)
 
     def after_recommit(_r: value) -> None:
         testing.assertEqual(restored.get(), struct_tree_updated)
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
-    def after_initial_commit(_r: value) -> None:
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
-        restored = ttt.Layer("struct", struct_root, None, db)
-        await async restored.load_from_db()
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
         testing.assertEqual(restored.get(), struct_tree)
         restored.edit_config(struct_tree_updated, None, after_recommit)
+
+    def after_initial_commit(_r: value) -> None:
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
+        restored = ttt.Layer("struct", struct_root, None, db)
+        restored.load_from_db(after_restore)
 
     restored.edit_config(struct_tree, after_initial_commit)
 
@@ -734,12 +814,14 @@ actor restore_survives_forced_recompute(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_recompute_survive_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored = ttt.Layer("struct", struct_root, None, db)
 
-    def after_second_restore() -> None:
+    def after_second_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
         testing.assertEqual(restored.get(), struct_tree)
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
@@ -747,18 +829,22 @@ actor restore_survives_forced_recompute(t: testing.EnvT):
     def after_recompute(result: value) -> None:
         if isinstance(result, Exception):
             raise result
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
         restored = ttt.Layer("struct", struct_root, None, db)
-        await async restored.load_from_db()
-        after_second_restore()
+        restored.load_from_db(after_second_restore)
 
     def after_initial_commit(_r: value) -> None:
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
         restored = ttt.Layer("struct", struct_root, None, db)
-        await async restored.load_from_db()
-        restored.newsession().recompute(after_recompute, force=True)
+
+        def restored_then_recompute(error: ?Exception) -> None:
+            if error is not None:
+                raise error
+            restored.newsession().recompute(after_recompute, force=True)
+
+        restored.load_from_db(restored_then_recompute)
 
     restored.edit_config(struct_tree, after_initial_commit)
 
@@ -768,39 +854,47 @@ actor restore_structural_list_delete_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_struct_delete_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored = ttt.Layer("struct", struct_root, None, db)
 
-    def after_delete_commit(_r: value) -> None:
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
-        restored = ttt.Layer("struct", struct_root, None, db)
-        await async restored.load_from_db()
+    def after_delete_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
         actual = restored.get().prsrc(True)
         expected = empty_struct_tree.prsrc(True)
         if actual != expected:
-            read_txn = db.begin_read()
-            snapshot = ttt_db_snapshot(read_txn)
+            read_txn = db.db.begin_read()
+            snapshot = ttt_db_snapshot(read_txn, swdb.decode_key_codec(read_txn.get(swdb.META_KEY)))
             await async read_txn.commit()
             raise AssertionError("Expected empty restored list after delete.\nSnapshot:\n{snapshot}\nActual:\n{actual}")
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
-    def after_initial_commit(_r: value) -> None:
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
+    def after_delete_commit(_r: value) -> None:
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
         restored = ttt.Layer("struct", struct_root, None, db)
-        await async restored.load_from_db()
+        restored.load_from_db(after_delete_restore)
+
+    def after_initial_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
         actual = restored.get().prsrc(True)
         expected = struct_delete_tree.prsrc(True)
         if actual != expected:
-            read_txn = db.begin_read()
-            snapshot = ttt_db_snapshot(read_txn)
+            read_txn = db.db.begin_read()
+            snapshot = ttt_db_snapshot(read_txn, swdb.decode_key_codec(read_txn.get(swdb.META_KEY)))
             await async read_txn.commit()
             raise AssertionError("Unexpected restored list before delete.\nSnapshot:\n{snapshot}\nActual:\n{actual}")
         restored.edit_config(deleted_struct_tree, None, after_delete_commit)
+
+    def after_initial_commit(_r: value) -> None:
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
+        restored = ttt.Layer("struct", struct_root, None, db)
+        restored.load_from_db(after_initial_restore)
 
     restored.edit_config(struct_delete_tree, after_initial_commit)
 
@@ -810,23 +904,27 @@ actor restore_structural_list_escaped_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_struct_escaped_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored = ttt.Layer(escaped_layer_name, struct_root, None, db)
 
     def after_recommit(_r: value) -> None:
         testing.assertEqual(restored.get(), escaped_struct_tree_updated)
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
-    def after_initial_commit(_r: value) -> None:
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
-        restored = ttt.Layer(escaped_layer_name, struct_root, None, db)
-        await async restored.load_from_db()
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
         testing.assertEqual(restored.get(), escaped_struct_tree)
         restored.edit_config(escaped_struct_tree_updated, None, after_recommit)
+
+    def after_initial_commit(_r: value) -> None:
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
+        restored = ttt.Layer(escaped_layer_name, struct_root, None, db)
+        restored.load_from_db(after_restore)
 
     restored.edit_config(escaped_struct_tree, after_initial_commit)
 
@@ -836,22 +934,26 @@ actor restore_layer_stack_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_layers_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored_lower = ttt.Layer("lower", ttt.Transform(ttt.PassThrough), None, db)
     var restored_top = ttt.Layer("upper", ttt.Transform(ttt.PassThrough), restored_lower, db)
 
-    def after_initial_commit(_r: value) -> None:
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
-        restored_lower = ttt.Layer("lower", ttt.Transform(ttt.PassThrough), None, db)
-        restored_top = ttt.Layer("upper", ttt.Transform(ttt.PassThrough), restored_lower, db)
-        await async restored_top.load_from_db()
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
         testing.assertEqual(restored_top.get(), persist_cfg)
         testing.assertEqual(restored_lower.get(), persist_cfg)
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
+
+    def after_initial_commit(_r: value) -> None:
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
+        restored_lower = ttt.Layer("lower", ttt.Transform(ttt.PassThrough), None, db)
+        restored_top = ttt.Layer("upper", ttt.Transform(ttt.PassThrough), restored_lower, db)
+        restored_top.load_from_db(after_restore)
 
     restored_top.edit_config(persist_cfg, after_initial_commit)
 
@@ -861,28 +963,36 @@ actor restore_exact_layer_name_prefix_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_exact_layer_prefix_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var foo_layer = ttt.Layer("foo", ttt.Transform(ttt.PassThrough), None, db)
     var foobar_layer = ttt.Layer("foobar", ttt.Transform(ttt.PassThrough), None, db)
 
     def cleanup_success() -> None:
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
-    def after_foobar_commit(r: value) -> None:
-        if not isinstance(r, str):
-            raise AssertionError("Expected successful foobar completion, got {r}")
-        await async db.close()
-        db = lmdb.Db(cap, db_path)
-        foo_layer = ttt.Layer("foo", ttt.Transform(ttt.PassThrough), None, db)
-        foobar_layer = ttt.Layer("foobar", ttt.Transform(ttt.PassThrough), None, db)
-        await async foo_layer.load_from_db()
-        await async foobar_layer.load_from_db()
+    def after_foobar_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
         testing.assertEqual(foo_layer.get(), foo_cfg)
         testing.assertEqual(foobar_layer.get(), foobar_cfg)
         cleanup_success()
+
+    def after_foo_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        foobar_layer.load_from_db(after_foobar_restore)
+
+    def after_foobar_commit(r: value) -> None:
+        if not isinstance(r, str):
+            raise AssertionError("Expected successful foobar completion, got {r}")
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
+        foo_layer = ttt.Layer("foo", ttt.Transform(ttt.PassThrough), None, db)
+        foobar_layer = ttt.Layer("foobar", ttt.Transform(ttt.PassThrough), None, db)
+        foo_layer.load_from_db(after_foo_restore)
 
     def after_foo_commit(r: value) -> None:
         if not isinstance(r, str):
@@ -897,7 +1007,7 @@ actor restore_qualified_namespace_shift_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_ns_shift_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored = ttt.Layer("shift", qualified_root, None, db)
 
     def write_transform_state(write_txn: lmdb.WriteTransaction, codec: swdb.KeyCodec, path: list[value], value: gdata.Node) -> None:
@@ -905,26 +1015,30 @@ actor restore_qualified_namespace_shift_round_trip(t: testing.EnvT):
         write_txn.put(swdb.to_attr_key(path, swdb.ATTR_RUNNING, "_", codec), value.to_json_str(pretty=False).encode())
 
     def after_recommit(_r: value) -> None:
-        read_txn = db.begin_read()
-        codec = swdb.read_key_codec(read_txn)
+        read_txn = db.db.begin_read()
+        codec = swdb.decode_key_codec(read_txn.get(swdb.META_KEY))
         testing.assertEqual(codec.namespaces, [SHIFT_NS_B, SHIFT_NS_A, SHIFT_NS_C])
         testing.assertEqual(restored.get(), qualified_tree_updated)
         await async read_txn.commit()
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
-    write_txn = db.begin_write()
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(restored.get(), qualified_tree)
+        restored.edit_config(qualified_tree_updated, None, after_recommit)
+
+    write_txn = db.db.begin_write()
     codec = swdb.KeyCodec([SHIFT_NS_B, SHIFT_NS_A])
     write_txn.put(swdb.META_KEY, json.encode({"version": swdb.VERSION, "namespaces": codec.namespaces}, pretty=False).encode())
     write_transform_state(write_txn, codec, ["shift", qa_shift("branch"), qb_shift("value")], gdata.Leaf(11))
     write_transform_state(write_txn, codec, ["shift", qb_shift("branch"), qa_shift("value")], gdata.Leaf(22))
     await async write_txn.commit()
 
-    await async restored.load_from_db()
-    testing.assertEqual(restored.get(), qualified_tree)
-    restored.edit_config(qualified_tree_updated, None, after_recommit)
+    restored.load_from_db(after_restore)
 
 
 actor restore_removed_namespace_gap_round_trip(t: testing.EnvT):
@@ -932,29 +1046,33 @@ actor restore_removed_namespace_gap_round_trip(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_removed_ns_gap_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = swdb.LmdbStore(cap, db_path)
     var restored = ttt.Layer("removed", removed_live_root, None, db)
 
     def after_recommit(_r: value) -> None:
-        read_txn = db.begin_read()
-        codec = swdb.read_key_codec(read_txn)
+        read_txn = db.db.begin_read()
+        codec = swdb.decode_key_codec(read_txn.get(swdb.META_KEY))
         testing.assertEqual(codec.namespaces, [REMOVED_NS_OLD, REMOVED_NS_LIVE])
         testing.assertEqual(restored.get(), removed_live_tree_updated)
         await async read_txn.commit()
-        await async db.close()
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         t.success()
 
-    write_txn = db.begin_write()
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(restored.get(), removed_live_tree)
+        restored.edit_config(removed_live_tree_updated, None, after_recommit)
+
+    write_txn = db.db.begin_write()
     codec = swdb.KeyCodec([REMOVED_NS_OLD, REMOVED_NS_LIVE])
     write_txn.put(swdb.META_KEY, json.encode({"version": swdb.VERSION, "namespaces": codec.namespaces}, pretty=False).encode())
     write_structural_list_element(write_txn, codec, "removed", qlive_removed("items"), qlive_removed("name"), qlive_removed("value"), "a", gdata.Leaf(7))
     await async write_txn.commit()
 
-    await async restored.load_from_db()
-    testing.assertEqual(restored.get(), removed_live_tree)
-    restored.edit_config(removed_live_tree_updated, None, after_recommit)
+    restored.load_from_db(after_restore)
 
 
 actor reject_removed_namespace_with_persisted_list_data(t: testing.EnvT):
@@ -962,8 +1080,8 @@ actor reject_removed_namespace_with_persisted_list_data(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_removed_ns_data_")
     cap = file.WriteFileCap(fc)
-    db = lmdb.Db(cap, db_path)
-    write_txn = db.begin_write()
+    db = swdb.LmdbStore(cap, db_path)
+    write_txn = db.db.begin_write()
     codec = swdb.KeyCodec([REMOVED_NS_OLD, REMOVED_NS_LIVE])
     write_txn.put(swdb.META_KEY, json.encode({"version": swdb.VERSION, "namespaces": codec.namespaces}, pretty=False).encode())
     write_structural_list_element(write_txn, codec, "removed", qold_removed("items"), qold_removed("name"), qold_removed("value"), "legacy", gdata.Leaf(1))
@@ -971,19 +1089,21 @@ actor reject_removed_namespace_with_persisted_list_data(t: testing.EnvT):
 
     layer = ttt.Layer("removed", removed_live_root, None, db)
 
-    try:
-        await async layer.load_from_db()
-        await async db.close()
-        await async fs.rmtree(db_path)
-        await async fs.rmdir(db_path)
-        t.failure(AssertionError("Expected load_from_db to reject persisted data under a removed namespace"))
-    except ValueError as e:
-        err = str(e)
-        await async db.close()
+    def after_restore(error: ?Exception) -> None:
+        if error is None:
+            await async db.db.close()
+            await async fs.rmtree(db_path)
+            await async fs.rmdir(db_path)
+            t.failure(AssertionError("Expected load_from_db to reject persisted data under a removed namespace"))
+            return
+        err = str(error)
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         testing.assertEqual("Unable to route persisted child items#{REMOVED_NS_OLD}" in err, True)
         t.success()
+
+    layer.load_from_db(after_restore)
 
 
 actor reject_persistence_version_mismatch(t: testing.EnvT):
@@ -991,22 +1111,24 @@ actor reject_persistence_version_mismatch(t: testing.EnvT):
     fs = file.FS(fc)
     db_path = fs.mktmpdir("test_ttt_restore_bad_version_")
     cap = file.WriteFileCap(fc)
-    db = lmdb.Db(cap, db_path)
-    write_txn = db.begin_write()
+    db = swdb.LmdbStore(cap, db_path)
+    write_txn = db.db.begin_write()
     write_txn.put(swdb.META_KEY, json.encode({"version": 0}, pretty=False).encode())
     await async write_txn.commit()
     layer = ttt.Layer("single", ttt.Transform(ttt.PassThrough), None, db)
 
-    try:
-        await async layer.load_from_db()
-        await async db.close()
-        await async fs.rmtree(db_path)
-        await async fs.rmdir(db_path)
-        t.failure(AssertionError("Expected load_from_db to reject unsupported persistence version"))
-    except ValueError as e:
-        err = str(e)
-        await async db.close()
+    def after_restore(error: ?Exception) -> None:
+        if error is None:
+            await async db.db.close()
+            await async fs.rmtree(db_path)
+            await async fs.rmdir(db_path)
+            t.failure(AssertionError("Expected load_from_db to reject unsupported persistence version"))
+            return
+        err = str(error)
+        await async db.db.close()
         await async fs.rmtree(db_path)
         await async fs.rmdir(db_path)
         testing.assertEqual(err, "ValueError: Unsupported TTT persistence version 0, expected 1")
         t.success()
+
+    layer.load_from_db(after_restore)

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -6,7 +6,6 @@ import adapters.adapter as swadapt
 from device_meta_config import stratoweave_rfs__device_entry as DeviceMetaConfig
 import std.xml as xml
 import logging
-import lmdb
 
 def unwrap[T](t: ?T) -> T:
     if t is not None:
@@ -512,7 +511,7 @@ actor Node(impl: _Node):
     def get_data(filt: ?gdata.FNode=None):
         return impl.get_data(filt)
 
-    def bind_db(db: ?lmdb.Db):
+    def bind_db(db: ?swdb.Store):
         """Attach DB handle to this node (and its children)
 
         The DB used for persistence is not bound in at construction time which
@@ -533,7 +532,7 @@ class _Node(object):
     get: proc() -> gdata.Node
     def get_data(self, filt: ?gdata.FNode=None) -> ?gdata.Node:
         return gdata.filter(self.get(), filt)
-    def bind_db(self, db: ?lmdb.Db) -> None:
+    def bind_db(self, db: ?swdb.Store) -> None:
         pass
     restore: proc(list[str], str, ?str, bytes) -> None
     def is_empty(self) -> bool:
@@ -569,7 +568,7 @@ actor Transaction(impl: _Transaction):
     def get_data(filt: ?gdata.FNode=None):
         return impl.get_data(filt)
 
-    def bind_db(db: ?lmdb.Db):
+    def bind_db(db: ?swdb.Store):
         impl.bind_db(db)
 
     def restore(attr: str, qualifier: ?str, raw: bytes):
@@ -601,7 +600,7 @@ class _Transaction(object):
     def get_data(self, filt: ?gdata.FNode=None) -> ?gdata.Node:
         return gdata.filter(self.get(), filt)
 
-    def bind_db(self, db: ?lmdb.Db) -> None:
+    def bind_db(self, db: ?swdb.Store) -> None:
         pass
 
     def restore(self, attr: str, qualifier: ?str, raw: bytes) -> None:
@@ -621,46 +620,96 @@ class _Transaction(object):
 
 ####################### Layer ########################
 
-actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg: ?lmdb.Db=None):
+actor LayerRestore(
+    name: str,
+    root: Node,
+    lower,
+    store: swdb.Store,
+    top_only: bool,
+    done: action(?Exception) -> None
+):
+    var codec = swdb.KeyCodec([])
+    var prefix = b""
+    var scan: ?swdb.Scan = None
+    var result_error: ?Exception = None
+    var finished = False
+
+    def read_next() -> None:
+        scan!.next(got_record)
+
+    def closed(error: ?Exception) -> None:
+        final_error = result_error if result_error is not None else error
+        if final_error is not None:
+            done(final_error)
+        elif not top_only and lower is not None:
+            lower.load_from_db(done, False)
+        else:
+            done(None)
+
+    def finish(error: ?Exception) -> None:
+        if finished:
+            return
+        finished = True
+        result_error = error
+        if scan is not None:
+            scan.close(closed)
+        else:
+            closed(None)
+
+    def got_record(kv: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            finish(error)
+            return
+        if kv is None:
+            finish(None)
+            return
+
+        try:
+            entry = kv!
+            if not entry.key.startswith(prefix):
+                finish(None)
+                return
+            boundary = entry.key[len(prefix)] if len(entry.key) > len(prefix) else None
+            if boundary != swdb.PATH_SEPARATOR[0] and boundary != swdb.ATTRIBUTE_SEPARATOR[0]:
+                finish(None)
+                return
+            path, attr, qualifier = swdb.parse_attr_key(entry.key, codec)
+            if len(path) == 0 or path[0] != name:
+                raise ValueError("Unexpected persistence path for layer {name}: {path}")
+            await async root.restore(path[1:], attr, qualifier, entry.value)
+            read_next()
+        except Exception as e:
+            finish(e)
+
+    def got_metadata(raw: ?bytes, error: ?Exception) -> None:
+        if error is not None:
+            finish(error)
+            return
+        try:
+            if not root.is_empty():
+                raise ValueError("TTT restore requires an empty tree in layer {name}")
+            codec = swdb.decode_key_codec(raw)
+            prefix = swdb.to_key([name], codec)
+            scan = store.scan(prefix, None)
+            read_next()
+        except Exception as e:
+            finish(e)
+
+    store.get(swdb.META_KEY, got_metadata)
+
+
+actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg: ?swdb.Store=None):
     root = rootgen(PathRoot(name), lower)
     root.bind_db(db_arg)
     var subs: dict[gdata.SubscriptionSpec, LayerSharedSubscription] = {}
     var sub_owners: dict[str, LayerSubscriptionOwner] = {}
 
-    def load_from_db(top_only=False):
-        db = db_arg!
-        read_txn = db.begin_read()
-        try:
-            codec = swdb.read_key_codec(read_txn)
-            load_from_read_txn(read_txn, codec, top_only)
-            await async read_txn.commit()
-        except Exception as e:
-            await async read_txn.abort()
-            raise e
-
-    def load_from_read_txn(read_txn: lmdb.ReadTransaction, codec: swdb.KeyCodec, top_only=False):
-        if not root.is_empty():
-            raise ValueError("TTT restore requires an empty tree in layer {name}")
-        prefix = swdb.to_key([name], codec)
-        cursor = read_txn.cursor()
-        kv = cursor.seek_prefix(prefix)
-        while kv is not None:
-            entry = kv!
-            if not entry.key.startswith(prefix):
-                break
-            boundary = entry.key[len(prefix)] if len(entry.key) > len(prefix) else None
-            if boundary != swdb.PATH_SEPARATOR[0] and boundary != swdb.ATTRIBUTE_SEPARATOR[0]:
-                break
-            path, attr, qualifier = swdb.parse_attr_key(entry.key, codec)
-            if len(path) == 0 or path[0] != name:
-                raise ValueError("Unexpected persistence path for layer {name}: {path}")
-            # TODO: we should branch out the load of different nodes. Just pass
-            # a new cursor to this child node, then skip forward etc so we can
-            # do concurrent load using many cursors across the whole tree
-            await async root.restore(path[1:], attr, qualifier, entry.value)
-            kv = cursor.next()
-        if not top_only and lower is not None:
-            await async lower.load_from_read_txn(read_txn, codec, False)
+    def load_from_db(done: action(?Exception) -> None, top_only=False) -> None:
+        db = db_arg
+        if db is not None:
+            LayerRestore(name, root, lower, db, top_only, done)
+        else:
+            done(ValueError("Missing db for TTT persistence restore in layer {name}"))
 
     def newsession(dbuf: ?swdb.Buffer=None):
         return Session(name, root, lower, db_arg, dbuf)
@@ -789,7 +838,7 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
             _remove_owner_spec(owner_id, spec)
 
 
-actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_arg: ?swdb.Buffer=None):
+actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?swdb.Store, dbuf_arg: ?swdb.Buffer=None):
     dbuf: ?swdb.Buffer = dbuf_arg if dbuf_arg is not None else swdb.Buffer() if db is not None else None
     root: Transaction = rootnode.newtrans()
     lower: ?Session = lowerlayer.newsession(dbuf) if lowerlayer is not None else None
@@ -801,37 +850,20 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
     var tid_state: ?str = None
 
     def _flush_dbuffer_then_commit():
-        def finish(ok: bool, result: value) -> None:
-            commit(tid_state!, ok)
-            edit_config_finish(result)
-
-        proc def write_txn_ready(dbuf: swdb.Buffer, error: ?Exception, txn: ?lmdb.WriteTransaction):
-            if error is not None:
-                finish(False, error)
-                return
-            if txn is not None:
-                dbtr = swdb.WriteTransaction(txn)
-                try:
-                    await async dbuf.flush_to_db(dbtr)
-                    swdb.write_metadata(dbtr)
-                    await async dbtr.txn.commit()
-                except Exception as e:
-                    try:
-                        await async dbtr.txn.abort()
-                    except Exception:
-                        pass
-                    finish(False, e)
-                    return
-                finish(True, "Ok")
-                return
-            e = lmdb.InvalidStateError("Writer request returned neither transaction nor error")
-            finish(False, e)
-
         if tid_state is not None:
+            tid = tid_state
             if db is not None and dbuf is not None:
-                db.request_write(lambda error, txn: write_txn_ready(dbuf, error, txn))
+                def flushed(error: ?Exception) -> None:
+                    if error is not None:
+                        commit(tid, False)
+                        edit_config_finish(error)
+                    else:
+                        commit(tid, True)
+                        edit_config_finish("Ok")
+
+                dbuf.flush_to_db(db, flushed)
                 return
-            commit(tid_state, True)
+            commit(tid, True)
             edit_config_finish("Ok")
 
     # yield action
@@ -1031,7 +1063,7 @@ class _Container(_Node):
             return None
         return gdata.Container(res, ns=self.ns, module=self.module)
 
-    def bind_db(self, db: ?lmdb.Db) -> None:
+    def bind_db(self, db: ?swdb.Store) -> None:
         for node in self.elems.values():
             node.bind_db(db)
 
@@ -1289,7 +1321,7 @@ class _List(_Node):
             return None
         return gdata.List(self.key_names, res, ns=self.ns, module=self.module)
 
-    def bind_db(self, db: ?lmdb.Db) -> None:
+    def bind_db(self, db: ?swdb.Store) -> None:
         self.liststate.bind_db(db)
 
     def restore(self, path_segments: list[str], attr: str, qualifier: ?str, raw: bytes):
@@ -1318,7 +1350,7 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
     var provisional = set()
     var db = None
 
-    def bind_db(db1: ?lmdb.Db) -> None:
+    def bind_db(db1: ?swdb.Store) -> None:
         db = db1
         for node in elems.values():
             node.bind_db(db1)
@@ -1652,7 +1684,7 @@ class _TransformBase(_Node):
     def get_data(self, filt: ?gdata.FNode=None):
         return self.transaction.get_data(filt)
 
-    def bind_db(self, db: ?lmdb.Db) -> None:
+    def bind_db(self, db: ?swdb.Store) -> None:
         self.transaction.bind_db(db)
 
     def restore(self, path_segments: list[str], attr: str, qualifier: ?str, raw: bytes) -> None:
@@ -1686,7 +1718,7 @@ class _TransformTransactionBase(_Transaction):
     filter_fpath: gdata.FNode
 
     me: str
-    db: ?lmdb.Db
+    db: ?swdb.Store
 
     compute : proc(tid: str, merged: gdata.Node, linked: gdata.Node, out: ?Session) -> (gdata.Node, ?gdata.Node)
     clear : proc(tid: str, out: ?Session) -> None
@@ -1922,7 +1954,7 @@ class _TransformTransactionBase(_Transaction):
     mut def update_memory(self, newmem: ?gdata.Node):
         pass
 
-    def bind_db(self, db: ?lmdb.Db) -> None:
+    def bind_db(self, db: ?swdb.Store) -> None:
         self.db = db
 
     def restore(self, attr: str, qualifier: ?str, raw: bytes) -> None:


### PR DESCRIPTION
TTT currently exposes LMDB transactions and cursors throughout its restore and write paths, which cannot support nonblocking network databases.

Introduce a backend-neutral Store with callback completion, a streaming Scan handle, and atomic batched writes. Exactly one active TTT instance owns a store: TTT alone decides transaction outcomes, so writes carry no coordination. Adapt LMDB and existing callers while preserving current behavior.

Part of #340 to implement generic DB interface