### PR TITLE
Reject RPCs missing from device schema

### DIFF
--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -1575,12 +1575,18 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         if schema is None:
             cb(None, ValueError("Schema for rpc {rpc_id} not found"))
             return
-        out_path = None
+        rpc_def = None
         for r in schema!.rpcs:
             if r.namespace == rpc_id.q and r.name == rpc_id.name:
-                if r.output is not None:
-                    out_path = ["{r.module}:{r.name}", "output"]
+                rpc_def = r
                 break
+        if rpc_def is None:
+            cb(None, ValueError("RPC {rpc_id} not found in device schema"))
+            return
+
+        out_path = None
+        if rpc_def!.output is not None:
+            out_path = ["{rpc_def!.module}:{rpc_def!.name}", "output"]
 
         def rpc_reply(c, r: ?xml.Node, error: ?netconf.NetconfError):
             if _is_stale(c):
@@ -1590,9 +1596,9 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             if r is not None and error is None:
                 if netconf.is_ok_reply(r):
                     cb(ygdata.Container({}), None)
-                elif out_path is not None and schema is not None:
+                elif out_path is not None:
                     try:
-                        gd = yxml.from_xml(schema, r, loose=True, root_path=out_path)
+                        gd = yxml.from_xml(schema!, r, loose=True, root_path=out_path)
                         cb(gd, None)
                     except Exception as e:
                         cb(None, e)

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -386,6 +386,61 @@ actor _test_rpc_without_input(t: testing.EnvT):
     after 2.0: fail("Timed out waiting for the RPC callback")
 
 
+actor _test_rpc_missing_from_schema(t: testing.EnvT):
+    """An RPC absent from the device schema is rejected before transport."""
+    def noop_on_reconf(name: str):
+        pass
+    dev = new_netconf_mock_device_mgr(t, "dev-rpc-missing-schema", noop_on_reconf)
+    var done = False
+
+    def fail(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(ValueError(msg))
+
+    def on_reply(r: ?ygdata.Node, err: ?Exception):
+        if done:
+            return
+        if r is not None:
+            fail("Unknown RPC returned data: {r}")
+        elif err is None:
+            fail("Unknown RPC unexpectedly succeeded")
+        elif "not found in device schema" not in str(err):
+            fail("Unknown RPC returned an unexpected error: {err}")
+        else:
+            def succeed_if_not_sent():
+                if not done:
+                    done = True
+                    t.success()
+            after 0.05: succeed_if_not_sent()
+
+    def start():
+        if done:
+            return
+        if IETF_SYSTEM_MODULE not in dev.get_modules().0:
+            after 0.01: start()
+            return
+        msg = async dev.get_adapter()
+        adapter = await msg
+        if isinstance(adapter, swna.NetconfAdapter):
+            mock_server = adapter.get_mock_server()
+            if mock_server is not None:
+                def on_rpc(request: xml.Node, reply: action(?list[xml.Node], ?str, ?str) -> None) -> None:
+                    fail("Unknown RPC reached the NETCONF server")
+                mock_server.set_rpc_cb(on_rpc)
+                dev.rpc(on_reply, ygdata.Container({
+                    _q("not-modeled"): ygdata.Container({})
+                }))
+            else:
+                fail("Expected NetconfMockServer from NetconfAdapter")
+        else:
+            fail("Expected NetconfAdapter from DeviceMgr")
+
+    start()
+    after 2.0: fail("Timed out waiting for the RPC callback")
+
+
 actor _test_rpc_cb_sees_request_and_keeps_state(t: testing.EnvT):
     """RPC callback on the mock server, installed with set_rpc_cb.
 


### PR DESCRIPTION
The RPC output path is derived from the device schema, but a missing RPC and a modeled RPC without output both left out_path unset.  The former could therefore be sent despite the typed request/reply contract being unknown.

Keep the matched RPC definition, reject missing definitions before transport, and derive the output path from the match.