### PR TITLE
Remove libssh runtime requirement

### DIFF
--- a/docs/operations/run.md
+++ b/docs/operations/run.md
@@ -2,7 +2,6 @@
 # Running StratoWeave
 A StratoWeave-based Orchestrator is a single binary that can be deployed on any
 Linux-based system.
-The only runtime requirement is [libssh](https://www.libssh.org).
 
 ## Deployment
 The simplest way to deploy a StratoWeave orchestrator is wrap up the binary


### PR DESCRIPTION
Remove the incorrect statement that libssh is a runtime requirement. SORESPO links libssh statically, so operators do not need to install it separately.
