### PR TITLE
Let NETCONF mock server RPCs be handled by a callback

### DIFF
--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -311,8 +311,9 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
     var oper_ds = ygdata.Container({})
     var conf_ds = ygdata.Container({})
     var rpc_log: list[(message_id: str, op: xml.Node)] = []
-    # Static mock RPC replies, set with set_rpc_reply(...)
-    var rpc_replies: dict[str, ygdata.Node] = {}
+    # Callback for every RPC the mock server does not implement itself,
+    # installed with set_rpc_cb(...).
+    var rpc_cb: ?action(xml.Node, action(?list[xml.Node], ?str, ?str) -> None) -> None = None
     # YANG-push: the last operational tree pushed, to diff against for on-change.
     var _yp_last: ?ygdata.Node = None
     var yp_service: ?nyp.NetconfSubscriptionService = None
@@ -526,10 +527,19 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
             send_ok(s, message_id)
         elif op.tag == "commit" or op.tag == "discard-changes" or op.tag == "lock" or op.tag == "unlock":
             send_ok(s, message_id)
-        elif op.tag in rpc_replies:
-            send_reply_with_log(s, message_id, rpc_replies[op.tag].to_xml(deterministic=True))
         else:
-            send_error(s, message_id, "operation-not-supported", "Unsupported RPC operation: {op.tag}")
+            h = rpc_cb
+            if h is not None:
+                def done(children: ?list[xml.Node], error_tag: ?str, error_msg: ?str) -> None:
+                    if error_tag is not None:
+                        send_error(s, message_id, error_tag, str(error_msg))
+                    elif children is not None:
+                        send_reply_with_log(s, message_id, children)
+                    else:
+                        send_ok(s, message_id)
+                h(op, done)
+            else:
+                send_error(s, message_id, "operation-not-supported", "Unsupported RPC operation: {op.tag}")
 
     var server: netconf.Server = netconf.Server(pipe=pipe, on_rpc=on_rpc, log_handler=log_handler, capabilities=all_capabilities)
     yp_service = nyp.NetconfSubscriptionService(server, _MockPushBackend(_yp_prepare_filter, _yp_snapshot, _yp_change), log_handler)
@@ -552,9 +562,32 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
             conf_schema = schema
             yl_view = monitoring.build_yl_view([conf_schema, oper_schema])
 
-    def set_rpc_reply(tag: str, output: ygdata.Node):
-        """Register a static RPC output."""
-        rpc_replies[tag] = output
+    def set_rpc_cb(cb: action(xml.Node, action(?list[xml.Node], ?str, ?str) -> None) -> None):
+        """Install the callback for every RPC the mock server does not implement.
+
+        The mock server answers the datastore RPCs itself: get, get-config,
+        edit-config, commit, discard-changes, lock, unlock and the subscription
+        RPCs. Everything else goes to this callback, which is called with the
+        request element and a `done` action and answers whenever it is ready:
+
+            done(children, None, None)    reply with these rpc-reply children
+            done(None, None, None)        reply <ok/>
+            done(None, tag, message)      reply with an rpc-error
+
+        One callback rather than one per RPC tag, because what sits behind it
+        is a mock of a device: it decides what it supports and dispatches on
+        the request itself, the same way a real device does. Because it also
+        holds state of its own, it can model a real sequence, such as an
+        install that only succeeds after the image was added, or an activate
+        that changes what a later get reports.
+
+        Request and reply are raw XML on purpose. Mocks are usually written
+        from debug dumps of real NETCONF sessions, which paste in verbatim as
+        XML, and only XML can express a malformed reply for testing how the
+        client copes. Where a typed reply reads better, build it as gdata and
+        convert with to_xml(deterministic=True).
+        """
+        rpc_cb = cb
 
 
 actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler: logging.Handler, connect_cap: ?net.TCPConnectCap):

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -3,6 +3,7 @@
 import logging
 import net
 import testing
+import std.xml as xml
 import yang
 import yang.gdata as ygdata
 import yang.schema as yschema
@@ -171,7 +172,7 @@ actor _test_rpc(t: testing.EnvT):
     """YANG RPC through the gdata path against the mock NETCONF server.
 
     1. Create DeviceMgr in NETCONF mock-server mode.
-    2. Register a canned rpc-reply for set-clock on the mock server.
+    2. Install an RPC handler on the mock server answering set-clock.
     3. Call DeviceMgr.rpc with the RPC as gdata: a root container holding the
        set-clock node with its input subtree.
     4. Validate the RPC output gdata (old-datetime) parsed from the reply.
@@ -221,15 +222,123 @@ actor _test_rpc(t: testing.EnvT):
         if isinstance(adapter, swna.NetconfAdapter):
             mock_server = adapter.get_mock_server()
             if mock_server is not None:
-                mock_server.set_rpc_reply("set-clock", ygdata.Container({
-                    _q("old-datetime"): ygdata.Leaf(mock_old_datetime, ns=IETF_SYSTEM_NS, module=IETF_SYSTEM_MODULE)
-                }))
+                def on_rpc(request: xml.Node, reply: action(?list[xml.Node], ?str, ?str) -> None) -> None:
+                    if request.tag == "set-clock":
+                        out = ygdata.Container({
+                            _q("old-datetime"): ygdata.Leaf(mock_old_datetime, ns=IETF_SYSTEM_NS, module=IETF_SYSTEM_MODULE)
+                        })
+                        reply(out.to_xml(deterministic=True), None, None)
+                    else:
+                        reply(None, "operation-not-supported", "mock does not do {request.tag}")
+                mock_server.set_rpc_cb(on_rpc)
                 rpc_gdata = ygdata.Container({
                     _q("set-clock"): ygdata.Container({
                         _q("new-datetime"): ygdata.Leaf("2026-03-01T00:00:00Z")
                     })
                 })
                 dev.rpc(on_reply, rpc_gdata)
+            else:
+                fail("Expected NetconfMockServer from NetconfAdapter")
+        else:
+            fail("Expected NetconfAdapter from DeviceMgr")
+
+    start()
+
+
+actor _test_rpc_cb_sees_request_and_keeps_state(t: testing.EnvT):
+    """RPC callback on the mock server, installed with set_rpc_cb.
+
+    The callback is called with the request and a done action, so unlike a
+    canned reply it can look at what was asked and answer differently each
+    time. Here
+    the first set-clock is refused and the second echoes back the datetime it
+    was actually given, which a static reply cannot do.
+
+    The reply is built by pasting XML the way it would come off a real NETCONF
+    session, which is the usual way these mocks get written.
+
+    1. Create DeviceMgr in NETCONF mock-server mode.
+    2. Install an RPC callback answering set-clock, failing once first.
+    3. Call DeviceMgr.rpc twice and check we get the error then the echo.
+    """
+    sent_datetime = "2026-03-01T00:00:00Z"
+
+    def noop_on_reconf(name: str):
+        pass
+    dev = new_netconf_mock_device_mgr(t, "dev-rpc-handler", noop_on_reconf)
+    var done = False
+    var calls = 0
+
+    def fail(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(ValueError(msg))
+
+    def rpc_gdata() -> ygdata.Node:
+        return ygdata.Container({
+            _q("set-clock"): ygdata.Container({
+                _q("new-datetime"): ygdata.Leaf(sent_datetime)
+            })
+        })
+
+    def on_rpc(request: xml.Node, reply: action(?list[xml.Node], ?str, ?str) -> None) -> None:
+        if request.tag != "set-clock":
+            reply(None, "operation-not-supported", "mock does not do {request.tag}")
+            return
+        calls += 1
+        if calls == 1:
+            reply(None, "operation-failed", "clock is busy")
+            return
+        got = ""
+        for child in request.children:
+            if child.tag == "new-datetime":
+                txt = child.text
+                if txt is not None:
+                    got = txt
+        if got == "":
+            reply(None, "missing-element", "no new-datetime in request")
+            return
+        captured = "<old-datetime xmlns=\"{IETF_SYSTEM_NS}\">{got}</old-datetime>"
+        reply([xml.decode(captured)], None, None)
+
+    def on_second_reply(r: ?ygdata.Node, err: ?Exception):
+        if done:
+            return
+        if err is not None:
+            fail("Second set-clock should have succeeded: {err}")
+            return
+        if r is not None:
+            echoed = r.get_opt_str(_q("old-datetime"))
+            if echoed is not None and echoed == sent_datetime:
+                done = True
+                t.success()
+            else:
+                fail("Callback did not echo the requested datetime, got {echoed}")
+        else:
+            fail("Second set-clock returned no output")
+
+    def on_first_reply(r: ?ygdata.Node, err: ?Exception):
+        if done:
+            return
+        if err is None:
+            fail("First set-clock should have been refused")
+            return
+        dev.rpc(on_second_reply, rpc_gdata())
+
+    def start():
+        if done:
+            return
+        if IETF_SYSTEM_MODULE not in dev.get_modules().0:
+            after 0.01: start()
+            return
+        msg = async dev.get_adapter()
+        adapter = await msg
+        if isinstance(adapter, swna.NetconfAdapter):
+            mock_server = adapter.get_mock_server()
+            if mock_server is not None:
+                mock_server.set_rpc_cb(on_rpc)
+                dev.rpc(on_first_reply, rpc_gdata())
             else:
                 fail("Expected NetconfMockServer from NetconfAdapter")
         else:


### PR DESCRIPTION
Mock RPC replies via set_rpc_reply were canned per tag, so a reply could not depend on the request or on anything that happened earlier. That is enough to check that an RPC round trips, but not to model a real device operation such as a software upgrade, where install, activate and commit each depend on the state the previous one left behind.

set_rpc_cb(cb) installs a single callback for every RPC the mock server does not implement itself, called with the request element and a done action. One callback rather than one per tag, because what sits behind it is a mock of a device: it decides what it supports and dispatches on the request itself, the way a real device does.

Request and reply stay raw XML. Mocks are usually written from debug dumps of real NETCONF sessions, which paste in verbatim as XML, and only XML can express a malformed reply for testing how the client copes.