### PR TITLE
Answer mock server RPCs with a single respond action

### DIFF
--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -313,7 +313,7 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
     var rpc_log: list[(message_id: str, op: xml.Node)] = []
     # Callback for every RPC the mock server does not implement itself,
     # installed with set_rpc_cb(...).
-    var rpc_cb: ?action(xml.Node, action(?list[xml.Node], ?str, ?str) -> None) -> None = None
+    var rpc_cb: ?action(xml.Node, action(children: ?list[xml.Node], tag: ?str, message: ?str) -> None) -> None = None
     # YANG-push: the last operational tree pushed, to diff against for on-change.
     var _yp_last: ?ygdata.Node = None
     var yp_service: ?nyp.NetconfSubscriptionService = None
@@ -513,12 +513,13 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
         else:
             h = rpc_cb
             if h is not None:
-                def done(children: ?list[xml.Node], error_tag: ?str, error_msg: ?str) -> None:
-                    if error_tag is not None:
-                        s.send_error(message_id, error_tag, str(error_msg))
+                def respond(children: ?list[xml.Node], tag: ?str, message: ?str) -> None:
+                    if tag is not None:
+                        s.send_error(message_id, tag,
+                                     message if message is not None else tag)
                     else:
                         s.send_reply(message_id, children if children is not None else [])
-                h(op, done)
+                h(op, respond)
             else:
                 s.send_error(message_id, "operation-not-supported", "Unsupported RPC operation: {op.tag}")
 
@@ -543,18 +544,26 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
             conf_schema = schema
             yl_view = monitoring.build_yl_view([conf_schema, oper_schema])
 
-    def set_rpc_cb(cb: action(xml.Node, action(?list[xml.Node], ?str, ?str) -> None) -> None):
+    def set_rpc_cb(cb: action(xml.Node, action(children: ?list[xml.Node], tag: ?str, message: ?str) -> None) -> None):
         """Install the callback for every RPC the mock server does not implement.
 
         The mock server answers the datastore RPCs itself: get, get-config,
         edit-config, commit, discard-changes, lock, unlock and the subscription
         RPCs. Everything else goes to this callback, which is called with the
-        request element and a `done` action and answers whenever it is ready:
+        request element and a `respond` action, and answers when it is ready:
 
-            done(children, None, None)    reply with these rpc-reply children;
-                                          an empty list becomes <ok/>
-            done(None, None, None)        same as an empty list
-            done(None, tag, message)      reply with an rpc-error
+            respond([node])                     reply with these children
+            respond([])                         reply <ok/>
+            respond(tag="invalid-value",
+                    message="no such image")    reply with an rpc-error
+
+        Arguments are optional and named, so each call says only what it
+        means. A `tag` makes it an rpc-error and any children are ignored;
+        without one it is a reply, and no children means <ok/>.
+
+        Answer exactly once. Never answering leaves the session waiting,
+        since RFC 6241 dispatch is serialized and the next RPC only runs
+        once this one is answered.
 
         One callback rather than one per RPC tag, because what sits behind it
         is a mock of a device: it decides what it supports and dispatches on

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -229,14 +229,16 @@ actor _test_rpc(t: testing.EnvT):
         if isinstance(adapter, swna.NetconfAdapter):
             mock_server = adapter.get_mock_server()
             if mock_server is not None:
-                def on_rpc(request: xml.Node, reply: action(?list[xml.Node], ?str, ?str) -> None) -> None:
+                def on_rpc(request: xml.Node,
+                           respond: action(children: ?list[xml.Node], tag: ?str, message: ?str) -> None) -> None:
                     if request.tag == "set-clock":
                         out = ygdata.Container({
                             _q("old-datetime"): ygdata.Leaf(mock_old_datetime, ns=IETF_SYSTEM_NS, module=IETF_SYSTEM_MODULE)
                         })
-                        reply(out.to_xml(deterministic=True), None, None)
+                        respond(out.to_xml(deterministic=True))
                     else:
-                        reply(None, "operation-not-supported", "mock does not do {request.tag}")
+                        respond(tag="operation-not-supported",
+                                message="mock does not do {request.tag}")
                 mock_server.set_rpc_cb(on_rpc)
                 rpc_gdata = ygdata.Container({
                     _q("set-clock"): ygdata.Container({
@@ -287,13 +289,15 @@ actor _test_rpc_without_output(t: testing.EnvT):
         if isinstance(adapter, swna.NetconfAdapter):
             mock_server = adapter.get_mock_server()
             if mock_server is not None:
-                def on_rpc(request: xml.Node, reply: action(?list[xml.Node], ?str, ?str) -> None) -> None:
+                def on_rpc(request: xml.Node,
+                           respond: action(children: ?list[xml.Node], tag: ?str, message: ?str) -> None) -> None:
                     if request.tag == "set-current-datetime":
                         # An empty successful result is normalized to <ok/> by
                         # netconf.Server before it is sent on the wire.
-                        reply([], None, None)
+                        respond([])
                     else:
-                        reply(None, "operation-not-supported", "mock does not do {request.tag}")
+                        respond(tag="operation-not-supported",
+                                message="mock does not do {request.tag}")
                 mock_server.set_rpc_cb(on_rpc)
                 dev.rpc(on_reply, ygdata.Container({
                     _q("set-current-datetime"): ygdata.Container({
@@ -330,13 +334,13 @@ actor _test_rpc_cb_sees_request_and_keeps_state(t: testing.EnvT):
     def noop_on_reconf(name: str):
         pass
     dev = new_netconf_mock_device_mgr(t, "dev-rpc-handler", noop_on_reconf)
-    var done = False
+    var finished = False
     var calls = 0
 
     def fail(msg: str):
-        if done:
+        if finished:
             return
-        done = True
+        finished = True
         t.failure(ValueError(msg))
 
     def rpc_gdata() -> ygdata.Node:
@@ -346,13 +350,15 @@ actor _test_rpc_cb_sees_request_and_keeps_state(t: testing.EnvT):
             })
         })
 
-    def on_rpc(request: xml.Node, reply: action(?list[xml.Node], ?str, ?str) -> None) -> None:
+    def on_rpc(request: xml.Node,
+               respond: action(children: ?list[xml.Node], tag: ?str, message: ?str) -> None) -> None:
         if request.tag != "set-clock":
-            reply(None, "operation-not-supported", "mock does not do {request.tag}")
+            respond(tag="operation-not-supported",
+                    message="mock does not do {request.tag}")
             return
         calls += 1
         if calls == 1:
-            reply(None, "operation-failed", "clock is busy")
+            respond(tag="operation-failed", message="clock is busy")
             return
         got = ""
         for child in request.children:
@@ -361,13 +367,13 @@ actor _test_rpc_cb_sees_request_and_keeps_state(t: testing.EnvT):
                 if txt is not None:
                     got = txt
         if got == "":
-            reply(None, "missing-element", "no new-datetime in request")
+            respond(tag="missing-element", message="no new-datetime in request")
             return
         captured = "<old-datetime xmlns=\"{IETF_SYSTEM_NS}\">{got}</old-datetime>"
-        reply([xml.decode(captured)], None, None)
+        respond([xml.decode(captured)])
 
     def on_second_reply(r: ?ygdata.Node, err: ?Exception):
-        if done:
+        if finished:
             return
         if err is not None:
             fail("Second set-clock should have succeeded: {err}")
@@ -375,7 +381,7 @@ actor _test_rpc_cb_sees_request_and_keeps_state(t: testing.EnvT):
         if r is not None:
             echoed = r.get_opt_str(_q("old-datetime"))
             if echoed is not None and echoed == sent_datetime:
-                done = True
+                finished = True
                 t.success()
             else:
                 fail("Callback did not echo the requested datetime, got {echoed}")
@@ -383,15 +389,21 @@ actor _test_rpc_cb_sees_request_and_keeps_state(t: testing.EnvT):
             fail("Second set-clock returned no output")
 
     def on_first_reply(r: ?ygdata.Node, err: ?Exception):
-        if done:
+        if finished:
             return
         if err is None:
             fail("First set-clock should have been refused")
             return
+        # Specifically the callback's refusal, not the operation-not-supported
+        # the mock server sends when nothing handles an RPC. Without this the
+        # test would pass even if the callback were never installed.
+        if "clock is busy" not in str(err):
+            fail("Expected the callback's rpc-error, got: {err}")
+            return
         dev.rpc(on_second_reply, rpc_gdata())
 
     def start():
-        if done:
+        if finished:
             return
         if IETF_SYSTEM_MODULE not in dev.get_modules().0:
             after 0.01: start()


### PR DESCRIPTION
Three positional arguments meant every call site was mostly None, and an error with no message stringified the absent optional into a literal "None" in <error-message>. Optional parameters can be omitted in a keyword call, so one action still reads well:

    respond([node])                       reply with these children
    respond([])                           reply <ok/>
    respond(tag="invalid-value",
            message="no such image")      reply with an rpc-error

Also assert on the callback's own rpc-error in the mock RPC test, which otherwise passes even when the callback is never installed.