### PR TITLE
Use native optional handling instead of unwrap() helpers

### DIFF
--- a/minisys/src/mini/rfs.act
+++ b/minisys/src/mini/rfs.act
@@ -15,11 +15,6 @@ import mini.devices.ietf as ietf_dev
 import mini.devices.ietf_oper as ietf_oper
 from mini.devices.ietf_oper import root as ietf_oper_root
 
-def unwrap[T](t: ?T) -> T:
-    if t is not None:
-        return t
-    raise ValueError("unwrap called on None")
-
 
 class BaseConfig(base.BaseConfig):
     def transform(self, i, di, dynstate: ?BaseConfigDynstate):
@@ -78,7 +73,7 @@ class L3vpnEndpoint(base.L3vpnEndpoint):
             elif i.vlan_id is not None or "." in i.interface_name:
                 interface_type = ietf_dev.iana_if_type_l3ipvlan
 
-            description = unwrap(i.description) if i.description is not None else "{i.customer_name} vpn {i.vpn_name}"
+            description = i.description! if i.description is not None else "{i.customer_name} vpn {i.vpn_name}"
             if i.description is None:
                 if i.site_code is not None:
                     description += " site {i.site_code}"

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -43,13 +43,6 @@ def build_explicit_schemas_list(explicit_modules: list[str], format: str) -> lis
     return schemas_to_download
 
 
-def unwrap[T](a: ?T, msg: ?str=None) -> T:
-    if a is not None:
-        return a
-    errmsg = msg if msg is not None else "Expected non-None value"
-    raise ValueError(errmsg)
-
-
 def resolve_client_fixups(args, log_handler):
     log = logging.Logger(log_handler)
     no_fixups = args.get_bool("no-fixups")
@@ -699,7 +692,7 @@ actor CmdRpc(env, args, log_handler):
             print("Error: No RPC content to send", err=True)
             env.exit(1)
             return
-        c.rpc(unwrap(rpc_content, "Expected RPC content"), _on_rpc)
+        c.rpc(rpc_content!, _on_rpc)
 
     def _close_and_exit(exit_code: int):
         def _close_cb():
@@ -733,7 +726,7 @@ actor CmdRpc(env, args, log_handler):
             _close_and_exit(1)
             return
 
-        _emit_reply(unwrap(result, "Expected rpc-reply").encode(), 1 if error is not None else 0, error)
+        _emit_reply(result!.encode(), 1 if error is not None else 0, error)
 
     def _connect_and_send():
         netconf.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))),

--- a/src/netconf.act
+++ b/src/netconf.act
@@ -80,6 +80,17 @@ class NetconfError(Exception):
         return "{self._name()}({repr(self.error_message)}, {repr(self.rpc_error)})"
 
 
+class MalformedRpcError(NetconfError):
+    pass
+
+
+def required_text(child: xml.Node, field: str) -> str:
+    text = child.text
+    if text is not None:
+        return text
+    raise MalformedRpcError("rpc-error missing expected {field}", None)
+
+
 class RpcError(object):
     # RFC 6241 rpc-error fields
     error_type: str         # transport/rpc/protocol/application
@@ -105,11 +116,11 @@ class RpcError(object):
         # Parse the XML into well-known attributes
         for child in xml_node.children:
             if child.tag == "error-type":
-                self.error_type = child.text!
+                self.error_type = required_text(child, "error-type")
             elif child.tag == "error-tag":
-                self.error_tag = child.text!
+                self.error_tag = required_text(child, "error-tag")
             elif child.tag == "error-severity":
-                self.error_severity = child.text!
+                self.error_severity = required_text(child, "error-severity")
             elif child.tag == "error-app-tag":
                 self.error_app_tag = child.text
             elif child.tag == "error-path":

--- a/src/netconf.act
+++ b/src/netconf.act
@@ -67,12 +67,6 @@ class ConnectionRefusedError(ConnectionError):
 class ConnectionResetError(ConnectionError):
     pass
 
-def unwrap[T](a: ?T, msg: ?str=None) -> T:
-    if a is not None:
-        return a
-    errmsg = msg if msg is not None else "Expected non-None value"
-    raise ValueError(errmsg)
-
 
 class NetconfError(Exception):
     def __init__(self, error_message: ?str, rpc_error: ?list[RpcError]):
@@ -111,11 +105,11 @@ class RpcError(object):
         # Parse the XML into well-known attributes
         for child in xml_node.children:
             if child.tag == "error-type":
-                self.error_type = unwrap(child.text, "rpc-error missing expected error-type")
+                self.error_type = child.text!
             elif child.tag == "error-tag":
-                self.error_tag = unwrap(child.text, "rpc-error missing expected error-tag")
+                self.error_tag = child.text!
             elif child.tag == "error-severity":
-                self.error_severity = unwrap(child.text, "rpc-error missing expected error-severity")
+                self.error_severity = child.text!
             elif child.tag == "error-app-tag":
                 self.error_app_tag = child.text
             elif child.tag == "error-path":
@@ -230,7 +224,7 @@ actor Client(
         if fixups is None:
             _log.debug("NETCONF fixups disabled")
             return
-        configured_fixups = unwrap(fixups, "Expected fixup list")
+        configured_fixups = fixups!
 
         for mk in configured_fixups:
             try:

--- a/src/netconf/fixups/openconfig_list_keys.act
+++ b/src/netconf/fixups/openconfig_list_keys.act
@@ -1,12 +1,6 @@
 import std.xml as xml
 from netconf.fixups.base import Fixup
 
-def unwrap[T](a: ?T, msg: ?str=None) -> T:
-    if a is not None:
-        return a
-    errmsg = msg if msg is not None else "Expected non-None value"
-    raise ValueError(errmsg)
-
 
 # Prototype for xml navigation TODO: Upstream to xml module!?
 protocol XmlNav:

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -7,12 +7,6 @@ from device_meta_config import stratoweave_rfs__device_entry as DeviceMetaConfig
 import std.xml as xml
 import logging
 
-def unwrap[T](t: ?T) -> T:
-    if t is not None:
-        return t
-    raise ValueError("unwrap called on None")
-
-
 NS_stratoweave_device = "http://stratoweave.org/yang/stratoweave-device"
 
 # How many node restores of one layer load may run at the same time.
@@ -2292,7 +2286,7 @@ class _TransformTransaction(_TransformTransactionBase):
 
     proc def init_actor(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate, update_oper):
         self.node = node
-        self.function.init_actor(act, update_dynstate, update_oper, unwrap(self.path), self.lower)
+        self.function.init_actor(act, update_dynstate, update_oper, self.path!, self.lower)
 
     proc def update_dynstate(self, dynstate):
         if self.dynstate == dynstate:
@@ -2454,7 +2448,7 @@ class _RFSTransaction(_TransformTransactionBase):
 
     proc def init_actor(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate, update_oper):
         self.node = node
-        self.function.init_actor(act, update_dynstate, update_oper, unwrap(self.path), self.dev)
+        self.function.init_actor(act, update_dynstate, update_oper, self.path!, self.dev)
 
     proc def update_dynstate(self, dynstate):
         if self.dynstate == dynstate:


### PR DESCRIPTION
Replace the per-file unwrap[T] helpers and all call sites with postfix ! forced unwraps, and drop the uncalled helper in netconf/fixups/openconfig_list_keys.act.

The rpc-error parsing sites get a real fix rather than a mechanical swap: error-type, error-tag and error-severity are required rpc-error children per RFC 6241, so a reply missing one is a protocol error from the peer, not a broken internal invariant. Those now raise MalformedRpcError (a NetconfError subclass) naming the missing field, via a small required_text helper.