### PR TITLE
Run the etcd integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,59 @@ jobs:
       # notconf is stateful and module tests are sensitive to parallel/retry runs
       - run: acton test --tag notconf-server --module netconf --jobs 1 --min-iter 1 --max-iter 1
 
+  etcd:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actonlang/setup-acton@v1
+        with:
+          channel: 'tip'
+      - name: "Check out repository code"
+        uses: actions/checkout@v4
+      - name: "Start etcd in background"
+        run: |
+          docker run -d --name etcd --publish 2379:2379 \
+            gcr.io/etcd-development/etcd:v3.6.11 \
+            /usr/local/bin/etcd \
+            --name s1 \
+            --data-dir /tmp/etcd-data \
+            --listen-client-urls http://0.0.0.0:2379 \
+            --advertise-client-urls http://0.0.0.0:2379 \
+            --listen-peer-urls http://0.0.0.0:2380 \
+            --initial-advertise-peer-urls http://0.0.0.0:2380 \
+            --initial-cluster s1=http://0.0.0.0:2380 \
+            --initial-cluster-state new \
+            --max-txn-ops 100000 \
+            --max-request-bytes 104857600 \
+            --quota-backend-bytes 8589934592 \
+            --auto-compaction-mode periodic \
+            --auto-compaction-retention 10m
+      - name: "Wait for etcd"
+        run: |
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:2379/health | grep -q '"health":"true"'; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs etcd
+          exit 1
+      # The race showed on the first request of a fresh process, so run the
+      # module ten times, each a new process, with the cache off.
+      - name: "Run etcd integration tests"
+        run: |
+          for i in $(seq 1 10); do
+            echo "::group::etcd test run $i/10"
+            acton test --tag etcd --module test_ttt_persistence_etcd --jobs 1 --min-iter 1 --max-iter 1 --no-cache
+            echo "::endgroup::"
+          done
+      - name: "etcd logs on failure"
+        if: failure()
+        run: docker logs etcd
+      - name: "Remove etcd"
+        if: always()
+        run: docker rm -f etcd
+
   ncurl:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The etcd persistence tests are tagged `etcd` and need a running etcd, so the default `acton test` skips them and CI never exercises the store. The flake in #521, fixed by #523, is exactly the kind of regression these tests catch, so it helps to run them in CI.

This adds an `etcd` job that mirrors the existing `notconf` job: it starts etcd in a container, waits until it answers `/health`, and runs the tagged module. It runs on pushes to `main` and on pull requests to `main`, using the triggers #531 added.

## etcd settings

A TTT commit is one etcd transaction with an operation per changed record, and etcd's defaults (128 operations and 1.5 MB per transaction) are far below a real commit. The container raises `--max-txn-ops` and `--max-request-bytes`, matching the settings `test_ttt_persistence_etcd` already documents.

## Run each test in a fresh process

Like the `notconf` job, the tests run with `--jobs 1 --min-iter 1 --max-iter 1` because they share one etcd endpoint. The flake they guard against showed on the first request of a fresh process and reproduced about 7 runs in 16, so a single pass would often miss it. The job runs the module ten times, each a new process, with `--no-cache` so a cached result never stands in for a real reconnect. It is capped at fifteen minutes, always removes the container, and dumps etcd logs if a run fails.

## Merge order

This job exercises the store that #523 fixes, so it reads best merged after #523. The race is timing-sensitive: it reproduced about 7 runs in 16 on the machine in #521, but ten fresh runs on this CI runner all passed, so the loop gives the race repeated chances to surface without guaranteeing it every time. The deterministic proof of the fix is #523's `test_etcd_client`, and with #523 in, the store is reliable by construction; against #523's branch the module also passes 100 of 100 fresh-process runs locally. Merge #523 first, then rebase this onto `main`.
