### PR TITLE
Read operational state once with get_oper

### DIFF
--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -277,6 +277,13 @@ class DeviceAdapter(object):
 
     rpc: proc(cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None
 
+    ## Read device data once, narrowed by `filt`.
+    ##
+    ## The result may contain configuration, operational state, or both. For
+    ## callers that need a value now rather than a stream of updates. A
+    ## subscription is the better choice for anything watched continuously.
+    get: proc(cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode) -> None
+
     declare_subscriptions: proc(str, action(?ygdata.Node, ?Exception) -> None, set[ygdata.SubscriptionSpec]) -> None
     remove_subscriptions: proc(str) -> None
 
@@ -314,6 +321,9 @@ class NoAdapter(DeviceAdapter):
         pass
 
     def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
+        cb(None, NotConnectedError())
+
+    def get(self, cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
         cb(None, NotConnectedError())
 
     def declare_subscriptions(self, owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
@@ -361,6 +371,9 @@ class MockAdapter(DeviceAdapter):
 
     def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
         return self._driver.rpc(cb, gdata_rpc)
+
+    def get(self, cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
+        return self._driver.get(cb, filt)
 
     def declare_subscriptions(self, owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
         # TODO: can / should subscriptions do something on a MockAdapter ?
@@ -433,6 +446,10 @@ actor MockDriver(on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_sc
         return running_conf
 
     def rpc(cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
+        cb(ygdata.Container({}), None)
+
+    def get(cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
+        # The mock driver keeps no device data.
         cb(ygdata.Container({}), None)
 
 

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -1519,6 +1519,37 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             return _parse_data_node(r.children[0])
         return None
 
+    def get(cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
+        def on_get(c: netconf.Client, r: ?xml.Node, error: ?netconf.NetconfError):
+            if _is_stale(c):
+                cb(None, NotConnectedError())
+                return
+            if error is not None:
+                cb(None, error)
+                return
+            if r is None:
+                cb(None, NotConnectedError())
+                return
+            try:
+                parsed = _parse_get_reply(r)
+                if parsed is not None:
+                    cb(parsed, None)
+                else:
+                    cb(None, ValueError("Unexpected rpc-reply for get"))
+            except Exception as e:
+                cb(None, e)
+
+        if _oper_schema() is None:
+            cb(None, ValueError("Schema for operational data not found"))
+            return
+        filt_xml: ?xml.Node = None
+        if filt is not None:
+            filt_xml = _build_subtree_filter(filt)
+        if client is not None:
+            client.get(on_get, filt_xml)
+        else:
+            cb(None, NotConnectedError())
+
     def rpc(cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
         if len(gdata_rpc.children) != 1:
             cb(None, ValueError("gdata_rpc container must have exactly one child"))
@@ -1861,6 +1892,9 @@ class NetconfAdapter(DeviceAdapter):
 
     def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
         self._driver.rpc(cb, gdata_rpc)
+
+    def get(self, cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
+        self._driver.get(cb, filt)
 
     def declare_subscriptions(self, owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
         self._driver.declare_subscriptions(owner_id, cb, want)

--- a/src/device.act
+++ b/src/device.act
@@ -782,6 +782,12 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
     def rpc(cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node):
         adapter.rpc(cb, gdata_rpc)
 
+    def get(cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None):
+        """Read device data once, narrowed by `filt`. The result may contain
+        configuration, operational state, or both. Subscribe instead when the
+        value is watched continuously."""
+        adapter.get(cb, filt)
+
     def declare_subscriptions(owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
         adapter.declare_subscriptions(owner_id, cb, want)
 

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -238,6 +238,71 @@ actor _test_rpc(t: testing.EnvT):
     start()
 
 
+actor _test_get(t: testing.EnvT):
+    """One-shot device data read through the gdata path against the mock
+    NETCONF server, mapping to NETCONF <get>.
+
+    1. Create DeviceMgr in NETCONF mock-server mode.
+    2. Seed the mock operational datastore with both clock leaves.
+    3. Call DeviceMgr.get with a filter selecting current-datetime.
+    4. Validate that the reply carries current-datetime and nothing else.
+    """
+    mock_current_datetime = "2026-02-21T10:11:12Z"
+    mock_boot_datetime = "2026-02-20T08:00:00Z"
+
+    def noop_on_reconf(name: str):
+        pass
+    dev = new_netconf_mock_device_mgr(t, "dev-get", noop_on_reconf)
+    var done = False
+
+    def fail(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(ValueError(msg))
+
+    def on_get(r: ?ygdata.Node, err: ?Exception):
+        if done:
+            return
+        if err is not None:
+            fail("get failed: {err}")
+            return
+        if r is None:
+            fail("get returned no data")
+            return
+        current = _current_datetime_from_tree(r)
+        if current is None or current != mock_current_datetime:
+            fail("Unexpected current-datetime: {current}")
+            return
+        if _has_boot_datetime(r):
+            fail("get returned data outside the filter")
+            return
+        done = True
+        t.success()
+
+    def start():
+        if done:
+            return
+        if IETF_SYSTEM_MODULE not in dev.get_modules().0:
+            after 0.01: start()
+            return
+        msg = async dev.get_adapter()
+        adapter = await msg
+        if isinstance(adapter, swna.NetconfAdapter):
+            mock_server = adapter.get_mock_server()
+            if mock_server is not None:
+                mock_server.set_oper_ds(_mock_oper_ds(
+                    mock_current_datetime, mock_boot_datetime))
+                dev.get(on_get, _current_datetime_filter())
+            else:
+                fail("Expected NetconfMockServer from NetconfAdapter")
+        else:
+            fail("Expected NetconfAdapter from DeviceMgr")
+
+    start()
+    after 2.0: fail("Timed out waiting for the device data read")
+
+
 actor _test_subscribe_periodic(t: testing.EnvT):
     """Periodic subscription via NETCONF mock server.
 


### PR DESCRIPTION
DeviceAdapter and DeviceMgr gets get_oper which reads operational state narrowed by a filter and hands back gdata.

Closes #494 