### PR TITLE
Restore TTT state by path

### DIFF
--- a/snapshots/expected/test_ttt_persistence/persist_structural_list_escaped_snapshot
+++ b/snapshots/expected/test_ttt_persistence/persist_structural_list_escaped_snapshot
@@ -2,7 +2,7 @@ ttt
 
 {"version":1,"namespaces":["urn:test:persistence"]}
 
-ttt/struct\x1flayer/items#urn:test:persistence/a\x1fb\x1ec\x1dd\x1ce@#keys
+ttt/struct\x1flayer/items#urn:test:persistence@keys[a\x1fb\x1ec\x1dd\x1ce]
 
 {"type":"Container","children":[{"id":{"q":"urn:test:persistence","name":"name"},"node":{"type":"Leaf","value":{"type":"str","value":"a\u001Fb\u001Ec\u001Dd\u001Ce"}}}]}
 

--- a/snapshots/expected/test_ttt_persistence/persist_structural_list_snapshot
+++ b/snapshots/expected/test_ttt_persistence/persist_structural_list_snapshot
@@ -2,9 +2,13 @@ ttt
 
 {"version":1,"namespaces":["urn:test:persistence"]}
 
-ttt/struct/items#urn:test:persistence/a@#keys
+ttt/struct/items#urn:test:persistence@keys[a]
 
 {"type":"Container","children":[{"id":{"q":"urn:test:persistence","name":"name"},"node":{"type":"Leaf","value":{"type":"str","value":"a"}}}]}
+
+ttt/struct/items#urn:test:persistence@keys[b]
+
+{"type":"Container","children":[{"id":{"q":"urn:test:persistence","name":"name"},"node":{"type":"Leaf","value":{"type":"str","value":"b"}}}]}
 
 ttt/struct/items#urn:test:persistence/a/value#urn:test:persistence@output
 
@@ -13,10 +17,6 @@ ttt/struct/items#urn:test:persistence/a/value#urn:test:persistence@output
 ttt/struct/items#urn:test:persistence/a/value#urn:test:persistence@running[_]
 
 {"type":"Leaf","value":{"type":"int","value":1}}
-
-ttt/struct/items#urn:test:persistence/b@#keys
-
-{"type":"Container","children":[{"id":{"q":"urn:test:persistence","name":"name"},"node":{"type":"Leaf","value":{"type":"str","value":"b"}}}]}
 
 ttt/struct/items#urn:test:persistence/b/value#urn:test:persistence@output
 

--- a/src/db.act
+++ b/src/db.act
@@ -23,9 +23,13 @@ ESCAPED_PATH_SEPARATOR = b"p"
 ESCAPED_ATTRIBUTE_SEPARATOR = b"a"
 ESCAPED_QUALIFIER_SEPARATOR = b"q"
 
-# We need ATTR_KEYS to appear before all other attributes of a path when the
-# db iterates over its keys. Prefix with '#' (ASCII 35) to ensure this.
-ATTR_KEYS = "#keys"
+# A list stores its element keys in the keys attribute on the list's own
+# path, one entry per element with the element key as qualifier: a list l1
+# with elements foo and bar has l1@keys[foo] and l1@keys[bar], each holding
+# only that element's key leaves. The rest of an element is stored below
+# the list, under l1/foo and l1/bar. Restore reads the keys entries to
+# create the elements, which then read their own subtrees.
+ATTR_KEYS = "keys"
 ATTR_DYNSTATE = "dynstate"
 ATTR_MEMORY = "memory"
 ATTR_OUTPUT = "output"
@@ -36,21 +40,26 @@ class Scan(object):
 
     `next` reads one record and reports it through its callback; a `None`
     record means end of range. At most one `next` callback is outstanding per
-    scan. `close` releases the scan; callers close every scan, including scans
-    abandoned after an error.
+    scan. `seek_ge` moves the scan so that the next read returns the first
+    record whose key is at least the given key. `close` releases the scan;
+    callers close every scan, including scans abandoned after an error.
     """
 
     @property
     next: proc(action(?(key: bytes, value: bytes), ?Exception) -> None) -> None
+    @property
+    seek_ge: proc(bytes) -> None
     @property
     close: proc(action(?Exception) -> None) -> None
 
     def __init__(
         self,
         next: proc(action(?(key: bytes, value: bytes), ?Exception) -> None) -> None,
+        seek_ge: proc(bytes) -> None,
         close: proc(action(?Exception) -> None) -> None
     ):
         self.next = next
+        self.seek_ge = seek_ge
         self.close = close
 
 
@@ -129,7 +138,7 @@ actor LmdbScan(db: lmdb.Db, start: bytes, end: ?bytes):
 
     txn = db.begin_read()
     cursor = txn.cursor()
-    var started = False
+    var seek_to: ?bytes = start
     var released = False
 
     def release() -> None:
@@ -142,11 +151,12 @@ actor LmdbScan(db: lmdb.Db, start: bytes, end: ?bytes):
             done(None, None)
             return
         try:
-            if started:
-                record = cursor.next()
+            target = seek_to
+            seek_to = None
+            if target is not None:
+                record = cursor.seek(target)
             else:
-                started = True
-                record = cursor.seek(start)
+                record = cursor.next()
 
             if record is None or (end is not None and record!.key >= end):
                 release()
@@ -159,6 +169,10 @@ actor LmdbScan(db: lmdb.Db, start: bytes, end: ?bytes):
             except Exception:
                 pass
             done(None, e)
+
+    def seek_ge(key: bytes) -> None:
+        if not released:
+            seek_to = key if key >= start else start
 
     def close(done: action(?Exception) -> None) -> None:
         try:
@@ -189,7 +203,7 @@ class LmdbStore(Store):
 
     def scan(self, start: bytes, end: ?bytes=None) -> Scan:
         scan = LmdbScan(self.db, start, end)
-        return Scan(scan.next, scan.close)
+        return Scan(scan.next, scan.seek_ge, scan.close)
 
     proc def write(
         self,
@@ -205,6 +219,57 @@ class LmdbStore(Store):
         except Exception as e:
             done(e)
 
+
+actor RangeReader(
+    store: Store,
+    start: bytes,
+    end: ?bytes,
+    each: action((key: bytes, value: bytes), action(?Exception) -> None) -> None,
+    done: action(?Exception) -> None
+):
+    """Read a store range one record at a time.
+
+    Each record is delivered to the consumer through the `each` callback.
+    Along with the record, `each` receives a second callback, `proceed`;
+    the consumer calls it when it is ready for the next record, or with an
+    error to stop the read. `skip_to` makes the next read continue from the
+    given key. When the range is exhausted or the read has stopped, the
+    scan is closed and `done` is called with the outcome.
+    """
+
+    scan = store.scan(start, end)
+    var result_error: ?Exception = None
+    var finished = False
+
+    def skip_to(key: bytes) -> None:
+        scan.seek_ge(key)
+
+    def closed(error: ?Exception) -> None:
+        done(result_error if result_error is not None else error)
+
+    def finish(error: ?Exception) -> None:
+        if finished:
+            return
+        finished = True
+        result_error = error
+        scan.close(closed)
+
+    def proceed(error: ?Exception) -> None:
+        if error is not None:
+            finish(error)
+        else:
+            scan.next(got_record)
+
+    def got_record(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            finish(error)
+            return
+        if record is None:
+            finish(None)
+            return
+        each(record!, proceed)
+
+    scan.next(got_record)
 
 # Qualified path segments are encoded as:
 #   namespace-id byte + encoded local name
@@ -416,6 +481,30 @@ def to_attr_key(path: list[value], attr: str, qualifier: ?str=None, codec: ?KeyC
         key += QUALIFIER_SEPARATOR + _encode_text(qualifier)
     return key
 
+
+def next_prefix(raw: bytes) -> ?bytes:
+    """Return the first key after every key that starts with raw, e.g.
+    b"ab" -> b"ac"; None if there is none (raw is empty or all 0xff)."""
+    i = len(raw) - 1
+    while i >= 0:
+        if raw[i] < 0xff:
+            return raw[:i] + bytes([raw[i] + 1])
+        i -= 1
+    return None
+
+
+def attrs_range(path: list[value], codec: ?KeyCodec=None) -> (start: bytes, end: ?bytes):
+    """Return the range containing only attributes stored on path itself."""
+    start = to_key(path, codec) + ATTRIBUTE_SEPARATOR
+    return (start=start, end=next_prefix(start))
+
+
+def children_range(path: list[value], codec: ?KeyCodec=None) -> (start: bytes, end: ?bytes):
+    """Return the range containing every descendant below path."""
+    start = to_key(path, codec) + PATH_SEPARATOR
+    return (start=start, end=next_prefix(start))
+
+
 def _canonical_namespaces(namespaces: list[str]) -> list[str]:
     seen = set()
     res = []
@@ -593,27 +682,46 @@ def _parse_attr_key_bytes(key: bytes) -> (list[bytes], bytes, ?bytes):
         return path, attr_bytes, None
     return path, attr_bytes[:qual_pos], attr_bytes[qual_pos + len(QUALIFIER_SEPARATOR):]
 
-def parse_attr_key(key: bytes, codec: ?KeyCodec=None) -> (list[str], str, ?str):
+def _decode_segment_bytes(raw: bytes, codec: KeyCodec) -> str:
+    decoded_id = codec.decode_id(raw)
+    if decoded_id is not None:
+        return qualified_name(decoded_id)
+    if len(raw) == 0 or raw[0] != PLAIN_SEGMENT_ID[0]:
+        raise ValueError("Missing plain-string segment namespace id byte in TTT persistence key")
+    return _decode_text(raw[1:])
+
+
+def child_from_key(path: list[value], key: bytes, codec: KeyCodec) -> (name: str, next_key: bytes):
+    """Given the path to a parent node and a key stored somewhere below it,
+    find the child that the key belongs to.
+
+    Returns the child's name and the first key after the child's whole
+    subtree, so a reader can skip past it. For parent ttt/netinfra and key
+    ttt/netinfra/router/r1@output the child is "router" and next_key is
+    the first key after ttt/netinfra/router/..."""
+    path_bytes, _, _ = _parse_attr_key_bytes(key)
+    parent_bytes = [_encode_segment(segment, codec) for segment in path]
+    if len(path_bytes) <= len(parent_bytes) or path_bytes[:len(parent_bytes)] != parent_bytes:
+        raise ValueError("Persistence key is outside expected parent path: {key}")
+    child_bytes = path_bytes[len(parent_bytes)]
+    child_prefix = to_key(path, codec) + PATH_SEPARATOR + child_bytes
+    return (name=_decode_segment_bytes(child_bytes, codec), next_key=next_prefix(child_prefix + PATH_SEPARATOR)!)
+
+
+def parse_attr_key(key: bytes, codec: ?KeyCodec=None) -> (path: list[str], attr: str, qualifier: ?str):
     path_bytes, attr_bytes, qualifier_bytes = _parse_attr_key_bytes(key)
     codec1 = codec if codec is not None else KeyCodec([])
-    path = []
-    for segment_bytes in path_bytes:
-        decoded_id = codec1.decode_id(segment_bytes)
-        if decoded_id is not None:
-            path.append(qualified_name(decoded_id))
-        else:
-            if len(segment_bytes) == 0 or segment_bytes[0] != PLAIN_SEGMENT_ID[0]:
-                raise ValueError("Missing plain-string segment namespace id byte in TTT persistence key")
-            path.append(_decode_text(segment_bytes[1:]))
+    path = [_decode_segment_bytes(segment_bytes, codec1) for segment_bytes in path_bytes]
     if qualifier_bytes is None:
-        return path, _decode_text(attr_bytes), None
-    return path, _decode_text(attr_bytes), _decode_text(qualifier_bytes!)
+        return (path=path, attr=_decode_text(attr_bytes), qualifier=None)
+    return (path=path, attr=_decode_text(attr_bytes), qualifier=_decode_text(qualifier_bytes!))
 
 def format_key_debug(key: bytes, codec: ?KeyCodec=None) -> str:
     if key == META_KEY:
         return "ttt"
-    path, attr, qualifier = parse_attr_key(key, codec)
-    rendered = "ttt/" + "/".join([_format_text_debug(segment) for segment in path]) + "@" + _format_text_debug(attr)
+    parsed = parse_attr_key(key, codec)
+    rendered = "ttt/" + "/".join([_format_text_debug(segment) for segment in parsed.path]) + "@" + _format_text_debug(parsed.attr)
+    qualifier = parsed.qualifier
     if qualifier is not None:
         return rendered + "[" + _format_text_debug(qualifier) + "]"
     return rendered

--- a/src/test_db.act
+++ b/src/test_db.act
@@ -1,0 +1,44 @@
+import testing
+
+import db as swdb
+import yang.gdata as gdata
+
+
+TEST_NS = "urn:test:persistence"
+DB_PATH_CHAR = chr(31)
+
+
+def q(name: str) -> gdata.Id:
+    return gdata.Id(TEST_NS, name)
+
+
+actor ranges_bound_exact_attrs_and_descendants(t: testing.AsyncT):
+    codec = swdb.KeyCodec([TEST_NS])
+    path = ["root", q("items"), "a"]
+    attrs = swdb.attrs_range(path, codec)
+    children = swdb.children_range(path, codec)
+    attr_key = swdb.to_attr_key(path, swdb.ATTR_KEYS, None, codec)
+    child_key = swdb.to_attr_key(path + [q("value")], swdb.ATTR_OUTPUT, None, codec)
+    sibling_key = swdb.to_attr_key(["root", q("items"), "ab"], swdb.ATTR_KEYS, None, codec)
+
+    testing.assertTrue(attr_key >= attrs.start and attr_key < attrs.end!)
+    testing.assertTrue(child_key >= children.start and child_key < children.end!)
+    testing.assertFalse(sibling_key >= children.start and sibling_key < children.end!)
+    t.success()
+
+
+actor child_from_key_skips_only_one_subtree(t: testing.AsyncT):
+    codec = swdb.KeyCodec([TEST_NS])
+    parent = ["root", q("items")]
+    escaped_child = "a" + DB_PATH_CHAR + "suffix"
+    escaped_key = swdb.to_attr_key(parent + [escaped_child, q("value")], swdb.ATTR_OUTPUT, None, codec)
+    short_key = swdb.to_attr_key(parent + ["a"], swdb.ATTR_KEYS, None, codec)
+    longer_key = swdb.to_attr_key(parent + ["ab"], swdb.ATTR_KEYS, None, codec)
+
+    escaped = swdb.child_from_key(parent, escaped_key, codec)
+    short = swdb.child_from_key(parent, short_key, codec)
+    testing.assertEqual(escaped.name, escaped_child)
+    testing.assertTrue(escaped.next_key <= short_key)
+    testing.assertEqual(short.name, "a")
+    testing.assertTrue(short.next_key <= longer_key)
+    t.success()

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -139,6 +139,20 @@ struct_root = ttt.Container({
     )
 })
 
+direct_list_tree = gdata.List([q("name")], [
+    gdata.Container({
+        q("name"): gdata.Leaf("a"),
+        q("value"): gdata.Leaf(1)
+    }),
+    gdata.Container({
+        q("name"): gdata.Leaf("b"),
+        q("value"): gdata.Leaf(2)
+    })
+])
+
+def direct_list_root() -> proc(ttt.Path, ?ttt.Layer) -> ttt.Node:
+    return ttt.List(ttt.Transform(ttt.PassThrough), [q("name")])
+
 struct_keys_tree = gdata.Container({
     q("items"): gdata.List([q("name")], [
         gdata.Container({
@@ -294,9 +308,9 @@ actor db_key_codec_escapes_reserved_bytes(t: testing.AsyncT):
     path = [escaped_layer_name, "node" + db_attribute_char + "attr", escaped_list_key]
     key = swdb.to_attr_key(path, escaped_attr, escaped_src)
     parsed = swdb.parse_attr_key(key)
-    testing.assertEqual(parsed.0, path)
-    testing.assertEqual(parsed.1, escaped_attr)
-    testing.assertEqual(parsed.2!, escaped_src)
+    testing.assertEqual(parsed.path, path)
+    testing.assertEqual(parsed.attr, escaped_attr)
+    testing.assertEqual(parsed.qualifier!, escaped_src)
     testing.assertEqual(key.find(swdb.ESCAPE) != -1, True)
     t.success()
 
@@ -305,9 +319,9 @@ actor db_key_codec_round_trips_qualified_segments(t: testing.AsyncT):
     path = ["qualified", qa_shift("branch"), "list-key", qb_shift("value")]
     key = swdb.to_attr_key(path, swdb.ATTR_RUNNING, "_", codec)
     parsed = swdb.parse_attr_key(key, codec)
-    testing.assertEqual(parsed.0, ["qualified", swdb.qualified_name(qa_shift("branch")), "list-key", swdb.qualified_name(qb_shift("value"))])
-    testing.assertEqual(parsed.1, swdb.ATTR_RUNNING)
-    testing.assertEqual(parsed.2!, "_")
+    testing.assertEqual(parsed.path, ["qualified", swdb.qualified_name(qa_shift("branch")), "list-key", swdb.qualified_name(qb_shift("value"))])
+    testing.assertEqual(parsed.attr, swdb.ATTR_RUNNING)
+    testing.assertEqual(parsed.qualifier!, "_")
     t.success()
 
 
@@ -394,7 +408,7 @@ def write_structural_list_element(write_txn: lmdb.WriteTransaction, codec: swdb.
     key_leaves = gdata.Container({
         key_id: gdata.Leaf(element_key)
     })
-    write_txn.put(swdb.to_attr_key(element_path, swdb.ATTR_KEYS, None, codec), key_leaves.to_json_str(pretty=False).encode())
+    write_txn.put(swdb.to_attr_key([layer_name, list_id], swdb.ATTR_KEYS, element_key, codec), key_leaves.to_json_str(pretty=False).encode())
     write_txn.put(swdb.to_attr_key(element_path + [value_id], swdb.ATTR_OUTPUT, None, codec), value_node.to_json_str(pretty=False).encode())
     write_txn.put(swdb.to_attr_key(element_path + [value_id], swdb.ATTR_RUNNING, "_", codec), value_node.to_json_str(pretty=False).encode())
 
@@ -807,7 +821,7 @@ actor restore_structural_list_round_trip(t: testing.EnvT):
 
 actor restore_survives_forced_recompute(t: testing.EnvT):
     # A forced recompute (as StartupBootstrap runs after every restore) must
-    # preserve each list element's #keys index record. Regression: db_ops used
+    # preserve each list element's keys index record. Regression: db_ops used
     # to delete every element's record when the refresh recomputed no leaves,
     # so the next restore lost the list.
     fc = file.FileCap(t.env.cap)
@@ -847,6 +861,32 @@ actor restore_survives_forced_recompute(t: testing.EnvT):
         restored.load_from_db(restored_then_recompute)
 
     restored.edit_config(struct_tree, after_initial_commit)
+
+
+actor restore_direct_list_transform_round_trip(t: testing.EnvT):
+    fc = file.FileCap(t.env.cap)
+    fs = file.FS(fc)
+    db_path = fs.mktmpdir("test_ttt_restore_direct_list_")
+    cap = file.WriteFileCap(fc)
+    var db = swdb.LmdbStore(cap, db_path)
+    var restored = ttt.Layer("direct", direct_list_root(), None, db)
+
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(restored.get(), direct_list_tree)
+        await async db.db.close()
+        await async fs.rmtree(db_path)
+        await async fs.rmdir(db_path)
+        t.success()
+
+    def after_initial_commit(_r: value) -> None:
+        await async db.db.close()
+        db = swdb.LmdbStore(cap, db_path)
+        restored = ttt.Layer("direct", direct_list_root(), None, db)
+        restored.load_from_db(after_restore)
+
+    restored.edit_config(direct_list_tree, after_initial_commit)
 
 
 actor restore_structural_list_delete_round_trip(t: testing.EnvT):

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -476,6 +476,7 @@ def _db_path(path: Path) -> list[value]:
         par = [path.name]
     return par
 
+
 class YieldState[T(Hashable)](object):
     it: Iterator[T]
     key: T
@@ -519,9 +520,9 @@ actor Node(impl: _Node):
         """
         impl.bind_db(db)
 
-    def restore(path_segments: list[str], attr: str, qualifier: ?str, raw: bytes):
-        """Restore one DB record at this node or route it to the named child path."""
-        impl.restore(path_segments, attr, qualifier, raw)
+    def restore_from_db(store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+        """Restore persisted state rooted at this node's path."""
+        impl.restore_from_db(store, codec, done)
 
     def is_empty():
         return impl.is_empty()
@@ -534,7 +535,7 @@ class _Node(object):
         return gdata.filter(self.get(), filt)
     def bind_db(self, db: ?swdb.Store) -> None:
         pass
-    restore: proc(list[str], str, ?str, bytes) -> None
+    restore_from_db: proc(swdb.Store, swdb.KeyCodec, action(?Exception) -> None) -> None
     def is_empty(self) -> bool:
         return True
 
@@ -628,58 +629,21 @@ actor LayerRestore(
     top_only: bool,
     done: action(?Exception) -> None
 ):
-    var codec = swdb.KeyCodec([])
-    var prefix = b""
-    var scan: ?swdb.Scan = None
-    var result_error: ?Exception = None
     var finished = False
-
-    def read_next() -> None:
-        scan!.next(got_record)
-
-    def closed(error: ?Exception) -> None:
-        final_error = result_error if result_error is not None else error
-        if final_error is not None:
-            done(final_error)
-        elif not top_only and lower is not None:
-            lower.load_from_db(done, False)
-        else:
-            done(None)
 
     def finish(error: ?Exception) -> None:
         if finished:
             return
         finished = True
-        result_error = error
-        if scan is not None:
-            scan.close(closed)
-        else:
-            closed(None)
+        done(error)
 
-    def got_record(kv: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+    def restored(error: ?Exception) -> None:
         if error is not None:
             finish(error)
-            return
-        if kv is None:
+        elif not top_only and lower is not None:
+            lower.load_from_db(finish, False)
+        else:
             finish(None)
-            return
-
-        try:
-            entry = kv!
-            if not entry.key.startswith(prefix):
-                finish(None)
-                return
-            boundary = entry.key[len(prefix)] if len(entry.key) > len(prefix) else None
-            if boundary != swdb.PATH_SEPARATOR[0] and boundary != swdb.ATTRIBUTE_SEPARATOR[0]:
-                finish(None)
-                return
-            path, attr, qualifier = swdb.parse_attr_key(entry.key, codec)
-            if len(path) == 0 or path[0] != name:
-                raise ValueError("Unexpected persistence path for layer {name}: {path}")
-            await async root.restore(path[1:], attr, qualifier, entry.value)
-            read_next()
-        except Exception as e:
-            finish(e)
 
     def got_metadata(raw: ?bytes, error: ?Exception) -> None:
         if error is not None:
@@ -688,10 +652,7 @@ actor LayerRestore(
         try:
             if not root.is_empty():
                 raise ValueError("TTT restore requires an empty tree in layer {name}")
-            codec = swdb.decode_key_codec(raw)
-            prefix = swdb.to_key([name], codec)
-            scan = store.scan(prefix, None)
-            read_next()
+            root.restore_from_db(store, swdb.decode_key_codec(raw), restored)
         except Exception as e:
             finish(e)
 
@@ -1023,6 +984,70 @@ class LayerTreeProvider(gdata.TreeProvider):
 def Container(template={}, ns:?str=None, module:?str=None) -> proc(Path, ?Layer)->Node:
     return lambda path, lower: Node(_Container(path, template, ns, module, lower))
 
+
+actor ContainerRestore(
+    path: Path,
+    elems: dict[gdata.Id, Node],
+    store: swdb.Store,
+    codec: swdb.KeyCodec,
+    done: action(?Exception) -> None
+):
+    """Restore a container.
+
+    A container has no attributes of its own, so an attribute record on its
+    path is an error. Its children live in the range below it. Reading that
+    range, the first record met belongs to some child; the child is started
+    and reads its own subtree from the store, and the reader skips past
+    that subtree to the first record of the next child. This repeats until
+    all children are restored.
+    """
+
+    db_path = _db_path(path)
+    var children: ?swdb.RangeReader = None
+
+    def each_attr(record: (key: bytes, value: bytes), proceed: action(?Exception) -> None) -> None:
+        try:
+            parsed = swdb.parse_attr_key(record.key, codec)
+            proceed(ValueError("Unexpected persisted container attribute {parsed.attr} at {_format_path(path)}"))
+        except Exception as e:
+            proceed(e)
+
+    def each_child(record: (key: bytes, value: bytes), proceed: action(?Exception) -> None) -> None:
+        try:
+            child = swdb.child_from_key(db_path, record.key, codec)
+            child_node = None
+            for key, node in elems.items():
+                if key.name == child.name or swdb.qualified_name(key) == child.name:
+                    child_node = node
+                    break
+            if child_node is not None:
+                children!.skip_to(child.next_key)
+                child_node.restore_from_db(store, codec, proceed)
+            else:
+                raise ValueError("Unable to route persisted child {child.name} at {_format_path(path)}")
+        except Exception as e:
+            proceed(e)
+
+    def attrs_done(error: ?Exception) -> None:
+        if error is not None:
+            done(error)
+            return
+        try:
+            child_range = swdb.children_range(db_path, codec)
+            children = swdb.RangeReader(store, child_range.start, child_range.end, each_child, done)
+        except Exception as e:
+            done(e)
+
+    def start() -> None:
+        try:
+            attr_range = swdb.attrs_range(db_path, codec)
+            swdb.RangeReader(store, attr_range.start, attr_range.end, each_attr, attrs_done)
+        except Exception as e:
+            done(e)
+
+    start()
+
+
 class _Container(_Node):
     elems: dict[gdata.Id, Node]
     ns: ?str
@@ -1067,17 +1092,8 @@ class _Container(_Node):
         for node in self.elems.values():
             node.bind_db(db)
 
-    def restore(self, path_segments: list[str], attr: str, qualifier: ?str, raw: bytes) -> None:
-        if len(path_segments) == 0:
-            raise ValueError("Unexpected persisted container attribute {attr} at {_format_path(self.path)}")
-
-        child_name = path_segments[0]
-        for key, node in self.elems.items():
-            if key.name == child_name or swdb.qualified_name(key) == child_name:
-                node.restore(path_segments[1:], attr, qualifier, raw)
-                return
-
-        raise ValueError("Unable to route persisted child {child_name} at {_format_path(self.path)}")
+    def restore_from_db(self, store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+        ContainerRestore(self.path, self.elems, store, codec, done)
 
     def is_empty(self) -> bool:
         for node in self.elems.values():
@@ -1324,24 +1340,84 @@ class _List(_Node):
     def bind_db(self, db: ?swdb.Store) -> None:
         self.liststate.bind_db(db)
 
-    def restore(self, path_segments: list[str], attr: str, qualifier: ?str, raw: bytes):
-        if len(path_segments) == 0:
-            raise ValueError("Unexpected persisted list attribute {attr} at {_format_path(self.path)}")
-        key = path_segments[0]
-        if len(path_segments) == 1 and attr == swdb.ATTR_KEYS:
-            # Because of the lexicographic ordering among the different swdb.ATTR_*, liststate.recreate(key)
-            # is bound to be called before liststate.restore(key) for every key; thereby ensuring that
-            # element 'key' exists in liststate before its restoration is requested.
-            leaves = swdb.decode_node_bytes(raw)
-            if isinstance(leaves, gdata.Container):
-                self.liststate.recreate(key, leaves.children)
-            else:
-                raise ValueError("Persisted list key leaves must decode to Container at {_format_path(self.path)}[{key}]")
-        else:
-            self.liststate.restore(key, path_segments[1:], attr, qualifier, raw)
+    def restore_from_db(self, store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+        self.liststate.restore_from_db(store, codec, done)
 
     def is_empty(self) -> bool:
         return self.liststate.is_empty()
+
+
+actor ListRestore(
+    path: Path,
+    liststate,
+    store: swdb.Store,
+    codec: swdb.KeyCodec,
+    done: action(?Exception) -> None
+):
+    """Restore a list.
+
+    A list stores its element keys in the keys attribute on its own path,
+    one entry per element with the element key as qualifier: a list l1
+    with elements foo and bar has l1@keys[foo] and l1@keys[bar]. The rest
+    of each element is stored below the list, under l1/foo and l1/bar.
+
+    The list first reads the keys entries and creates one element per
+    entry; each element then reads its own subtree from the store. The
+    list then walks the subtrees under l1/ to check that each has a keys
+    entry, skipping past each one; a subtree with no keys entry, such as
+    l1/baz without l1@keys[baz], is an error.
+    """
+
+    db_path = _db_path(path)
+    var elements: ?swdb.RangeReader = None
+    var restored = set()
+
+    def each_entry(record: (key: bytes, value: bytes), proceed: action(?Exception) -> None) -> None:
+        try:
+            parsed = swdb.parse_attr_key(record.key, codec)
+            name = parsed.qualifier
+            if parsed.attr == swdb.ATTR_KEYS and name is not None:
+                leaves = swdb.decode_node_bytes(record.value)
+                if isinstance(leaves, gdata.Container):
+                    restored.add(name)
+                    node = liststate.create_restored(name, leaves.children, store)
+                    node.restore_from_db(store, codec, proceed)
+                else:
+                    raise ValueError("Persisted list key leaves must decode to Container at {_format_path(path)}[{name}]")
+            else:
+                raise ValueError("Unexpected persisted list attribute {parsed.attr} at {_format_path(path)}")
+        except Exception as e:
+            proceed(e)
+
+    def each_element_data(record: (key: bytes, value: bytes), proceed: action(?Exception) -> None) -> None:
+        try:
+            child = swdb.child_from_key(db_path, record.key, codec)
+            if child.name in restored:
+                elements!.skip_to(child.next_key)
+                proceed(None)
+            else:
+                raise ValueError("Persisted data for unknown list element at {_format_path(path)}[{child.name}]")
+        except Exception as e:
+            proceed(e)
+
+    def entries_done(error: ?Exception) -> None:
+        if error is not None:
+            done(error)
+            return
+        try:
+            element_range = swdb.children_range(db_path, codec)
+            elements = swdb.RangeReader(store, element_range.start, element_range.end, each_element_data, done)
+        except Exception as e:
+            done(e)
+
+    def start() -> None:
+        try:
+            entry_range = swdb.attrs_range(db_path, codec)
+            swdb.RangeReader(store, entry_range.start, entry_range.end, each_entry, entries_done)
+        except Exception as e:
+            done(e)
+
+    start()
 
 
 actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?str, lower: ?Layer):
@@ -1402,11 +1478,14 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
     def is_empty() -> bool:
         return len(elems) == 0 and len(active) == 0 and len(provisional) == 0
 
-    def recreate(key, leaves):
-        elems[key] = template(PathKey(key, path, leaves), lower)
+    def restore_from_db(store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+        ListRestore(path, self, store, codec, done)
 
-    def restore(key, path_segments, attr, qualifier, raw):
-        elems[key].restore(path_segments, attr, qualifier, raw)
+    def create_restored(key: str, leaves: dict[gdata.Id, gdata.Node], store: swdb.Store) -> Node:
+        node = template(PathKey(key, path, leaves), lower)
+        node.bind_db(store)
+        elems[key] = node
+        return node
 
 
 class _ListTransaction(_Transaction):
@@ -1480,17 +1559,17 @@ class _ListTransaction(_Transaction):
 
     def db_ops(self, leaves_by_key) -> list[swdb.BufferOp]:
         # A list element's key leaves are immutable for its lifetime, so its
-        # #keys record is written once at creation and deleted at removal.
-        # A configure that only refreshes an existing element (force recompute,
+        # keys record is written once at creation and deleted at removal. A
+        # configure that only refreshes an existing element (force recompute,
         # wildcard) recomputes no leaves for it; emitting no op leaves the
         # existing record intact rather than deleting the element's index entry.
         ops = []
         for key, res in self.accum.items():
-            path = _db_path(self.path) + [key]
+            path = _db_path(self.path)
             if res.empty:
-                ops.append(swdb.del_op(path, swdb.ATTR_KEYS))
+                ops.append(swdb.del_op(path, swdb.ATTR_KEYS, key))
             elif not res.errors and key in leaves_by_key:
-                ops.append(swdb.put_op(path, swdb.ATTR_KEYS, gdata.Container(leaves_by_key[key])))
+                ops.append(swdb.put_op(path, swdb.ATTR_KEYS, gdata.Container(leaves_by_key[key]), key))
         return ops
 
     def _analyze(self, results: dict[str,CfgResult]):
@@ -1672,6 +1751,58 @@ def ListTransaction(path, liststate: ListState, key_names, ns, module):
 
 ################# Transform #####################
 
+actor TransformRestore(
+    path: Path,
+    transaction: Transaction,
+    store: swdb.Store,
+    codec: swdb.KeyCodec,
+    done: action(?Exception) -> None
+):
+    """Restore a transform.
+
+    A transform has no children, so any subtree below its path is an
+    error. Its state is all in its attributes: running config per source,
+    output, memory and dynamic state. Each attribute record is applied to
+    the transform.
+    """
+
+    db_path = _db_path(path)
+
+    def each_child(record: (key: bytes, value: bytes), proceed: action(?Exception) -> None) -> None:
+        try:
+            child = swdb.child_from_key(db_path, record.key, codec)
+            proceed(ValueError("Unexpected persisted descendant under transform {_format_path(path)}: {child.name}"))
+        except Exception as e:
+            proceed(e)
+
+    def each_attr(record: (key: bytes, value: bytes), proceed: action(?Exception) -> None) -> None:
+        try:
+            parsed = swdb.parse_attr_key(record.key, codec)
+            await async transaction.restore(parsed.attr, parsed.qualifier, record.value)
+            proceed(None)
+        except Exception as e:
+            proceed(e)
+
+    def children_done(error: ?Exception) -> None:
+        if error is not None:
+            done(error)
+            return
+        try:
+            attr_range = swdb.attrs_range(db_path, codec)
+            swdb.RangeReader(store, attr_range.start, attr_range.end, each_attr, done)
+        except Exception as e:
+            done(e)
+
+    def start() -> None:
+        try:
+            child_range = swdb.children_range(db_path, codec)
+            swdb.RangeReader(store, child_range.start, child_range.end, each_child, children_done)
+        except Exception as e:
+            done(e)
+
+    start()
+
+
 class _TransformBase(_Node):
     transaction: Transaction
 
@@ -1687,10 +1818,8 @@ class _TransformBase(_Node):
     def bind_db(self, db: ?swdb.Store) -> None:
         self.transaction.bind_db(db)
 
-    def restore(self, path_segments: list[str], attr: str, qualifier: ?str, raw: bytes) -> None:
-        if len(path_segments) != 0:
-            raise ValueError("Unexpected persisted descendant under transform {_format_path(self.path)}: {path_segments}")
-        self.transaction.restore(attr, qualifier, raw)
+    def restore_from_db(self, store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+        TransformRestore(self.path, self.transaction, store, codec, done)
 
     def is_empty(self) -> bool:
         return self.transaction.is_empty()


### PR DESCRIPTION
Restore no longer reads the whole layer at the root and routes records down the tree. Every node reads the key range under its own path straight from the store: its attributes, and the subtrees of its children. A container starts each child it finds and skips past its subtree; a list creates its elements from its index and each element reads its own subtree; a transform applies its attributes. A record no node owns is an error.

On-disk format change: a list's element index moves to the list's own path, one keys attribute per element.