### PR TITLE
Restore through one reader, nodes in parallel

### DIFF
--- a/src/db.act
+++ b/src/db.act
@@ -63,14 +63,27 @@ class Scan(object):
         self.close = close
 
 
+class Reader(object):
+    """One read session over a store, for a restore.
+
+    All scans of a restore are opened from one reader, so a backend can serve
+    them from a single read transaction or snapshot instead of one per scan.
+    `scan(start, end)` streams records in byte-key order from the half-open
+    range `[start, end)`; `end=None` means that the range has no upper bound.
+    `close` ends the session; every scan opened from it is closed too.
+    """
+
+    scan: proc(bytes, ?bytes) -> Scan
+    close: proc(action(?Exception) -> None) -> None
+
+
 class Store(object):
     """Ordered byte key/value storage used by TTT persistence.
 
     Database operations report completion through callbacks so implementations
-    can use asynchronous network I/O. `scan(start, end)` streams records in
-    byte-key order from the half-open range `[start, end)`; `end=None` means
-    that the range has no upper bound. Writes atomically apply `(key, value)`
-    entries, where a `None` value deletes a key.
+    can use asynchronous network I/O. `read()` opens a Reader for range scans.
+    Writes atomically apply `(key, value)` entries, where a `None` value
+    deletes a key.
 
     Exactly one process owns a store: TTT alone decides transaction outcomes
     and its in-memory state is authoritative, so writes are unconditional and
@@ -80,7 +93,7 @@ class Store(object):
     """
 
     get: proc(bytes, action(?bytes, ?Exception) -> None) -> None
-    scan: proc(bytes, ?bytes) -> Scan
+    read: proc() -> Reader
     write: proc(
         list[(key: bytes, value: ?bytes)],
         action(?Exception) -> None
@@ -129,14 +142,9 @@ actor LmdbAdapter(db: lmdb.Db):
         db.request_write(granted)
 
 
-actor LmdbScan(db: lmdb.Db, start: bytes, end: ?bytes):
-    """Streaming range scan over one LMDB read transaction.
+actor LmdbScan(txn: lmdb.ReadTransaction, start: bytes, end: ?bytes):
+    """Streaming range scan: one cursor in the reader's read transaction."""
 
-    The read transaction opens with the scan and holds a stable view until
-    the scan reaches end of range, fails, or is closed.
-    """
-
-    txn = db.begin_read()
     cursor = txn.cursor()
     var seek_to: ?bytes = start
     var released = False
@@ -144,7 +152,7 @@ actor LmdbScan(db: lmdb.Db, start: bytes, end: ?bytes):
     def release() -> None:
         if not released:
             released = True
-            await async txn.abort()
+            await async cursor.close()
 
     def next(done: action(?(key: bytes, value: bytes), ?Exception) -> None) -> None:
         if released:
@@ -182,6 +190,26 @@ actor LmdbScan(db: lmdb.Db, start: bytes, end: ?bytes):
             done(e)
 
 
+class LmdbReader(Reader):
+    """One LMDB read transaction serving every scan of a restore."""
+
+    txn: lmdb.ReadTransaction
+
+    def __init__(self, txn: lmdb.ReadTransaction):
+        self.txn = txn
+
+    def scan(self, start: bytes, end: ?bytes) -> Scan:
+        scan = LmdbScan(self.txn, start, end)
+        return Scan(scan.next, scan.seek_ge, scan.close)
+
+    proc def close(self, done: action(?Exception) -> None) -> None:
+        try:
+            await async self.txn.abort()
+            done(None)
+        except Exception as e:
+            done(e)
+
+
 class LmdbStore(Store):
     """Store backed by one LMDB database."""
 
@@ -201,9 +229,8 @@ class LmdbStore(Store):
         except Exception as e:
             done(None, e)
 
-    def scan(self, start: bytes, end: ?bytes=None) -> Scan:
-        scan = LmdbScan(self.db, start, end)
-        return Scan(scan.next, scan.seek_ge, scan.close)
+    proc def read(self) -> Reader:
+        return LmdbReader(self.db.begin_read())
 
     proc def write(
         self,
@@ -221,7 +248,7 @@ class LmdbStore(Store):
 
 
 actor RangeReader(
-    store: Store,
+    reader: Reader,
     start: bytes,
     end: ?bytes,
     each: action((key: bytes, value: bytes), action(?Exception) -> None) -> None,
@@ -237,7 +264,7 @@ actor RangeReader(
     scan is closed and `done` is called with the outcome.
     """
 
-    scan = store.scan(start, end)
+    scan = reader.scan(start, end)
     var result_error: ?Exception = None
     var finished = False
 

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -1180,3 +1180,178 @@ actor reject_persistence_version_mismatch(t: testing.EnvT):
         t.success()
 
     layer.load_from_db(after_restore)
+
+
+actor OpenScans():
+    """Counts scans open at the same time, and remembers the most."""
+    var open = 0
+    var most = 0
+
+    def opened() -> None:
+        open += 1
+        if open > most:
+            most = open
+
+    def closed() -> None:
+        open -= 1
+
+    def maximum() -> int:
+        return most
+
+
+actor SlowScan(
+    rows: list[(key: bytes, value: bytes)],
+    tracker: OpenScans,
+    start: bytes,
+    end: ?bytes
+):
+    """Scan over captured rows that answers each read a little later, so
+    restores overlap in time."""
+    var index = 0
+    var closed = False
+
+    def seek_ge(key: bytes) -> None:
+        target = key if key >= start else start
+        index = 0
+        while index < len(rows) and rows[index].key < target:
+            index += 1
+
+    def deliver(done: action(?(key: bytes, value: bytes), ?Exception) -> None) -> None:
+        if closed or index >= len(rows):
+            done(None, None)
+            return
+        row = rows[index]
+        if end is not None and row.key >= end:
+            done(None, None)
+            return
+        index += 1
+        done((key=row.key, value=row.value), None)
+
+    def next(done: action(?(key: bytes, value: bytes), ?Exception) -> None) -> None:
+        after 0.001: deliver(done)
+
+    def close(done: action(?Exception) -> None) -> None:
+        if not closed:
+            closed = True
+            await async tracker.closed()
+        done(None)
+
+    seek_ge(start)
+    await async tracker.opened()
+
+
+class SlowReader(swdb.Reader):
+    rows: list[(key: bytes, value: bytes)]
+    tracker: OpenScans
+
+    def __init__(self, rows: list[(key: bytes, value: bytes)], tracker: OpenScans):
+        self.rows = rows
+        self.tracker = tracker
+
+    def scan(self, start: bytes, end: ?bytes) -> swdb.Scan:
+        scan = SlowScan(self.rows, self.tracker, start, end)
+        return swdb.Scan(scan.next, scan.seek_ge, scan.close)
+
+    def close(self, done: action(?Exception) -> None) -> None:
+        done(None)
+
+
+class SlowStore(swdb.Store):
+    """Read-only Store over captured rows with slow scans."""
+    rows: list[(key: bytes, value: bytes)]
+    tracker: OpenScans
+
+    def __init__(self, rows: list[(key: bytes, value: bytes)], tracker: OpenScans):
+        self.rows = rows
+        self.tracker = tracker
+
+    def get(self, key: bytes, done: action(?bytes, ?Exception) -> None) -> None:
+        for row in self.rows:
+            if row.key == key:
+                done(row.value, None)
+                return
+        done(None, None)
+
+    def read(self) -> swdb.Reader:
+        return SlowReader(self.rows, self.tracker)
+
+    def write(
+        self,
+        writes: list[(key: bytes, value: ?bytes)],
+        done: action(?Exception) -> None
+    ) -> None:
+        done(ValueError("Slow test store is read-only"))
+
+    def close(self, done: action(?Exception) -> None) -> None:
+        done(None)
+
+
+def persisted_rows(read_txn: lmdb.ReadTransaction) -> list[(key: bytes, value: bytes)]:
+    rows = []
+    cursor = read_txn.cursor()
+    record = cursor.seek(swdb.META_KEY)
+    while record is not None:
+        row = record!
+        if not is_ttt_db_key(row.key):
+            break
+        rows.append((key=row.key, value=row.value))
+        record = cursor.next()
+    return rows
+
+
+def nested_list_root() -> proc(ttt.Path, ?ttt.Layer) -> ttt.Node:
+    return ttt.List(ttt.Container({
+        q("inner"): ttt.List(ttt.Transform(ttt.PassThrough), [q("name")])
+    }), [q("name")])
+
+
+def nested_list_tree(outer: int, inner: int) -> gdata.List:
+    elems = []
+    for i in range(outer):
+        inner_elems = []
+        for j in range(inner):
+            inner_elems.append(gdata.Container({
+                q("name"): gdata.Leaf("i" + str(j)),
+                q("value"): gdata.Leaf(j)
+            }))
+        elems.append(gdata.Container({
+            q("name"): gdata.Leaf("o" + str(i)),
+            q("inner"): gdata.List([q("name")], inner_elems)
+        }))
+    return gdata.List([q("name")], elems)
+
+
+# Node restores of one layer load run in parallel, and no more than
+# RESTORE_FANOUT of them at a time - across the whole tree, not per parent.
+# The tree is a list of 12 elements each holding a list of 24, so with a
+# limit per parent the inner lists alone could have 12 * 24 restores open.
+actor restore_runs_bounded_across_the_tree(t: testing.EnvT):
+    fc = file.FileCap(t.env.cap)
+    fs = file.FS(fc)
+    db_path = fs.mktmpdir("test_ttt_restore_bounded_")
+    cap = file.WriteFileCap(fc)
+    expected = nested_list_tree(12, 24)
+    var db = swdb.LmdbStore(cap, db_path)
+    var restored = ttt.Layer("nested", nested_list_root(), None, db)
+    tracker = OpenScans()
+
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(restored.get(), expected)
+        most = tracker.maximum()
+        testing.assertTrue(most > 1, "restores must overlap")
+        testing.assertTrue(most <= ttt.RESTORE_FANOUT, "restores must stay within RESTORE_FANOUT")
+        await async fs.rmtree(db_path)
+        await async fs.rmdir(db_path)
+        t.success()
+
+    def after_initial_commit(_r: value) -> None:
+        read_txn = db.db.begin_read()
+        rows = persisted_rows(read_txn)
+        await async read_txn.commit()
+        await async db.db.close()
+        restored = ttt.Layer("nested", nested_list_root(), None, SlowStore(rows, tracker))
+        restored.load_from_db(after_restore)
+
+    restored.edit_config(expected, after_initial_commit)

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -326,6 +326,7 @@ actor db_key_codec_round_trips_qualified_segments(t: testing.AsyncT):
 
 
 actor StoreCallbackFlow(t: testing.EnvT, fs: file.FS, db_path: str, store: swdb.Store):
+    var reader: ?swdb.Reader = None
     var scan: ?swdb.Scan = None
 
     def read_next(done: action(?(key: bytes, value: bytes), ?Exception) -> None) -> None:
@@ -338,10 +339,15 @@ actor StoreCallbackFlow(t: testing.EnvT, fs: file.FS, db_path: str, store: swdb.
         await async fs.rmdir(db_path)
         t.success()
 
-    def after_scan_close(error: ?Exception) -> None:
+    def after_reader_close(error: ?Exception) -> None:
         if error is not None:
             raise error
         store.close(after_store_close)
+
+    def after_scan_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        reader!.close(after_reader_close)
 
     def after_eof(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
         if error is not None:
@@ -369,7 +375,9 @@ actor StoreCallbackFlow(t: testing.EnvT, fs: file.FS, db_path: str, store: swdb.
         if error is not None:
             raise error
         testing.assertEqual(value, b"2")
-        scan = store.scan(b"a", b"c")
+        r = store.read()
+        reader = r
+        scan = r.scan(b"a", b"c")
         read_next(after_first)
 
     def after_write(error: ?Exception) -> None:

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -15,6 +15,9 @@ def unwrap[T](t: ?T) -> T:
 
 NS_stratoweave_device = "http://stratoweave.org/yang/stratoweave-device"
 
+# How many node restores of one layer load may run at the same time.
+RESTORE_FANOUT = 32
+
 def per_src(cfg_per_src: dict[str, gdata.Node]):
     return "\n".join([f"        '{src}': {cfg.prsrc(True, 4)}" for src,cfg in cfg_per_src.items()])
 
@@ -520,9 +523,9 @@ actor Node(impl: _Node):
         """
         impl.bind_db(db)
 
-    def restore_from_db(reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+    def restore_from_db(reader: swdb.Reader, codec: swdb.KeyCodec, window: RestoreWindow, done: action(?Exception) -> None) -> None:
         """Restore persisted state rooted at this node's path."""
-        impl.restore_from_db(reader, codec, done)
+        impl.restore_from_db(reader, codec, window, done)
 
     def is_empty():
         return impl.is_empty()
@@ -535,7 +538,7 @@ class _Node(object):
         return gdata.filter(self.get(), filt)
     def bind_db(self, db: ?swdb.Store) -> None:
         pass
-    restore_from_db: proc(swdb.Reader, swdb.KeyCodec, action(?Exception) -> None) -> None
+    restore_from_db: proc(swdb.Reader, swdb.KeyCodec, RestoreWindow, action(?Exception) -> None) -> None
     def is_empty(self) -> bool:
         return True
 
@@ -621,6 +624,47 @@ class _Transaction(object):
 
 ####################### Layer ########################
 
+actor RestoreWindow(limit: int, done: action(?Exception) -> None):
+    """Run the node restores of one layer load, at most `limit` at a time.
+
+    `launch(task)` runs the task when a slot is free and queues it
+    otherwise; a task calls the callback it is given when its own reads
+    are finished, which frees its slot for the next queued task. Every
+    node restore is launched here, so `done` is called once the last one
+    has finished. The first error is kept: any restore not yet started is
+    dropped, and `done` reports the error once the restores already
+    running have finished.
+    """
+
+    var active = 0
+    var queue: list[proc(action(?Exception) -> None) -> None] = []
+    var first_error: ?Exception = None
+    var finished = False
+
+    def launch(task: proc(action(?Exception) -> None) -> None) -> None:
+        if first_error is not None:
+            return
+        if active < limit:
+            _run(task)
+        else:
+            queue.append(task)
+
+    def _run(task: proc(action(?Exception) -> None) -> None) -> None:
+        active += 1
+        task(_finished)
+
+    def _finished(error: ?Exception) -> None:
+        active -= 1
+        if error is not None and first_error is None:
+            first_error = error
+            queue = []
+        if queue:
+            _run(queue.pop(0))
+        elif active == 0 and not finished:
+            finished = True
+            done(first_error)
+
+
 actor LayerRestore(
     name: str,
     root: Node,
@@ -664,7 +708,8 @@ actor LayerRestore(
             codec = swdb.decode_key_codec(raw)
             r = store.read()
             reader = r
-            root.restore_from_db(r, codec, restored)
+            window = RestoreWindow(RESTORE_FANOUT, restored)
+            window.launch(lambda finished1: root.restore_from_db(r, codec, window, finished1))
         except Exception as e:
             finish(e)
 
@@ -1002,6 +1047,7 @@ actor ContainerRestore(
     elems: dict[gdata.Id, Node],
     reader: swdb.Reader,
     codec: swdb.KeyCodec,
+    window: RestoreWindow,
     done: action(?Exception) -> None
 ):
     """Restore a container.
@@ -1011,7 +1057,8 @@ actor ContainerRestore(
     range, the first record met belongs to some child; the child is started
     and reads its own subtree from the store, and the reader skips past
     that subtree to the first record of the next child. This repeats until
-    all children are restored.
+    all children are restored. Children restore in parallel, through the
+    layer load's RestoreWindow.
     """
 
     db_path = _db_path(path)
@@ -1034,7 +1081,9 @@ actor ContainerRestore(
                     break
             if child_node is not None:
                 children!.skip_to(child.next_key)
-                child_node.restore_from_db(reader, codec, proceed)
+                node1 = child_node
+                window.launch(lambda finished: node1.restore_from_db(reader, codec, window, finished))
+                proceed(None)
             else:
                 raise ValueError("Unable to route persisted child {child.name} at {_format_path(path)}")
         except Exception as e:
@@ -1104,8 +1153,8 @@ class _Container(_Node):
         for node in self.elems.values():
             node.bind_db(db)
 
-    def restore_from_db(self, reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
-        ContainerRestore(self.path, self.elems, reader, codec, done)
+    def restore_from_db(self, reader: swdb.Reader, codec: swdb.KeyCodec, window: RestoreWindow, done: action(?Exception) -> None) -> None:
+        ContainerRestore(self.path, self.elems, reader, codec, window, done)
 
     def is_empty(self) -> bool:
         for node in self.elems.values():
@@ -1352,8 +1401,8 @@ class _List(_Node):
     def bind_db(self, db: ?swdb.Store) -> None:
         self.liststate.bind_db(db)
 
-    def restore_from_db(self, reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
-        self.liststate.restore_from_db(reader, codec, done)
+    def restore_from_db(self, reader: swdb.Reader, codec: swdb.KeyCodec, window: RestoreWindow, done: action(?Exception) -> None) -> None:
+        self.liststate.restore_from_db(reader, codec, window, done)
 
     def is_empty(self) -> bool:
         return self.liststate.is_empty()
@@ -1364,6 +1413,7 @@ actor ListRestore(
     liststate,
     reader: swdb.Reader,
     codec: swdb.KeyCodec,
+    window: RestoreWindow,
     done: action(?Exception) -> None
 ):
     """Restore a list.
@@ -1374,10 +1424,11 @@ actor ListRestore(
     of each element is stored below the list, under l1/foo and l1/bar.
 
     The list first reads the keys entries and creates one element per
-    entry; each element then reads its own subtree from the store. The
-    list then walks the subtrees under l1/ to check that each has a keys
-    entry, skipping past each one; a subtree with no keys entry, such as
-    l1/baz without l1@keys[baz], is an error.
+    entry; each element then reads its own subtree from the store, in
+    parallel through the layer load's RestoreWindow. The list then walks
+    the subtrees under l1/ to check that each has a keys entry, skipping
+    past each one; a subtree with no keys entry, such as l1/baz without
+    l1@keys[baz], is an error.
     """
 
     db_path = _db_path(path)
@@ -1393,7 +1444,8 @@ actor ListRestore(
                 if isinstance(leaves, gdata.Container):
                     restored.add(name)
                     node = liststate.create_restored(name, leaves.children)
-                    node.restore_from_db(reader, codec, proceed)
+                    window.launch(lambda finished: node.restore_from_db(reader, codec, window, finished))
+                    proceed(None)
                 else:
                     raise ValueError("Persisted list key leaves must decode to Container at {_format_path(path)}[{name}]")
             else:
@@ -1490,8 +1542,8 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
     def is_empty() -> bool:
         return len(elems) == 0 and len(active) == 0 and len(provisional) == 0
 
-    def restore_from_db(reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
-        ListRestore(path, self, reader, codec, done)
+    def restore_from_db(reader: swdb.Reader, codec: swdb.KeyCodec, window: RestoreWindow, done: action(?Exception) -> None) -> None:
+        ListRestore(path, self, reader, codec, window, done)
 
     def create_restored(key: str, leaves: dict[gdata.Id, gdata.Node]) -> Node:
         node = template(PathKey(key, path, leaves), lower)
@@ -1768,6 +1820,7 @@ actor TransformRestore(
     transaction: Transaction,
     reader: swdb.Reader,
     codec: swdb.KeyCodec,
+    window: RestoreWindow,
     done: action(?Exception) -> None
 ):
     """Restore a transform.
@@ -1830,8 +1883,8 @@ class _TransformBase(_Node):
     def bind_db(self, db: ?swdb.Store) -> None:
         self.transaction.bind_db(db)
 
-    def restore_from_db(self, reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
-        TransformRestore(self.path, self.transaction, reader, codec, done)
+    def restore_from_db(self, reader: swdb.Reader, codec: swdb.KeyCodec, window: RestoreWindow, done: action(?Exception) -> None) -> None:
+        TransformRestore(self.path, self.transaction, reader, codec, window, done)
 
     def is_empty(self) -> bool:
         return self.transaction.is_empty()

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -520,9 +520,9 @@ actor Node(impl: _Node):
         """
         impl.bind_db(db)
 
-    def restore_from_db(store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+    def restore_from_db(reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
         """Restore persisted state rooted at this node's path."""
-        impl.restore_from_db(store, codec, done)
+        impl.restore_from_db(reader, codec, done)
 
     def is_empty():
         return impl.is_empty()
@@ -535,7 +535,7 @@ class _Node(object):
         return gdata.filter(self.get(), filt)
     def bind_db(self, db: ?swdb.Store) -> None:
         pass
-    restore_from_db: proc(swdb.Store, swdb.KeyCodec, action(?Exception) -> None) -> None
+    restore_from_db: proc(swdb.Reader, swdb.KeyCodec, action(?Exception) -> None) -> None
     def is_empty(self) -> bool:
         return True
 
@@ -630,6 +630,7 @@ actor LayerRestore(
     done: action(?Exception) -> None
 ):
     var finished = False
+    var reader: ?swdb.Reader = None
 
     def finish(error: ?Exception) -> None:
         if finished:
@@ -638,12 +639,20 @@ actor LayerRestore(
         done(error)
 
     def restored(error: ?Exception) -> None:
-        if error is not None:
-            finish(error)
-        elif not top_only and lower is not None:
-            lower.load_from_db(finish, False)
+        def closed(close_error: ?Exception) -> None:
+            if error is not None:
+                finish(error)
+            elif close_error is not None:
+                finish(close_error)
+            elif not top_only and lower is not None:
+                lower.load_from_db(finish, False)
+            else:
+                finish(None)
+        r = reader
+        if r is not None:
+            r.close(closed)
         else:
-            finish(None)
+            closed(None)
 
     def got_metadata(raw: ?bytes, error: ?Exception) -> None:
         if error is not None:
@@ -652,7 +661,10 @@ actor LayerRestore(
         try:
             if not root.is_empty():
                 raise ValueError("TTT restore requires an empty tree in layer {name}")
-            root.restore_from_db(store, swdb.decode_key_codec(raw), restored)
+            codec = swdb.decode_key_codec(raw)
+            r = store.read()
+            reader = r
+            root.restore_from_db(r, codec, restored)
         except Exception as e:
             finish(e)
 
@@ -988,7 +1000,7 @@ def Container(template={}, ns:?str=None, module:?str=None) -> proc(Path, ?Layer)
 actor ContainerRestore(
     path: Path,
     elems: dict[gdata.Id, Node],
-    store: swdb.Store,
+    reader: swdb.Reader,
     codec: swdb.KeyCodec,
     done: action(?Exception) -> None
 ):
@@ -1022,7 +1034,7 @@ actor ContainerRestore(
                     break
             if child_node is not None:
                 children!.skip_to(child.next_key)
-                child_node.restore_from_db(store, codec, proceed)
+                child_node.restore_from_db(reader, codec, proceed)
             else:
                 raise ValueError("Unable to route persisted child {child.name} at {_format_path(path)}")
         except Exception as e:
@@ -1034,14 +1046,14 @@ actor ContainerRestore(
             return
         try:
             child_range = swdb.children_range(db_path, codec)
-            children = swdb.RangeReader(store, child_range.start, child_range.end, each_child, done)
+            children = swdb.RangeReader(reader, child_range.start, child_range.end, each_child, done)
         except Exception as e:
             done(e)
 
     def start() -> None:
         try:
             attr_range = swdb.attrs_range(db_path, codec)
-            swdb.RangeReader(store, attr_range.start, attr_range.end, each_attr, attrs_done)
+            swdb.RangeReader(reader, attr_range.start, attr_range.end, each_attr, attrs_done)
         except Exception as e:
             done(e)
 
@@ -1092,8 +1104,8 @@ class _Container(_Node):
         for node in self.elems.values():
             node.bind_db(db)
 
-    def restore_from_db(self, store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
-        ContainerRestore(self.path, self.elems, store, codec, done)
+    def restore_from_db(self, reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+        ContainerRestore(self.path, self.elems, reader, codec, done)
 
     def is_empty(self) -> bool:
         for node in self.elems.values():
@@ -1340,8 +1352,8 @@ class _List(_Node):
     def bind_db(self, db: ?swdb.Store) -> None:
         self.liststate.bind_db(db)
 
-    def restore_from_db(self, store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
-        self.liststate.restore_from_db(store, codec, done)
+    def restore_from_db(self, reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+        self.liststate.restore_from_db(reader, codec, done)
 
     def is_empty(self) -> bool:
         return self.liststate.is_empty()
@@ -1350,7 +1362,7 @@ class _List(_Node):
 actor ListRestore(
     path: Path,
     liststate,
-    store: swdb.Store,
+    reader: swdb.Reader,
     codec: swdb.KeyCodec,
     done: action(?Exception) -> None
 ):
@@ -1380,8 +1392,8 @@ actor ListRestore(
                 leaves = swdb.decode_node_bytes(record.value)
                 if isinstance(leaves, gdata.Container):
                     restored.add(name)
-                    node = liststate.create_restored(name, leaves.children, store)
-                    node.restore_from_db(store, codec, proceed)
+                    node = liststate.create_restored(name, leaves.children)
+                    node.restore_from_db(reader, codec, proceed)
                 else:
                     raise ValueError("Persisted list key leaves must decode to Container at {_format_path(path)}[{name}]")
             else:
@@ -1406,14 +1418,14 @@ actor ListRestore(
             return
         try:
             element_range = swdb.children_range(db_path, codec)
-            elements = swdb.RangeReader(store, element_range.start, element_range.end, each_element_data, done)
+            elements = swdb.RangeReader(reader, element_range.start, element_range.end, each_element_data, done)
         except Exception as e:
             done(e)
 
     def start() -> None:
         try:
             entry_range = swdb.attrs_range(db_path, codec)
-            swdb.RangeReader(store, entry_range.start, entry_range.end, each_entry, entries_done)
+            swdb.RangeReader(reader, entry_range.start, entry_range.end, each_entry, entries_done)
         except Exception as e:
             done(e)
 
@@ -1478,12 +1490,12 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
     def is_empty() -> bool:
         return len(elems) == 0 and len(active) == 0 and len(provisional) == 0
 
-    def restore_from_db(store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
-        ListRestore(path, self, store, codec, done)
+    def restore_from_db(reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+        ListRestore(path, self, reader, codec, done)
 
-    def create_restored(key: str, leaves: dict[gdata.Id, gdata.Node], store: swdb.Store) -> Node:
+    def create_restored(key: str, leaves: dict[gdata.Id, gdata.Node]) -> Node:
         node = template(PathKey(key, path, leaves), lower)
-        node.bind_db(store)
+        node.bind_db(db)
         elems[key] = node
         return node
 
@@ -1754,7 +1766,7 @@ def ListTransaction(path, liststate: ListState, key_names, ns, module):
 actor TransformRestore(
     path: Path,
     transaction: Transaction,
-    store: swdb.Store,
+    reader: swdb.Reader,
     codec: swdb.KeyCodec,
     done: action(?Exception) -> None
 ):
@@ -1789,14 +1801,14 @@ actor TransformRestore(
             return
         try:
             attr_range = swdb.attrs_range(db_path, codec)
-            swdb.RangeReader(store, attr_range.start, attr_range.end, each_attr, done)
+            swdb.RangeReader(reader, attr_range.start, attr_range.end, each_attr, done)
         except Exception as e:
             done(e)
 
     def start() -> None:
         try:
             child_range = swdb.children_range(db_path, codec)
-            swdb.RangeReader(store, child_range.start, child_range.end, each_child, children_done)
+            swdb.RangeReader(reader, child_range.start, child_range.end, each_child, children_done)
         except Exception as e:
             done(e)
 
@@ -1818,8 +1830,8 @@ class _TransformBase(_Node):
     def bind_db(self, db: ?swdb.Store) -> None:
         self.transaction.bind_db(db)
 
-    def restore_from_db(self, store: swdb.Store, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
-        TransformRestore(self.path, self.transaction, store, codec, done)
+    def restore_from_db(self, reader: swdb.Reader, codec: swdb.KeyCodec, done: action(?Exception) -> None) -> None:
+        TransformRestore(self.path, self.transaction, reader, codec, done)
 
     def is_empty(self) -> bool:
         return self.transaction.is_empty()


### PR DESCRIPTION
Store gains read(), which opens a Reader; a restore's scans are opened from the reader instead of the store, and closing the reader closes them all. On LMDB that is one read transaction with a cursor per scan - what a restore always meant but this way we avoid opening up many read transactions, one per scan.

RestoreWindow runs the node restores of one layer load, at most RESTORE_FANOUT at a time across the whole tree. A parent launches each child it discovers and reads on; the window reports done when the last restore has finished, and keeps the first error.