### PR TITLE
Rpc fixes

### DIFF
--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -1536,11 +1536,16 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             cb(None, ValueError("Schema for rpc {rpc_id} not found"))
             return
         out_path = None
+        rpc_found = False
         for r in schema!.rpcs:
             if r.namespace == rpc_id.q and r.name == rpc_id.name:
+                rpc_found = True
                 if r.output is not None:
                     out_path = ["{r.module}:{r.name}", "output"]
                 break
+        if not rpc_found:
+            cb(None, ValueError("RPC {rpc_id} not found in schema"))
+            return
 
         def rpc_reply(c, r: ?xml.Node, error: ?netconf.NetconfError):
             if _is_stale(c):
@@ -1554,11 +1559,13 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                         cb(gd, None)
                     except Exception as e:
                         cb(None, e)
-                else:
+                elif len(r.children) == 1 and r.children[0].tag == "ok":
                     # The RPC has no modeled output: <ok/> is the whole reply.
                     # Complete with an empty tree rather than dropping the
                     # callback, which would hang the caller.
                     cb(ygdata.Container({}), None)
+                else:
+                    cb(None, ValueError("Unexpected rpc-reply for {rpc_id}"))
                 return
             cb(None, error)
 

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -527,7 +527,13 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
         elif op.tag == "commit" or op.tag == "discard-changes" or op.tag == "lock" or op.tag == "unlock":
             send_ok(s, message_id)
         elif op.tag in rpc_replies:
-            send_reply_with_log(s, message_id, rpc_replies[op.tag].to_xml(deterministic=True))
+            output = rpc_replies[op.tag].to_xml(deterministic=True)
+            if len(output) == 0:
+                # An RPC with no output answers <ok/> on a real device. An
+                # empty <rpc-reply> is not a valid reply.
+                send_ok(s, message_id)
+            else:
+                send_reply_with_log(s, message_id, output)
         else:
             send_error(s, message_id, "operation-not-supported", "Unsupported RPC operation: {op.tag}")
 
@@ -1548,10 +1554,22 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                         cb(gd, None)
                     except Exception as e:
                         cb(None, e)
+                else:
+                    # The RPC has no modeled output: <ok/> is the whole reply.
+                    # Complete with an empty tree rather than dropping the
+                    # callback, which would hang the caller.
+                    cb(ygdata.Container({}), None)
                 return
             cb(None, error)
 
-        xml_rpc = gdata_rpc.to_xml()[0]
+        # Build the operation element ourselves, named and namespaced from
+        # the RPC's schema id. Serializing gdata_rpc directly would drop the
+        # namespace: gdata reads xmlns from the container's ns field, which
+        # callers leave unset, and an element without xmlns inherits the
+        # NETCONF base namespace inside <rpc>. The child container
+        # serializes to just the input elements (empty for an RPC with no
+        # input).
+        xml_rpc = xml.Node(rpc_id.name, nsdefs=[(None, rpc_id.q)], children=gdata_rpc.children[rpc_id].to_xml())
         _log.debug("Device.rpc", {"xml_rpc": xml_rpc})
         if client is not None:
             client.rpc(xml_rpc, rpc_reply)

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -35,6 +35,8 @@ IETF_SYSTEM_YANG = r"""module ietf-system {
       }
     }
   }
+  rpc system-restart {
+  }
   rpc set-clock {
     input {
       leaf new-datetime {
@@ -236,6 +238,60 @@ actor _test_rpc(t: testing.EnvT):
             fail("Expected NetconfAdapter from DeviceMgr")
 
     start()
+
+
+actor _test_rpc_without_output(t: testing.EnvT):
+    """An RPC whose model declares no output still completes.
+
+    1. Create DeviceMgr in NETCONF mock-server mode.
+    2. Register an empty reply for system-restart, which has no output.
+    3. Call DeviceMgr.rpc and expect the callback to run without an error.
+    """
+    def noop_on_reconf(name: str):
+        pass
+    dev = new_netconf_mock_device_mgr(t, "dev-rpc-no-output", noop_on_reconf)
+    var done = False
+
+    def fail(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(ValueError(msg))
+
+    def on_reply(r: ?ygdata.Node, err: ?Exception):
+        if done:
+            return
+        if err is not None:
+            fail("system-restart RPC failed: {err}")
+            return
+        if r is None:
+            fail("system-restart RPC returned no tree")
+            return
+        done = True
+        t.success()
+
+    def start():
+        if done:
+            return
+        if IETF_SYSTEM_MODULE not in dev.get_modules().0:
+            after 0.01: start()
+            return
+        msg = async dev.get_adapter()
+        adapter = await msg
+        if isinstance(adapter, swna.NetconfAdapter):
+            mock_server = adapter.get_mock_server()
+            if mock_server is not None:
+                mock_server.set_rpc_reply("system-restart", ygdata.Container({}))
+                dev.rpc(on_reply, ygdata.Container({
+                    _q("system-restart"): ygdata.Container({})
+                }))
+            else:
+                fail("Expected NetconfMockServer from NetconfAdapter")
+        else:
+            fail("Expected NetconfAdapter from DeviceMgr")
+
+    start()
+    after 2.0: fail("Timed out waiting for the RPC callback")
 
 
 actor _test_subscribe_periodic(t: testing.EnvT):


### PR DESCRIPTION
An RPC with no output never completed: the reply handler had no branch
for it, so the caller waited forever. It now completes with an empty
tree, like the mock driver. An RPC with no input never got sent: empty
input serializes to no XML, and taking the first element of the empty
result raised IndexError.

The operation element is now built from the RPC's schema id: name,
namespace, and the serialized input as children (empty for no input).
This also fixes RPCs going out without xmlns and inheriting the NETCONF
base namespace, which a conforming device rejects: gdata reads xmlns
from the container's ns field, which callers never set. The mock server
matches on tag only, so tests never saw it.

The mock server answers a registered empty output with <ok/>; an empty
<rpc-reply> is not a valid reply.

The no-output branch fired whenever the schema lookup found no match,
reporting an unknown RPC as success and dropping any output the device
sent. Error out before sending instead, and accept only an actual
<ok/> as a no-output success.