### PR TITLE
Queue etcd requests until the HTTP connection is up

### DIFF
--- a/src/db/etcd.act
+++ b/src/db/etcd.act
@@ -58,6 +58,26 @@ def lst(data: ?value, context: str) -> list[?value]:
     raise ValueError("Etcd returned an invalid {context}")
 
 
+def obvious_response_kind(data: ?value) -> ?str:
+    # etcd's JSON gateway omits default-valued fields, so a failed transaction
+    # and an empty range are both header-only. Only classify an unambiguous
+    # envelope; leave a header-only response to the endpoint decoder.
+    if isinstance(data, dict):
+        if "succeeded" in data or "responses" in data:
+            return "txn"
+        if "kvs" in data or "more" in data or "count" in data:
+            return "range"
+    return None
+
+
+def response_kind(path: str) -> str:
+    if path == "/v3/kv/txn":
+        return "txn"
+    if path == "/v3/kv/range":
+        return "range"
+    raise ValueError("Unsupported etcd request path: {path}")
+
+
 def as_bytes(data: ?value, context: str, required: bool=False) -> bytes:
     """Decode a base64 field; a missing field is empty unless required."""
     if data is None and not required:
@@ -77,40 +97,102 @@ def end_key(prefix: bytes, end: ?bytes) -> bytes:
 actor EtcdClient(cap: net.TCPConnectCap, host: str, port: int):
     """Send etcd JSON requests over one pipelined HTTP connection.
 
-    Many requests can be in flight at once; answers come back in order.
-    If the connection fails, every request waiting for an answer fails
-    with the same error, as does every later request.
+    Requests wait for the connection, then go out in order and their answers
+    return in order. http.Client resends whatever is still outstanding when
+    it connects, so handing it a request earlier sends it twice and desyncs
+    answers from callbacks. On failure every waiting request, and every later
+    one, fails with the same error. A response that unambiguously belongs to
+    the other request family means the stream is out of sync, so the client
+    fails everything and closes rather than passing on a mismatched answer.
     """
 
-    var pending: list[action(?value, ?Exception) -> None] = []
+    var pending: list[(kind: str, done: action(?value, ?Exception) -> None)] = []
+    var queued: list[(path: str, body: bytes, kind: str, done: action(?value, ?Exception) -> None)] = []
+    var ready = False
     var sent = 0
     var failure: ?Exception = None
     var closed = False
     var client: ?http.Client = None
 
-    def connected(_client: http.Client) -> None:
-        pass
+    def dispatch(c: http.Client, path: str, body: bytes, kind: str, done: action(?value, ?Exception) -> None) -> None:
+        pending.append((kind=kind, done=done))
+        sent += 1
+        c.post(path, body, response, {"Content-Type": "application/json"})
+
+    def connected(c: http.Client) -> None:
+        if closed or failure is not None:
+            c.close()
+            return
+        ready = True
+        waiting = queued
+        queued = []
+        for req in waiting:
+            dispatch(c, req.path, req.body, req.kind, req.done)
 
     def failed(_client: http.Client, message: str) -> None:
+        # http.Client does not reconnect after an error, so close it rather than
+        # leave a dead connection open in a client that can no longer be used.
+        # Only close when this is the first death, since poison() or close()
+        # already closed the client and this error is the socket tearing down.
+        already_dead = failure is not None or closed
+        ready = False
         if failure is None:
             failure = ValueError("Etcd connection failed: {message}")
-        callbacks = pending
+        callbacks = [p.done for p in pending] + [req.done for req in queued]
         pending = []
+        queued = []
         for callback in callbacks:
             callback(None, failure)
+        c = client
+        if c is not None and not already_dead:
+            c.close()
+
+    def poison(error: Exception) -> None:
+        # An out-of-sync stream cannot be trusted, so fail everything with one
+        # error and close rather than guessing how to realign it.
+        if failure is None:
+            failure = error
+        ready = False
+        callbacks = [p.done for p in pending] + [req.done for req in queued]
+        pending = []
+        queued = []
+        for callback in callbacks:
+            callback(None, failure)
+        c = client
+        if c is not None:
+            c.close()
 
     def response(_client: http.Client, result: http.Response) -> None:
+        # After a failure, poison, or close the stream is dead; drop the response.
+        if failure is not None or closed:
+            return
+        # Connection: close makes http.Client reconnect; hold later requests until then.
+        if "connection" in result.headers and result.headers["connection"] == "close":
+            ready = False
         if len(pending) == 0:
             return
-        callback = pending[0]
-        del pending[0]
+        # Keep the request at the head until it is validated; on a mismatch
+        # poison() then fails it and everything after it in request order.
+        req = pending[0]
         if result.status < 200 or result.status >= 300:
-            callback(None, ValueError("Etcd request failed with HTTP {result.status}: {result.body.decode()}"))
-        else:
+            del pending[0]
             try:
-                callback(result.decode_json(), None)
-            except Exception as e:
-                callback(None, e)
+                req.done(None, ValueError("Etcd request failed with HTTP {result.status}: {result.body.decode()}"))
+            except Exception:
+                # A non-UTF-8 error body must not swallow the callback.
+                req.done(None, ValueError("Etcd request failed with HTTP {result.status}"))
+            return
+        try:
+            decoded = result.decode_json()
+            observed = obvious_response_kind(decoded)
+            if observed is not None and observed != req.kind:
+                poison(ValueError("Etcd returned a {observed} response for a pending {req.kind} request; the stream is out of sync"))
+                return
+            del pending[0]
+            req.done(decoded, None)
+        except Exception as e:
+            del pending[0]
+            req.done(None, e)
 
     client = http.Client(cap, host, connected, failed, scheme="http", port=port, log_handler=None)
 
@@ -122,12 +204,18 @@ actor EtcdClient(cap: net.TCPConnectCap, host: str, port: int):
             done(None, failure)
             return
         try:
+            # Resolve the kind now so an unknown path fails its own post rather
+            # than stranding sibling queued requests when connected() dispatches.
+            kind = response_kind(path)
             encoded = json.encode(body, pretty=False).encode()
             c = client
             if c is not None:
-                pending.append(done)
-                sent += 1
-                c.post(path, encoded, response, {"Content-Type": "application/json"})
+                if ready:
+                    dispatch(c, path, encoded, kind, done)
+                else:
+                    queued.append((path=path, body=encoded, kind=kind, done=done))
+            else:
+                done(None, ValueError("Etcd client is not connected"))
         except Exception as e:
             done(None, e)
 
@@ -140,10 +228,12 @@ actor EtcdClient(cap: net.TCPConnectCap, host: str, port: int):
             done(None)
             return
         closed = True
-        callbacks = pending
+        ready = False
+        callbacks = [p.done for p in pending] + [req.done for req in queued]
         pending = []
+        queued = []
         for callback in callbacks:
-            callback(None, ValueError("Etcd store closed with a request in flight"))
+            callback(None, ValueError("Etcd store closed with a request pending"))
         try:
             c = client
             if c is not None:

--- a/src/test_etcd_client.act
+++ b/src/test_etcd_client.act
@@ -1,0 +1,561 @@
+"""EtcdClient unit tests that need no running etcd.
+
+A raw TCP server stands in for etcd and replies with a canned body, so these
+run in the normal suite. The mismatch tests answer a range request with a
+transaction envelope (the wrong kind) to force the out-of-sync path; the
+header-only test answers a transaction request the way etcd answers a failed
+one, which must be accepted rather than mistaken for a mismatch.
+"""
+
+import net
+import http
+import logging
+import random
+import testing
+
+import db as swdb
+import db.etcd as swetcd
+
+
+# A transaction envelope carries succeeded/responses, so it is the wrong shape
+# for a range request and forces the client's out-of-sync path.
+TXN_ENVELOPE = b"{\"succeeded\":true,\"responses\":[]}"
+
+# etcd's JSON gateway omits default-valued fields, so a failed transaction and
+# an empty range both come back header-only. This must not read as a mismatch.
+HEADER_ONLY = b"{\"header\":{\"revision\":\"1\"}}"
+
+# A range reply that matches a range request, for the happy path: a well-formed
+# answer must be delivered, and the request behind it sent exactly once.
+RANGE_BODY = b"{\"header\":{\"revision\":\"1\"},\"kvs\":[{\"key\":\"QQ==\",\"value\":\"Yg==\"}],\"count\":\"1\"}"
+
+# Base64 keys for the range requests; the values do not matter because the
+# server never really ranges, it only ever replies with its canned body.
+RANGE_KEY_A = "QQ=="
+RANGE_KEY_B = "Qg=="
+
+
+actor MockEtcdServer(
+    listen_cap: net.TCPListenCap,
+    port: int,
+    reply_body: bytes,
+    on_ready: action(?str) -> None
+):
+    """Answers every request with one canned body and records activity.
+
+    Faults are recorded rather than ignored so a broken mock shows up in a
+    failing test's diagnostics. A peer-initiated close is expected here (the
+    client closes when it poisons), so a fault only ever surfaces through the
+    timeout path, where it cannot turn a passing run red.
+    """
+
+    var count = 0
+    var buf = b""
+    var faults: list[str] = []
+    var conns: list[net.TCPListenConnection] = []
+    log = logging.Logger(None)
+
+    def on_receive(conn: net.TCPListenConnection, data: bytes) -> None:
+        buf += data
+        while True:
+            req, rest = http.parse_request(buf, log)
+            if req is None:
+                break
+            buf = rest
+            count += 1
+            conn.write(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                + b"Content-Length: " + str(len(reply_body)).encode() + b"\r\n\r\n"
+                + reply_body
+            )
+
+    def on_error(conn: net.TCPListenConnection, message: str) -> None:
+        faults.append(message)
+
+    def on_accept(conn: net.TCPListenConnection) -> None:
+        conns.append(conn)
+        conn.cb_install(on_receive, on_error, None)
+
+    def on_listen(listener: net.TCPListener, error: ?str) -> None:
+        on_ready(error)
+
+    def request_count() -> int:
+        return count
+
+    def server_faults() -> list[str]:
+        return faults
+
+    def close() -> None:
+        for conn in conns:
+            conn.close()
+
+    listener = net.TCPListener(listen_cap, "127.0.0.1", port, on_listen, on_accept)
+
+
+actor etcd_client_poison_blocks_later_request(t: testing.EnvT):
+    """A mismatched response poisons the client so later requests never send.
+
+    The server answers a range request with a transaction envelope, so the
+    stream is out of sync. The client must fail the pending request and refuse
+    the next one locally; a pre-fix client passed the answer on and stayed
+    usable, so the server saw the second request too.
+    """
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    var attempts = 0
+    var bind_port = 0
+    var done = False
+    var got_first = False
+    var got_second = False
+    var first_error: ?Exception = None
+    var second_error: ?Exception = None
+    var server: ?MockEtcdServer = None
+    var client: ?swetcd.EtcdClient = None
+
+    def drop(error: ?Exception) -> None:
+        pass
+
+    def teardown() -> None:
+        c = client
+        if c is not None:
+            c.close(drop)
+        s = server
+        if s is not None:
+            s.close()
+
+    def fail(message: str) -> None:
+        if done:
+            return
+        done = True
+        teardown()
+        t.failure(ValueError(message))
+
+    def succeed() -> None:
+        if done:
+            return
+        done = True
+        teardown()
+        t.success()
+
+    def verify() -> None:
+        if done:
+            return
+        s = server
+        if s is not None:
+            n = await async s.request_count()
+            if not got_first or not got_second:
+                fail("both callbacks must fire: first={got_first} second={got_second}")
+                return
+            fe = first_error
+            se = second_error
+            if fe is None or se is None:
+                fail("both requests must fail after a mismatch")
+                return
+            if "out of sync" not in str(fe):
+                fail("first error must report the desync: {fe}")
+                return
+            if "out of sync" not in str(se):
+                fail("second error must report the desync: {se}")
+                return
+            if n != 1:
+                fail("poison did not stop the later request: server saw {n}")
+                return
+            succeed()
+
+    def on_second(result: ?value, error: ?Exception) -> None:
+        if got_second:
+            fail("second callback fired twice")
+            return
+        got_second = True
+        second_error = error
+        # Give any stray request time to reach the server before counting.
+        after 0.3: verify()
+
+    def on_first(result: ?value, error: ?Exception) -> None:
+        if got_first:
+            fail("first callback fired twice")
+            return
+        got_first = True
+        first_error = error
+        c = client
+        if c is not None:
+            c.post("/v3/kv/range", {"key": RANGE_KEY_B}, on_second)
+
+    def bind() -> None:
+        attempts += 1
+        p = random.randint(20000, 45000)
+        bind_port = p
+        server = MockEtcdServer(listen_cap, p, TXN_ENVELOPE, on_ready)
+
+    def on_ready(error: ?str) -> None:
+        if error is not None:
+            # A port can be taken; retry a fresh one a bounded number of times
+            # rather than skip, so a real bind fault still fails the test.
+            if attempts < 10:
+                bind()
+            else:
+                fail("mock server could not bind after {attempts} attempts: {error}")
+            return
+        c = swetcd.EtcdClient(connect_cap, "127.0.0.1", bind_port)
+        client = c
+        c.post("/v3/kv/range", {"key": RANGE_KEY_A}, on_first)
+
+    def timeout() -> None:
+        if done:
+            return
+        s = server
+        detail = ""
+        if s is not None:
+            fs = await async s.server_faults()
+            if len(fs) > 0:
+                detail = "; server faults: " + str(fs)
+        fail("timed out: first={got_first} second={got_second}{detail}")
+
+    bind()
+    after 10.0: timeout()
+
+
+actor etcd_client_poison_drains_pending(t: testing.EnvT):
+    """Poison fails every pending request in order, not just the head.
+
+    Two range requests are in flight when the server answers the first with a
+    transaction envelope. The client must fail both, in the order they were
+    sent, with the same out-of-sync error.
+    """
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    var attempts = 0
+    var bind_port = 0
+    var done = False
+    var got_a = False
+    var got_b = False
+    var a_before_b = False
+    var a_error: ?Exception = None
+    var b_error: ?Exception = None
+    var server: ?MockEtcdServer = None
+    var client: ?swetcd.EtcdClient = None
+
+    def drop(error: ?Exception) -> None:
+        pass
+
+    def teardown() -> None:
+        c = client
+        if c is not None:
+            c.close(drop)
+        s = server
+        if s is not None:
+            s.close()
+
+    def fail(message: str) -> None:
+        if done:
+            return
+        done = True
+        teardown()
+        t.failure(ValueError(message))
+
+    def succeed() -> None:
+        if done:
+            return
+        done = True
+        teardown()
+        t.success()
+
+    def verify() -> None:
+        if done:
+            return
+        if not got_a or not got_b:
+            fail("both callbacks must fire: a={got_a} b={got_b}")
+            return
+        ae = a_error
+        be = b_error
+        if ae is None or be is None:
+            fail("both pending requests must fail after a mismatch")
+            return
+        if not a_before_b:
+            fail("pending requests must fail in the order they were sent")
+            return
+        if "out of sync" not in str(ae):
+            fail("first error must report the desync: {ae}")
+            return
+        if "out of sync" not in str(be):
+            fail("second error must report the desync: {be}")
+            return
+        succeed()
+
+    def on_b(result: ?value, error: ?Exception) -> None:
+        if got_b:
+            fail("second callback fired twice")
+            return
+        got_b = True
+        b_error = error
+        # b arriving after a already fired is the FIFO order we require.
+        a_before_b = got_a
+        if got_a and got_b:
+            after 0.3: verify()
+
+    def on_a(result: ?value, error: ?Exception) -> None:
+        if got_a:
+            fail("first callback fired twice")
+            return
+        got_a = True
+        a_error = error
+        if got_a and got_b:
+            after 0.3: verify()
+
+    def bind() -> None:
+        attempts += 1
+        p = random.randint(20000, 45000)
+        bind_port = p
+        server = MockEtcdServer(listen_cap, p, TXN_ENVELOPE, on_ready)
+
+    def on_ready(error: ?str) -> None:
+        if error is not None:
+            if attempts < 10:
+                bind()
+            else:
+                fail("mock server could not bind after {attempts} attempts: {error}")
+            return
+        c = swetcd.EtcdClient(connect_cap, "127.0.0.1", bind_port)
+        client = c
+        # Post both before the first answer arrives so both are pending when
+        # the mismatch poisons the client.
+        c.post("/v3/kv/range", {"key": RANGE_KEY_A}, on_a)
+        c.post("/v3/kv/range", {"key": RANGE_KEY_B}, on_b)
+
+    def timeout() -> None:
+        if done:
+            return
+        s = server
+        detail = ""
+        if s is not None:
+            fs = await async s.server_faults()
+            if len(fs) > 0:
+                detail = "; server faults: " + str(fs)
+        fail("timed out: a={got_a} b={got_b}{detail}")
+
+    bind()
+    after 10.0: timeout()
+
+
+actor etcd_client_accepts_header_only_response(t: testing.EnvT):
+    """A header-only body answers a transaction request without poisoning.
+
+    etcd returns a header-only body for a transaction whose comparison failed,
+    so the client must pass it on and stay usable. A pre-fix client read the
+    absent succeeded/responses fields as a mismatch and poisoned itself, so the
+    second request failed instead of reaching the server.
+    """
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    var attempts = 0
+    var bind_port = 0
+    var done = False
+    var got_first = False
+    var got_second = False
+    var first_ok = False
+    var second_ok = False
+    var server: ?MockEtcdServer = None
+    var client: ?swetcd.EtcdClient = None
+
+    def drop(error: ?Exception) -> None:
+        pass
+
+    def teardown() -> None:
+        c = client
+        if c is not None:
+            c.close(drop)
+        s = server
+        if s is not None:
+            s.close()
+
+    def fail(message: str) -> None:
+        if done:
+            return
+        done = True
+        teardown()
+        t.failure(ValueError(message))
+
+    def succeed() -> None:
+        if done:
+            return
+        done = True
+        teardown()
+        t.success()
+
+    def verify() -> None:
+        if done:
+            return
+        s = server
+        if s is not None:
+            n = await async s.request_count()
+            if not got_first or not got_second:
+                fail("both callbacks must fire: first={got_first} second={got_second}")
+                return
+            if not first_ok or not second_ok:
+                fail("header-only answers must be accepted: first={first_ok} second={second_ok}")
+                return
+            if n != 2:
+                fail("both requests should reach the server: saw {n}")
+                return
+            succeed()
+
+    def on_second(result: ?value, error: ?Exception) -> None:
+        if got_second:
+            fail("second callback fired twice")
+            return
+        got_second = True
+        second_ok = result is not None and error is None
+        after 0.3: verify()
+
+    def on_first(result: ?value, error: ?Exception) -> None:
+        if got_first:
+            fail("first callback fired twice")
+            return
+        got_first = True
+        first_ok = result is not None and error is None
+        c = client
+        if c is not None:
+            c.post("/v3/kv/txn", {"compare": "AA=="}, on_second)
+
+    def bind() -> None:
+        attempts += 1
+        p = random.randint(20000, 45000)
+        bind_port = p
+        server = MockEtcdServer(listen_cap, p, HEADER_ONLY, on_ready)
+
+    def on_ready(error: ?str) -> None:
+        if error is not None:
+            if attempts < 10:
+                bind()
+            else:
+                fail("mock server could not bind after {attempts} attempts: {error}")
+            return
+        c = swetcd.EtcdClient(connect_cap, "127.0.0.1", bind_port)
+        client = c
+        c.post("/v3/kv/txn", {"compare": "AA=="}, on_first)
+
+    def timeout() -> None:
+        if done:
+            return
+        s = server
+        detail = ""
+        if s is not None:
+            fs = await async s.server_faults()
+            if len(fs) > 0:
+                detail = "; server faults: " + str(fs)
+        fail("timed out: first={got_first} second={got_second}{detail}")
+
+    bind()
+    after 10.0: timeout()
+
+
+actor etcd_client_unknown_path_does_not_strand_siblings(t: testing.EnvT):
+    """An unknown path fails its own request without stranding queued siblings.
+
+    response_kind rejects an unsupported path. Resolved while connected() drains
+    the queue, that raise would abort the loop and leave the requests behind it
+    with no callback. The kind is resolved when a request is posted instead, so
+    a bad path fails on its own and a valid request queued alongside it still
+    completes.
+    """
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    var attempts = 0
+    var bind_port = 0
+    var done = False
+    var got_bad = False
+    var got_good = False
+    var bad_error: ?Exception = None
+    var good_ok = False
+    var server: ?MockEtcdServer = None
+    var client: ?swetcd.EtcdClient = None
+
+    def drop(error: ?Exception) -> None:
+        pass
+
+    def teardown() -> None:
+        c = client
+        if c is not None:
+            c.close(drop)
+        s = server
+        if s is not None:
+            s.close()
+
+    def fail(message: str) -> None:
+        if done:
+            return
+        done = True
+        teardown()
+        t.failure(ValueError(message))
+
+    def succeed() -> None:
+        if done:
+            return
+        done = True
+        teardown()
+        t.success()
+
+    def verify() -> None:
+        if done:
+            return
+        if not got_bad or not got_good:
+            fail("both callbacks must fire: bad={got_bad} good={got_good}")
+            return
+        be = bad_error
+        if be is None:
+            fail("the unknown path must fail its own request")
+            return
+        if not good_ok:
+            fail("the valid sibling must still complete")
+            return
+        succeed()
+
+    def on_good(result: ?value, error: ?Exception) -> None:
+        if got_good:
+            fail("valid callback fired twice")
+            return
+        got_good = True
+        good_ok = result is not None and error is None
+        if got_bad and got_good:
+            after 0.3: verify()
+
+    def on_bad(result: ?value, error: ?Exception) -> None:
+        if got_bad:
+            fail("unknown-path callback fired twice")
+            return
+        got_bad = True
+        bad_error = error
+        if got_bad and got_good:
+            after 0.3: verify()
+
+    def bind() -> None:
+        attempts += 1
+        p = random.randint(20000, 45000)
+        bind_port = p
+        server = MockEtcdServer(listen_cap, p, RANGE_BODY, on_ready)
+
+    def on_ready(error: ?str) -> None:
+        if error is not None:
+            if attempts < 10:
+                bind()
+            else:
+                fail("mock server could not bind after {attempts} attempts: {error}")
+            return
+        # Both posted before connect: the unknown path must fail on its own and
+        # not take the valid request queued behind it down with it.
+        c = swetcd.EtcdClient(connect_cap, "127.0.0.1", bind_port)
+        client = c
+        c.post("/v3/kv/bogus", {"key": RANGE_KEY_A}, on_bad)
+        c.post("/v3/kv/range", {"key": RANGE_KEY_A}, on_good)
+
+    def timeout() -> None:
+        if done:
+            return
+        fail("timed out: bad={got_bad} good={got_good}")
+
+    bind()
+    after 10.0: timeout()


### PR DESCRIPTION
`EtcdClient` sends etcd requests through one `http.Client`. `http.Client` writes a request as soon as `post` is called, before the socket is connected, and on connect it rewrites everything still outstanding. A request posted before the connection is up can therefore go out twice, and etcd returns two responses for it. Responses match callbacks by arrival order, so the duplicate lands on the next request's callback.

`etcd_store_uses_callback_ranges_and_transactions` writes a transaction and then reads a key back in the write's callback. When the transaction is the first request on a fresh connection and is doubled, the second transaction response reaches the `get`, which finds no `kvs` and returns `None`. On a clean checkout it fails intermittently on the process's first run: about 7 of 16 originally, and still reproducible. With this change it passes 100 of 100 fresh-process runs.

This PR is `EtcdClient` and nothing else. Everything outside the transport that an earlier version of it carried is listed at the bottom.

## Queue until connected

Hold requests in `EtcdClient` until its `connected` callback fires, then send them in order, so nothing is outstanding when `http.Client` connects and there is nothing to resend. `ready` is cleared again on connection failure, on close, and when a response carries `Connection: close`, so a request started from a response callback waits for the replacement connection rather than being dispatched to one that is still connecting. Failure and close drain the queued requests along with the in-flight ones, in the order they were sent.

If the connection completes after the client is already closed or failed, `connected` closes it: `TCPConnection.close()` is a no-op while the connection is still in progress, so a store closed mid connect could otherwise leave the finished socket open.

## Fail on a mismatched response

Each pending request carries the kind of answer it expects, and only an unambiguous envelope is classified: a body with `succeeded` or `responses` is a transaction reply, one with `kvs`, `count`, or `more` is a range reply. A range request answered by a transaction envelope, or a transaction request answered by range results, belongs to the other request and means the response FIFO is out of sync. Rather than error just that operation and leave the client usable, which lets the next real answer land on the wrong callback, the client fails every pending and queued request, in the order they were sent, with one error and closes. It does not try to guess how many responses to drop to realign a shifted stream.

A header-only body is not a mismatch. etcd's JSON gateway omits default-valued fields, so it returns one both for an empty range and for a transaction it did not apply; the client passes it to the request at the head, which reads it as an empty range or an unapplied transaction. The earlier check read a header-only body as a non-transaction and so poisoned the client on any transaction etcd reported as unapplied. StratoWeave's writes compare on nothing and always apply, so that never fired in normal use, but a legitimate answer should not fail a healthy client.

**What this catches and what it does not.** The check fails closed on an unambiguous cross-family shift, and only on that. A header-only reply, and a shift within one family (a range answer landing on another range request, a transaction answer on another transaction), carry the same envelope as the right answer and cannot be told apart at this layer. A response arriving with nothing pending is dropped rather than treated as a desync, because a reconnect legitimately produces one. The reconnect path that can shift a response, where `http.Client` resends a request that was already in flight, is tracked in #530.

## Smaller fixes in the same paths

- The request kind is resolved when a request is posted, not when it is dispatched, so an unsupported path is rejected on its own `post`. Resolving it during the connect-time drain would raise inside the loop and leave the requests queued behind the bad one with no callback.
- A non-2xx body that is not valid UTF-8 completes its callback with the status instead of throwing inside the response handler.
- `failed()` closes the `http.Client`, as `poison()` does, rather than leave a dead connection open in a client that can no longer be used, and only on the first death, since `poison()` and `close()` have already closed it.
- A response arriving after `close` is dropped like one after a failure, and `post()` always completes its callback.

## Testing

`test_etcd_client` stands up a raw TCP server that replies with a canned body, so it runs in the normal suite with no etcd. It covers four behaviours:

- a range answered by a transaction envelope poisons the client, so a later request fails locally without reaching the server;
- with two requests in flight, the same mismatch fails both, in the order they were sent;
- a transaction answered by a header-only body is accepted, and the client stays usable for the next request;
- an unsupported path fails its own request while a valid request queued alongside it still completes.

Each test was checked by reverting the change it covers and rerunning:

| revert | red |
|---|---|
| drop the envelope check | both mismatch tests |
| poison fails only the head request instead of draining | the drain test alone, on a timeout: the second callback never fires |
| classify a header-only body as a range | the header-only test alone |
| resolve the request kind at dispatch instead of at post | the unknown-path test alone, on a timeout: the queued sibling is left with no callback |

The two mismatch tests share the check, so no single revert isolates the first one; the second is isolated by the drain revert. The server binds a random port with bounded retries and the tests fail on timeout, so a bind race or a dropped callback cannot pass silently; they run, not skip, under `acton test perf`.

One thing these cannot test deterministically is the double-send itself. It is a connect-timing race: it reproduced about 7 of 16 runs on one machine, but neither a looped integration run on CI nor removing the queue in a unit test reproduces it on demand. What the tests do cover is the cross-family check, and the queue path is exercised by every test here, since each posts before the connection is up.

- Full suite on this branch: 219 passed, 14 capability-gated skips, on acton `0.29.1.20260826.3.3`.
- etcd module against etcd v3.6.11 with raised transaction limits: brute-forced 900 of 900 fresh-process integration runs and 1200 of 1200 unit runs with no failures.

## Split out of this PR

Reviewing the store turned up more bugs in the same file, and an earlier version of this PR carried them. They are separate now, each following this one and reusing the test server it adds:

- `EtcdScan.seek_ge` reads the wrong row when a scan seeks back into the page it is holding, plus `end_key` force-unwrapping `None`.
- `EtcdGet` returns the value of whatever row comes back, without checking it is the key it asked for.
- `EtcdReader.close` does not wait for the scans it closes, and names them from state shared across actors.

Fixes #521
