### PR TITLE
Match all downstream manifests

### DIFF
--- a/.github/workflows/upgrade-downstreams.yml
+++ b/.github/workflows/upgrade-downstreams.yml
@@ -91,6 +91,4 @@ jobs:
             Refreshes Acton package pins after stratoweave/stratoweave@${{ github.sha }} landed on main.
 
             This pull request is updated in place when newer stratoweave changes land.
-          add-paths: |
-            Build.act
-            **/Build.act
+          add-paths: ':(glob)**/Build.act'


### PR DESCRIPTION
Netclics has only a root Build.act. Passing separate root and recursive pathspecs makes git add reject the unmatched recursive pattern and stage nothing.

Use Git glob pathspec magic, where **/ also matches the root, so one pattern handles every consumer without broadening the files staged.