### PR TITLE
Run CI for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
 
 env:
   # ncurl ships as a standalone artifact under its own name even though it now


### PR DESCRIPTION
CI only listens for push events, so GitHub never queues it for pull requests from forks even after a maintainer approves Actions.

Change to trigger on pushes to main and pull requests targeting main.