### PR TITLE
Add an etcd persistence store

### DIFF
--- a/src/db.act
+++ b/src/db.act
@@ -37,8 +37,8 @@ ATTR_RUNNING = "running"
 def parse_store_spec(raw: str) -> (backend: str, target: str, port: ?int, prefix: bytes):
     """Parse the --db argument: a plain LMDB path or a database URL.
 
-    A plain path and lmdb://path both select LMDB. Other schemes select
-    other backends; each backend reads the parts it needs.
+    A plain path and lmdb://path both select LMDB; etcd://host:port/prefix
+    selects etcd, where the path is the key prefix of this store.
     """
     if "://" not in raw:
         if raw == "":
@@ -57,6 +57,16 @@ def parse_store_spec(raw: str) -> (backend: str, target: str, port: ?int, prefix
         if path == "":
             raise ValueError("LMDB URL is missing a path")
         return (backend="lmdb", target=path, port=None, prefix=b"")
+
+    if scheme == "etcd":
+        if parsed.host is None:
+            raise ValueError("Etcd URL is missing a host")
+        prefix = uri.unquote(uri.e_str(parsed.path)).encode()
+        if prefix == b"" or prefix == b"/":
+            raise ValueError("Etcd URL is missing a key prefix path, e.g. etcd://host:2379/stratoweave")
+        if not prefix.endswith(b"/"):
+            prefix += b"/"
+        return (backend="etcd", target=parsed.host!, port=parsed.port if parsed.port is not None else 2379, prefix=prefix)
 
     raise ValueError("Unsupported database URL scheme: {scheme}")
 

--- a/src/db/etcd.act
+++ b/src/db/etcd.act
@@ -1,0 +1,397 @@
+"""etcd persistence store over the etcd v3 JSON gateway.
+
+Keys live under a prefix so several logical stores can share one
+cluster. Range scans are paged; a write batch is one etcd transaction.
+"""
+
+import base64
+import json
+import net
+
+import db as swdb
+import http
+
+
+ETCD_PAGE_SIZE = 64
+
+
+def b64(raw: bytes) -> str:
+    return base64.encode(raw).decode()
+
+
+def obj(data: ?value, context: str) -> dict[str, ?value]:
+    if isinstance(data, dict):
+        return data
+    raise ValueError("Etcd returned an invalid {context}")
+
+
+def lst(data: ?value, context: str) -> list[?value]:
+    if data is None:
+        return []
+    if isinstance(data, list):
+        return data
+    raise ValueError("Etcd returned an invalid {context}")
+
+
+def as_bytes(data: ?value, context: str, required: bool=False) -> bytes:
+    """Decode a base64 field; a missing field is empty unless required."""
+    if data is None and not required:
+        return b""
+    if isinstance(data, str):
+        return base64.decode(data.encode())
+    raise ValueError("Etcd returned an invalid {context}")
+
+
+def end_key(prefix: bytes, end: ?bytes) -> bytes:
+    if end is not None:
+        return prefix + end
+    # The prefix is never empty, so it always has a next key.
+    return swdb.next_prefix(prefix)!
+
+
+actor EtcdClient(cap: net.TCPConnectCap, host: str, port: int):
+    """Send etcd JSON requests over one pipelined HTTP connection.
+
+    Many requests can be in flight at once; answers come back in order.
+    If the connection fails, every request waiting for an answer fails
+    with the same error, as does every later request.
+    """
+
+    var pending: list[action(?value, ?Exception) -> None] = []
+    var sent = 0
+    var failure: ?Exception = None
+    var closed = False
+    var client: ?http.Client = None
+
+    def connected(_client: http.Client) -> None:
+        pass
+
+    def failed(_client: http.Client, message: str) -> None:
+        if failure is None:
+            failure = ValueError("Etcd connection failed: {message}")
+        callbacks = pending
+        pending = []
+        for callback in callbacks:
+            callback(None, failure)
+
+    def response(_client: http.Client, result: http.Response) -> None:
+        if len(pending) == 0:
+            return
+        callback = pending[0]
+        del pending[0]
+        if result.status < 200 or result.status >= 300:
+            callback(None, ValueError("Etcd request failed with HTTP {result.status}: {result.body.decode()}"))
+        else:
+            try:
+                callback(result.decode_json(), None)
+            except Exception as e:
+                callback(None, e)
+
+    client = http.Client(cap, host, connected, failed, scheme="http", port=port, log_handler=None)
+
+    def post(path: str, body: dict[str, ?value], done: action(?value, ?Exception) -> None) -> None:
+        if closed:
+            done(None, ValueError("Etcd store is closed"))
+            return
+        if failure is not None:
+            done(None, failure)
+            return
+        try:
+            encoded = json.encode(body, pretty=False).encode()
+            c = client
+            if c is not None:
+                pending.append(done)
+                sent += 1
+                c.post(path, encoded, response, {"Content-Type": "application/json"})
+        except Exception as e:
+            done(None, e)
+
+    def request_count() -> int:
+        """Number of requests sent so far, for measurements."""
+        return sent
+
+    def close(done: action(?Exception) -> None) -> None:
+        if closed:
+            done(None)
+            return
+        closed = True
+        callbacks = pending
+        pending = []
+        for callback in callbacks:
+            callback(None, ValueError("Etcd store closed with a request in flight"))
+        try:
+            c = client
+            if c is not None:
+                c.close()
+            done(None)
+        except Exception as e:
+            done(e)
+
+
+actor EtcdGet(
+    client: EtcdClient,
+    prefix: bytes,
+    key: bytes,
+    done: action(?bytes, ?Exception) -> None
+):
+    def received(data: ?value, error: ?Exception) -> None:
+        if error is not None:
+            done(None, error)
+            return
+        try:
+            result = obj(data, "range response")
+            rows = lst(result.get("kvs"), "range rows")
+            if len(rows) == 0:
+                done(None, None)
+                return
+            row = obj(rows[0], "range row")
+            done(as_bytes(row.get("value"), "range value"), None)
+        except Exception as e:
+            done(None, e)
+
+    client.post("/v3/kv/range", {
+        "key": b64(prefix + key),
+        "limit": "1"
+    }, received)
+
+
+actor EtcdScan(
+    client: EtcdClient,
+    prefix: bytes,
+    start: bytes,
+    end: ?bytes
+):
+    """Lazy etcd range scan, one page of ETCD_PAGE_SIZE rows at a time."""
+
+    start_key = prefix + start
+    range_end = end_key(prefix, end)
+    var position = start_key
+    var rows: list[(key: bytes, value: bytes)] = []
+    var row_index = 0
+    var more = True
+    var waiting: ?action(?(key: bytes, value: bytes), ?Exception) -> None = None
+    var request_serial = 0
+    var pending_serial: ?int = None
+    var closed = False
+
+    def finish(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        callback = waiting
+        waiting = None
+        if callback is not None:
+            callback(record, error)
+
+    def deliver() -> None:
+        if waiting is None:
+            return
+        if closed:
+            finish(None, None)
+            return
+        if row_index < len(rows):
+            record = rows[row_index]
+            row_index += 1
+            finish(record, None)
+            return
+        if position >= range_end:
+            closed = True
+            finish(None, None)
+            return
+        if not more:
+            closed = True
+            finish(None, None)
+            return
+        if pending_serial is None:
+            fetch_page()
+
+    def page_received(serial: int, data: ?value, error: ?Exception) -> None:
+        if pending_serial != serial:
+            return
+        pending_serial = None
+        if closed:
+            return
+        if error is not None:
+            closed = True
+            finish(None, error)
+            return
+        try:
+            result = obj(data, "range response")
+            page_rows = []
+            physical_last: ?bytes = None
+            for row_data in lst(result.get("kvs"), "range rows"):
+                row = obj(row_data, "range row")
+                physical_key = as_bytes(row.get("key"), "range key", required=True)
+                if not physical_key.startswith(prefix):
+                    raise ValueError("Etcd returned a key outside the store prefix")
+                if physical_key < position or physical_key >= range_end:
+                    raise ValueError("Etcd returned a key outside the requested range")
+                page_rows.append((
+                    key=physical_key[len(prefix):],
+                    value=as_bytes(row.get("value"), "range value")
+                ))
+                physical_last = physical_key
+
+            more_data = result.get("more")
+            if more_data is None:
+                more = False
+            elif isinstance(more_data, bool):
+                more = more_data
+            else:
+                raise ValueError("Etcd returned an invalid range continuation flag")
+            if more and physical_last is None:
+                raise ValueError("Etcd returned an empty range page with more data")
+            if physical_last is not None:
+                position = physical_last + b"\x00"
+            rows = page_rows
+            row_index = 0
+            deliver()
+        except Exception as e:
+            closed = True
+            finish(None, e)
+
+    def fetch_page() -> None:
+        request_serial += 1
+        serial = request_serial
+        pending_serial = serial
+
+        def received(data: ?value, error: ?Exception) -> None:
+            page_received(serial, data, error)
+
+        client.post("/v3/kv/range", {
+            "key": b64(position),
+            "range_end": b64(range_end),
+            "limit": str(ETCD_PAGE_SIZE),
+            "sort_order": "ASCEND",
+            "sort_target": "KEY"
+        }, received)
+
+    def next(done: action(?(key: bytes, value: bytes), ?Exception) -> None) -> None:
+        if waiting is not None:
+            done(None, ValueError("Etcd scan already has a next request in progress"))
+            return
+        waiting = done
+        deliver()
+
+    def seek_ge(key: bytes) -> None:
+        if closed:
+            return
+        target = prefix + (key if key >= start else start)
+        # The buffered page is sorted. A target within it is a local skip,
+        # and a target past it when no more pages exist is the end of the
+        # range; only a target past a page with more data needs a new page.
+        if pending_serial is None and len(rows) > 0:
+            last = prefix + rows[len(rows) - 1].key
+            if target <= last:
+                while row_index < len(rows) and prefix + rows[row_index].key < target:
+                    row_index += 1
+                deliver()
+                return
+            if not more:
+                position = target
+                rows = []
+                row_index = 0
+                deliver()
+                return
+        position = target
+        rows = []
+        row_index = 0
+        more = True
+        request_serial += 1
+        pending_serial = None
+        deliver()
+
+    def close(done: action(?Exception) -> None) -> None:
+        if not closed:
+            closed = True
+            request_serial += 1
+            pending_serial = None
+            rows = []
+            finish(None, None)
+        done(None)
+
+
+actor EtcdWrite(
+    client: EtcdClient,
+    prefix: bytes,
+    writes: list[(key: bytes, value: ?bytes)],
+    done: action(?Exception) -> None
+):
+    success = []
+    for row in writes:
+        val = row.value
+        if val is not None:
+            success.append({
+                "request_put": {
+                    "key": b64(prefix + row.key),
+                    "value": b64(val)
+                }
+            })
+        else:
+            success.append({
+                "request_delete_range": {
+                    "key": b64(prefix + row.key)
+                }
+            })
+
+    def received(data: ?value, error: ?Exception) -> None:
+        if error is not None:
+            done(error)
+            return
+        try:
+            result = obj(data, "transaction response")
+            succeeded = result.get("succeeded")
+            if isinstance(succeeded, bool) and succeeded:
+                done(None)
+            else:
+                done(ValueError("Etcd transaction was not applied"))
+        except Exception as e:
+            done(e)
+
+    client.post("/v3/kv/txn", {
+        "compare": [],
+        "success": success,
+        "failure": []
+    }, received)
+
+
+class EtcdReader(swdb.Reader):
+    """Reader over an etcd store; scans read the current state."""
+
+    client: EtcdClient
+    prefix: bytes
+
+    def __init__(self, client: EtcdClient, prefix: bytes):
+        self.client = client
+        self.prefix = prefix
+
+    def scan(self, start: bytes, end: ?bytes) -> swdb.Scan:
+        scan = EtcdScan(self.client, self.prefix, start, end)
+        return swdb.Scan(scan.next, scan.seek_ge, scan.close)
+
+    def close(self, done: action(?Exception) -> None) -> None:
+        done(None)
+
+
+class EtcdStore(swdb.Store):
+    """Store backed by an etcd v3 JSON endpoint."""
+
+    client: EtcdClient
+    prefix: bytes
+
+    def __init__(self, cap: net.TCPConnectCap, host: str, port: int=2379, prefix: bytes=b""):
+        self.client = EtcdClient(cap, host, port)
+        self.prefix = prefix + b"/" if len(prefix) > 0 and not prefix.endswith(b"/") else prefix
+
+    def get(self, key: bytes, done: action(?bytes, ?Exception) -> None) -> None:
+        EtcdGet(self.client, self.prefix, key, done)
+
+    def read(self) -> swdb.Reader:
+        return EtcdReader(self.client, self.prefix)
+
+    def write(
+        self,
+        writes: list[(key: bytes, value: ?bytes)],
+        done: action(?Exception) -> None
+    ) -> None:
+        EtcdWrite(self.client, self.prefix, writes, done)
+
+    def close(self, done: action(?Exception) -> None) -> None:
+        self.client.close(done)

--- a/src/lib.act
+++ b/src/lib.act
@@ -6,6 +6,7 @@ import tmf.cfs
 
 import app as swapp
 import db as swdb
+import db.etcd as swetcd
 import db.lmdb as swlmdb
 import device as swdev
 import http_server as swhttp
@@ -67,16 +68,19 @@ def main(sysspec: swapp.SysSpec, env: Env, http: bool=True, netconf: bool=True):
 
     args = swapp.AppArgs.from_args(env.argv, env.exit)
     top_schema = sysspec.schema_for_layer(0)
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
     db: ?swdb.Store = None
     db_spec = args.db_spec
     if db_spec is not None:
         spec = swdb.parse_store_spec(db_spec)
         if spec.backend == "lmdb":
             db = swlmdb.LmdbStore(file.WriteFileCap(fcap), spec.target, TTT_DB_MAP_SIZE)
+        elif spec.backend == "etcd":
+            db = swetcd.EtcdStore(connect_cap, spec.target, spec.port!, spec.prefix)
         else:
             raise ValueError("Database backend is not available: {spec.backend}")
 
-    dev_registry = swdev.DeviceRegistry(sysspec.device_types, net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap))), logh_dev)
+    dev_registry = swdev.DeviceRegistry(sysspec.device_types, connect_cap, logh_dev)
     cfs = sysspec.get_layers(dev_registry, logh_ttt, db)
     swapp.RfsReconf(dev_registry, cfs)
 

--- a/src/test_db.act
+++ b/src/test_db.act
@@ -57,7 +57,18 @@ actor database_paths_and_urls_parse(t: testing.AsyncT):
     testing.assertEqual(explicit.target, implicit.target)
     testing.assertEqual(absolute.target, "/tmp/state.db")
 
-    for bad in ["", "lmdb://", "foo://host/x", "lmdb://state.db?opt=1"]:
+    etcd = swdb.parse_store_spec("etcd://127.0.0.1:12379/stratoweave/test")
+    default_port = swdb.parse_store_spec("etcd://db.example/tenant")
+    testing.assertEqual(etcd.backend, "etcd")
+    testing.assertEqual(etcd.target, "127.0.0.1")
+    testing.assertEqual(etcd.port, 12379)
+    testing.assertEqual(etcd.prefix, b"/stratoweave/test/")
+    testing.assertEqual(default_port.port, 2379)
+    testing.assertEqual(default_port.prefix, b"/tenant/")
+
+    # An etcd store needs a key prefix: without one every key of the
+    # cluster would be ours.
+    for bad in ["", "lmdb://", "foo://host/x", "lmdb://state.db?opt=1", "etcd://db.example", "etcd://db.example/", "etcd://db.example:2379"]:
         try:
             swdb.parse_store_spec(bad)
         except ValueError:

--- a/src/test_ttt_persistence_bench.act
+++ b/src/test_ttt_persistence_bench.act
@@ -3,13 +3,18 @@
     acton test perf --record --module test_ttt_persistence_bench
 
 records each test's time and memory for later perf runs to compare
-against; --show-log prints the commit and restore rates.
+against; --show-log prints the commit and restore rates. The etcd
+test needs the local etcd node from test_ttt_persistence_etcd, run
+with the raised transaction limits given there, and --tag etcd.
 """
 
 import file
+import net
 import testing
+import time
 
 import db as swdb
+import db.etcd as swetcd
 import db.lmdb as swlmdb
 import persistence_bench as bench
 
@@ -35,5 +40,33 @@ actor LmdbRoundtrip(t: testing.EnvT, elements: int):
     bench.Roundtrip(open_store, elements, finished)
 
 
+actor EtcdRoundtrip(t: testing.EnvT, elements: int):
+    """Round trip `elements` list elements through the local etcd node
+    under a prefix of its own, print the rates and the requests each phase
+    took, and finish the test."""
+    t.require("etcd")
+    cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+    prefix = b"/stratoweave/bench/" + str(time.time().second).encode() + b"-" + actorid().encode() + b"/"
+    var stores: list[swetcd.EtcdStore] = []
+
+    def open_store() -> swdb.Store:
+        store = swetcd.EtcdStore(cap, "127.0.0.1", 2379, prefix)
+        stores.append(store)
+        return store
+
+    def finished(error: ?Exception, commit_secs: float, restore_secs: float) -> None:
+        if error is not None:
+            raise error
+        # One store per phase: the first did the commit, the second the restore.
+        print(bench.report("etcd", elements, commit_secs, restore_secs) + " requests: commit={stores[0].client.request_count()} restore={stores[1].client.request_count()}")
+        t.success()
+
+    bench.Roundtrip(open_store, elements, finished)
+
+
 actor bench_lmdb_200(t: testing.EnvT):
     LmdbRoundtrip(t, 200)
+
+
+actor bench_etcd_200(t: testing.EnvT):
+    EtcdRoundtrip(t, 200)

--- a/src/test_ttt_persistence_etcd.act
+++ b/src/test_ttt_persistence_etcd.act
@@ -1,0 +1,261 @@
+"""Etcd persistence integration tests.
+
+A TTT commit is one etcd transaction with an operation per changed
+record, and etcd's defaults (128 operations and 1.5 MB per transaction)
+hold about 20 list elements. Run etcd with those limits raised:
+
+    docker run --rm --name stratoweave-etcd-test \
+      -p 2379:2379 \
+      gcr.io/etcd-development/etcd:v3.6.11 \
+      /usr/local/bin/etcd \
+      --name s1 \
+      --data-dir /tmp/etcd-data \
+      --listen-client-urls http://0.0.0.0:2379 \
+      --advertise-client-urls http://0.0.0.0:2379 \
+      --listen-peer-urls http://0.0.0.0:2380 \
+      --initial-advertise-peer-urls http://0.0.0.0:2380 \
+      --initial-cluster s1=http://0.0.0.0:2380 \
+      --initial-cluster-state new \
+      --max-txn-ops 100000 \
+      --max-request-bytes 104857600 \
+      --quota-backend-bytes 8589934592 \
+      --auto-compaction-mode periodic \
+      --auto-compaction-retention 10m
+
+Run these tests with:
+
+    acton test --tag etcd --module test_ttt_persistence_etcd
+
+An application uses the same endpoint through:
+
+    --db etcd://127.0.0.1:2379/stratoweave
+"""
+
+import net
+import testing
+import time
+
+import db as swdb
+import db.etcd as swetcd
+import ttt
+import yang.gdata as gdata
+
+
+TEST_NS = "urn:test:persistence:etcd"
+
+
+def q(name: str) -> gdata.Id:
+    return gdata.Id(TEST_NS, name)
+
+
+def connect_cap(t: testing.EnvT) -> net.TCPConnectCap:
+    return net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+
+def test_prefix(kind: str) -> bytes:
+    now = time.time()
+    timestamp = str(now.second).encode() + b"-" + str(now.attosecond).encode()
+    return b"/stratoweave/tests/" + kind.encode() + b"-" + timestamp + b"-" + actorid().encode() + b"/"
+
+
+def padded_index(index: int) -> str:
+    suffix = str(index)
+    while len(suffix) < 3:
+        suffix = "0" + suffix
+    return suffix
+
+
+actor ClearStore(store: swdb.Store, done: action(?Exception) -> None):
+    scan = store.read().scan(b"", None)
+    var deletes: list[(key: bytes, value: ?bytes)] = []
+    var scan_error: ?Exception = None
+
+    def after_close(error: ?Exception) -> None:
+        if scan_error is not None:
+            done(scan_error)
+        elif error is not None:
+            done(error)
+        elif len(deletes) == 0:
+            done(None)
+        else:
+            store.write(deletes, done)
+
+    def received(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            scan_error = error
+            scan.close(after_close)
+        elif record is None:
+            scan.close(after_close)
+        else:
+            row = record!
+            deletes.append((key=row.key, value=None))
+            scan.next(received)
+
+    scan.next(received)
+
+
+actor etcd_store_uses_callback_ranges_and_transactions(t: testing.EnvT):
+    t.require("etcd")
+    prefix = test_prefix("store")
+    store = swetcd.EtcdStore(connect_cap(t), "127.0.0.1", 2379, prefix)
+    var scan: ?swdb.Scan = None
+
+    def after_store_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        t.success()
+
+    def after_cleanup(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.close(after_store_close)
+
+    def after_scan_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.write([
+            (key=b"a", value=None),
+            (key=b"b", value=None),
+            (key=b"c", value=None)
+        ], after_cleanup)
+
+    def after_eof(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(record is None, True)
+        scan!.close(after_scan_close)
+
+    def after_seek(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        row = record!
+        testing.assertEqual(row.key, b"c")
+        testing.assertEqual(row.value, b"3")
+        scan!.seek_ge(b"z")
+        scan!.next(after_eof)
+
+    def after_first(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        row = record!
+        testing.assertEqual(row.key, b"a")
+        testing.assertEqual(row.value, b"1")
+        scan!.seek_ge(b"c")
+        scan!.next(after_seek)
+
+    def after_get(value: ?bytes, error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(value, b"2")
+        scan1 = store.read().scan(b"a", b"d")
+        scan = scan1
+        scan1.next(after_first)
+
+    def after_write(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.get(b"b", after_get)
+
+    store.write([
+        (key=b"a", value=b"1"),
+        (key=b"b", value=b"2"),
+        (key=b"c", value=b"3")
+    ], after_write)
+
+
+actor etcd_scan_streams_across_pages(t: testing.EnvT):
+    t.require("etcd")
+    store = swetcd.EtcdStore(connect_cap(t), "127.0.0.1", 2379, test_prefix("pages"))
+    writes = []
+    deletes = []
+    for i in range(70):
+        key = ("k-" + padded_index(i)).encode()
+        writes.append((key=key, value=str(i).encode()))
+        deletes.append((key=key, value=None))
+
+    var scan: ?swdb.Scan = None
+    var index = 0
+
+    def after_store_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        t.success()
+
+    def after_cleanup(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.close(after_store_close)
+
+    def after_scan_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.write(deletes, after_cleanup)
+
+    def received(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        if record is None:
+            testing.assertEqual(index, 70)
+            scan!.close(after_scan_close)
+            return
+        row = record!
+        testing.assertEqual(row.key, ("k-" + padded_index(index)).encode())
+        testing.assertEqual(row.value, str(index).encode())
+        index += 1
+        scan!.next(received)
+
+    def after_write(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        scan1 = store.read().scan(b"k-", b"k.")
+        scan = scan1
+        scan1.next(received)
+
+    store.write(writes, after_write)
+
+
+def list_tree(size: int) -> gdata.List:
+    elements = []
+    for i in range(size):
+        suffix = padded_index(i)
+        elements.append(gdata.Container({
+            q("name"): gdata.Leaf("item-{suffix}"),
+            q("value"): gdata.Leaf(i)
+        }))
+    return gdata.List([q("name")], elements)
+
+
+def list_root() -> proc(ttt.Path, ?ttt.Layer) -> ttt.Node:
+    return ttt.List(ttt.Transform(ttt.PassThrough), [q("name")])
+
+
+actor ttt_round_trip_restores_from_etcd_ranges(t: testing.EnvT):
+    t.require("etcd")
+    prefix = test_prefix("restore")
+    store = swetcd.EtcdStore(connect_cap(t), "127.0.0.1", 2379, prefix)
+    expected = list_tree(24)
+    var restored = ttt.Layer("etcd", list_root(), None, store)
+
+    def after_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        t.success()
+
+    def after_cleanup(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.close(after_close)
+
+    def after_restore(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(restored.get(), expected)
+        ClearStore(store, after_cleanup)
+
+    def after_commit(result: value) -> None:
+        if not (isinstance(result, str) and result == "Ok"):
+            raise AssertionError("Expected successful etcd persistence commit, got {result}")
+        restored = ttt.Layer("etcd", list_root(), None, store)
+        restored.load_from_db(after_restore)
+
+    restored.edit_config(expected, after_commit)


### PR DESCRIPTION
db.etcd implements the Store contract over the etcd v3 JSON gateway: paged range scans, a write batch as one etcd transaction, and a key prefix per logical store. --db etcd://host:port/prefix selects it. Requests are pipelined over one HTTP connection.

A TTT commit is one etcd transaction with an operation per changed record, more than etcd's default limits allow, so etcd runs with --max-txn-ops and --max-request-bytes raised; the test module gives the docker command. Tests run against that node with --tag etcd. 5000 elements commit in 2.1s and restore in 3.7s.

Fixes #340