### PR TITLE
Pin an etcd reader's scans to one MVCC revision

### DIFF
--- a/src/db/etcd.act
+++ b/src/db/etcd.act
@@ -2,6 +2,9 @@
 
 Keys live under a prefix so several logical stores can share one
 cluster. Range scans are paged; a write batch is one etcd transaction.
+Every range scan opened from one reader reads at a single pinned MVCC
+revision, so all of that reader's scan traffic observes one point-in-time
+view even though etcd has no cross-request read transaction.
 """
 
 import base64
@@ -40,6 +43,23 @@ def as_bytes(data: ?value, context: str, required: bool=False) -> bytes:
     if isinstance(data, str):
         return base64.decode(data.encode())
     raise ValueError("Etcd returned an invalid {context}")
+
+
+def as_revision(data: ?value, context: str) -> str:
+    """Return an etcd revision as a decimal string.
+
+    The JSON gateway encodes int64 as a string; an int is accepted too. The
+    result is a string to match how requests send integers, e.g. "64".
+    """
+    if isinstance(data, str):
+        revision = int(data)
+    elif isinstance(data, int):
+        revision = data
+    else:
+        raise ValueError("Etcd returned an invalid {context}")
+    if revision <= 0:
+        raise ValueError("Etcd returned a non-positive {context}: {revision}")
+    return str(revision)
 
 
 def end_key(prefix: bytes, end: ?bytes) -> bytes:
@@ -155,13 +175,76 @@ actor EtcdGet(
     }, received)
 
 
+actor EtcdReadSnapshot(client: EtcdClient, prefix: bytes):
+    """Pin one etcd MVCC revision for every scan of a reader.
+
+    A restore opens many scans from one reader and runs them at once, but
+    etcd has no cross-request read transaction. The first scan to need data
+    acquires the current revision from a range response header; every later
+    page of every scan reads at it, so the reader sees one snapshot.
+    Concurrent first requests wait for that one acquisition. Failure is
+    sticky: a read never falls back to latest, which would mix snapshots.
+    """
+
+    var revision: ?str = None
+    var failure: ?Exception = None
+    var acquiring = False
+    var waiters: list[action(?str, ?Exception) -> None] = []
+
+    def complete(resolved_revision: ?str, error: ?Exception) -> None:
+        revision = resolved_revision
+        failure = error
+        acquiring = False
+        callbacks = waiters
+        waiters = []
+        for callback in callbacks:
+            callback(resolved_revision, error)
+
+    def received(data: ?value, error: ?Exception) -> None:
+        if error is not None:
+            complete(None, error)
+            return
+        try:
+            result = obj(data, "snapshot range response")
+            header = obj(result.get("header"), "snapshot response header")
+            resolved = as_revision(header.get("revision"), "snapshot revision")
+            complete(resolved, None)
+        except Exception as e:
+            complete(None, e)
+
+    def get_revision(done: action(?str, ?Exception) -> None) -> None:
+        if revision is not None:
+            done(revision, None)
+            return
+        if failure is not None:
+            done(None, failure)
+            return
+        waiters.append(done)
+        if acquiring:
+            return
+        acquiring = True
+        # header.revision comes back even on an exact-key miss, so probe
+        # META_KEY. No range end, so an empty prefix works too.
+        client.post("/v3/kv/range", {
+            "key": b64(prefix + swdb.META_KEY),
+            "limit": "1",
+            "keys_only": True
+        }, received)
+
+
 actor EtcdScan(
     client: EtcdClient,
     prefix: bytes,
+    snapshot: EtcdReadSnapshot,
     start: bytes,
     end: ?bytes
 ):
-    """Lazy etcd range scan, one page of ETCD_PAGE_SIZE rows at a time."""
+    """Lazy etcd range scan, one page of ETCD_PAGE_SIZE rows at a time.
+
+    Every page reads at the reader's pinned revision (see EtcdReadSnapshot),
+    so the scan sees one point-in-time snapshot regardless of concurrent
+    writes.
+    """
 
     start_key = prefix + start
     range_end = end_key(prefix, end)
@@ -252,16 +335,29 @@ actor EtcdScan(
         serial = request_serial
         pending_serial = serial
 
-        def received(data: ?value, error: ?Exception) -> None:
+        def page_response(data: ?value, error: ?Exception) -> None:
             page_received(serial, data, error)
 
-        client.post("/v3/kv/range", {
-            "key": b64(position),
-            "range_end": b64(range_end),
-            "limit": str(ETCD_PAGE_SIZE),
-            "sort_order": "ASCEND",
-            "sort_target": "KEY"
-        }, received)
+        def revision_received(read_revision: ?str, error: ?Exception) -> None:
+            # a seek or close may have superseded this fetch; drop it if so.
+            if pending_serial != serial or closed:
+                return
+            if error is not None:
+                page_received(serial, None, error)
+                return
+            if read_revision is None:
+                page_received(serial, None, ValueError("Etcd snapshot returned no revision"))
+                return
+            client.post("/v3/kv/range", {
+                "key": b64(position),
+                "range_end": b64(range_end),
+                "limit": str(ETCD_PAGE_SIZE),
+                "revision": read_revision,
+                "sort_order": "ASCEND",
+                "sort_target": "KEY"
+            }, page_response)
+
+        snapshot.get_revision(revision_received)
 
     def next(done: action(?(key: bytes, value: bytes), ?Exception) -> None) -> None:
         if waiting is not None:
@@ -353,17 +449,19 @@ actor EtcdWrite(
 
 
 class EtcdReader(swdb.Reader):
-    """Reader over an etcd store; scans read the current state."""
+    """All scans in this reader use one pinned etcd MVCC revision."""
 
     client: EtcdClient
     prefix: bytes
+    snapshot: EtcdReadSnapshot
 
     def __init__(self, client: EtcdClient, prefix: bytes):
         self.client = client
         self.prefix = prefix
+        self.snapshot = EtcdReadSnapshot(client, prefix)
 
     def scan(self, start: bytes, end: ?bytes) -> swdb.Scan:
-        scan = EtcdScan(self.client, self.prefix, start, end)
+        scan = EtcdScan(self.client, self.prefix, self.snapshot, start, end)
         return swdb.Scan(scan.next, scan.seek_ge, scan.close)
 
     def close(self, done: action(?Exception) -> None) -> None:

--- a/src/test_ttt_persistence_etcd.act
+++ b/src/test_ttt_persistence_etcd.act
@@ -259,3 +259,221 @@ actor ttt_round_trip_restores_from_etcd_ranges(t: testing.EnvT):
         restored.load_from_db(after_restore)
 
     restored.edit_config(expected, after_commit)
+
+
+actor etcd_reader_pins_revision_across_pages_and_scans(t: testing.EnvT):
+    """All scans of one reader read at a single pinned MVCC revision.
+
+    70 keys span two pages (ETCD_PAGE_SIZE is 64). After scan1 drains the
+    first page, a mutation updates, deletes, and creates keys that fall in
+    the second page. scan1's later pages and a second scan opened from the
+    same reader after the mutation must both still see the original 70-key
+    snapshot; only a reader opened afresh sees the mutation. On the unpinned
+    "read current state" behaviour this fails, because the later reads would
+    observe the mutation.
+
+    EtcdScan does not prefetch, so the second page is not requested until the
+    65th next(); committing the mutation between the 64th record and that call
+    makes the ordering deterministic without sleeps or retries.
+    """
+    t.require("etcd")
+    prefix = test_prefix("snapshot")
+    store = swetcd.EtcdStore(connect_cap(t), "127.0.0.1", 2379, prefix)
+    total = 70
+    writes = []
+    cleanup = []
+    for i in range(total):
+        key = ("k-" + padded_index(i)).encode()
+        writes.append((key=key, value=("old-" + str(i)).encode()))
+        cleanup.append((key=key, value=None))
+    cleanup.append((key=("k-" + padded_index(70)).encode(), value=None))
+
+    var reader: ?swdb.Reader = None
+    var scan1: ?swdb.Scan = None
+    var scan2: ?swdb.Scan = None
+    var fresh_scan: ?swdb.Scan = None
+    var fresh_reader: ?swdb.Reader = None
+    var index_1 = 0
+    var index_2 = 0
+    var mutated = False
+    var fresh_rows: dict[bytes, bytes] = {}
+
+    def after_store_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        t.success()
+
+    def after_cleanup(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.close(after_store_close)
+
+    # Step 10-12: a reader opened after the mutation sees the new state.
+    def after_fresh_reader_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        testing.assertEqual(len(fresh_rows), total)
+        testing.assertEqual(fresh_rows.get(("k-" + padded_index(64)).encode()), b"new-64")
+        testing.assertEqual(("k-" + padded_index(65)).encode() in fresh_rows, False)
+        testing.assertEqual(fresh_rows.get(("k-" + padded_index(70)).encode()), b"new-70")
+        testing.assertEqual(fresh_rows.get(("k-" + padded_index(0)).encode()), b"old-0")
+        store.write(cleanup, after_cleanup)
+
+    def after_fresh_scan_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        fresh_reader!.close(after_fresh_reader_close)
+
+    def fresh_received(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        if record is None:
+            fresh_scan!.close(after_fresh_scan_close)
+            return
+        row = record!
+        fresh_rows[row.key] = row.value
+        fresh_scan!.next(fresh_received)
+
+    def start_fresh() -> None:
+        r = store.read()
+        fresh_reader = r
+        s = r.scan(b"k-", b"k.")
+        fresh_scan = s
+        s.next(fresh_received)
+
+    # Step 8-9: a second scan on the same reader still sees the snapshot.
+    def after_reader_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        start_fresh()
+
+    def after_scan2_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        reader!.close(after_reader_close)
+
+    def scan2_received(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        if record is None:
+            testing.assertEqual(index_2, total)
+            scan2!.close(after_scan2_close)
+            return
+        row = record!
+        testing.assertEqual(row.key, ("k-" + padded_index(index_2)).encode())
+        testing.assertEqual(row.value, ("old-" + str(index_2)).encode())
+        index_2 += 1
+        scan2!.next(scan2_received)
+
+    def start_scan2() -> None:
+        # Opened after the mutation, yet pinned to the same reader revision.
+        s = reader!.scan(b"k-", b"k.")
+        scan2 = s
+        s.next(scan2_received)
+
+    # Step 6-7: scan1 resumes into the second page, still at the snapshot.
+    def after_scan1_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        start_scan2()
+
+    def after_mutation(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        scan1!.next(scan1_received)
+
+    def scan1_received(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        if record is None:
+            testing.assertEqual(index_1, total)
+            scan1!.close(after_scan1_close)
+            return
+        row = record!
+        testing.assertEqual(row.key, ("k-" + padded_index(index_1)).encode())
+        testing.assertEqual(row.value, ("old-" + str(index_1)).encode())
+        index_1 += 1
+        # First page drained, second not yet fetched: mutate second-page keys
+        # before resuming. The pinned revision must hide them.
+        if index_1 == swetcd.ETCD_PAGE_SIZE and not mutated:
+            mutated = True
+            store.write([
+                (key=("k-" + padded_index(64)).encode(), value=b"new-64"),
+                (key=("k-" + padded_index(65)).encode(), value=None),
+                (key=("k-" + padded_index(70)).encode(), value=b"new-70")
+            ], after_mutation)
+        else:
+            scan1!.next(scan1_received)
+
+    def after_write(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        r = store.read()
+        reader = r
+        s = r.scan(b"k-", b"k.")
+        scan1 = s
+        s.next(scan1_received)
+
+    store.write(writes, after_write)
+
+
+actor etcd_reader_snapshot_supports_bounded_empty_prefix(t: testing.EnvT):
+    """Snapshot acquisition works when the store prefix is empty.
+
+    EtcdStore's low-level prefix defaults to b"". A bounded scan needs no
+    prefix successor key, and snapshot acquisition must not need one either:
+    it reads the exact metadata key, so it never computes next_prefix(b"").
+    """
+    t.require("etcd")
+    store = swetcd.EtcdStore(connect_cap(t), "127.0.0.1", 2379, b"")
+    unique = test_prefix("empty-prefix")
+    key = unique + b"a"
+    end = unique + b"z"
+
+    var reader: ?swdb.Reader = None
+    var scan: ?swdb.Scan = None
+    var seen = 0
+
+    def after_store_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        t.success()
+
+    def after_cleanup(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.close(after_store_close)
+
+    def after_reader_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        store.write([(key=key, value=None)], after_cleanup)
+
+    def after_scan_close(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        reader!.close(after_reader_close)
+
+    def received(record: ?(key: bytes, value: bytes), error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        if record is None:
+            testing.assertEqual(seen, 1)
+            scan!.close(after_scan_close)
+            return
+        row = record!
+        testing.assertEqual(row.key, key)
+        testing.assertEqual(row.value, b"v")
+        seen += 1
+        scan!.next(received)
+
+    def after_write(error: ?Exception) -> None:
+        if error is not None:
+            raise error
+        r = store.read()
+        reader = r
+        s = r.scan(key, end)
+        scan = s
+        s.next(received)
+
+    store.write([(key=key, value=b"v")], after_write)


### PR DESCRIPTION
Reader in `src/db.act` opens one read session for a whole restore so a backend can serve every scan from a single read transaction or snapshot. `LmdbReader` keeps that with one `lmdb.ReadTransaction`. The etcd backend did not: `EtcdScan.fetch_page` sent each `/v3/kv/range` without a `revision`, so page 1 and page 2 of a scan, and scan A versus scan B of one restore, could land on different revisions. Restore keeps `RESTORE_FANOUT` scans in flight (#343), so a write committed mid-restore was seen by some reads and not others, and recompute could start from a TTT state that never existed.

`EtcdReadSnapshot` acquires the store revision once, from the header of a range read of the metadata key, and every page of every scan on that reader reads at it. The first scan to need data triggers the acquisition and concurrent first scans wait for it, so they cannot pin different revisions. Acquisition failure is sticky and a compacted pinned revision fails the read, so a restore never quietly falls back to the latest revision. Operationally that means etcd history retention has to outlast a reader; if the pinned revision is compacted mid-restore the restore fails rather than mixing in newer data.

This pins the reader's scan traffic only. `LayerRestore` still reads `META_KEY` through `Store.get` before it opens the reader, so metadata and scan data are not yet one snapshot. Under the single-writer assumption their revisions match, and since namespace ids are append-only a stale codec fails a decode loudly rather than corrupting. Reading metadata through the reader is a separate `Store`/`Reader` change. `EtcdReader.close` is likewise still a no-op, and write-side ownership fencing stays out (`EtcdWrite` uses an empty compare); the `Store` contract still assumes a single owner.

Cost is one extra range request per reader that starts a scan, plus a round-trip barrier before its first page. Concurrent first scans share it, so the benchmark's restore request count rises by one.

`etcd_reader_pins_revision_across_pages_and_scans` writes 70 keys over two pages (`ETCD_PAGE_SIZE` is 64), drains the first page, then updates, deletes, and creates keys in the second page before it is fetched, and asserts the scan's later pages and a second scan on the same reader still see the original snapshot while a fresh reader sees the mutation. It is deterministic because `EtcdScan` does not prefetch. A second test covers acquisition under an empty store prefix. Both ran against a local etcd v3.6.11, where the first also fails against the backend before this change.

The etcd transport separately has a first-connect flake (#521, fixed in #523) that affects every read here, so #523 is best landed first; this then rebases onto it and can reuse its transaction-response guard on the snapshot read.

Fixes #520
