### PR TITLE
Link update race

### DIFF
--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -1021,7 +1021,7 @@ actor link_update_racing_subscriber_commit_is_kept(t: testing.AsyncT):
     # distance the production stack provides. The interleaving under test
     # stays pinned by per-sender FIFO ordering.
     def cont5b():
-        out2.apply("t2")
+        await async out2.apply("t2")
         sink.lock("t2", None, cont6)
 
     def cont5(_r: value):
@@ -1050,7 +1050,7 @@ actor link_update_racing_subscriber_commit_is_kept(t: testing.AsyncT):
         sink.wait_complete("t1", cont3b)
 
     def cont2b():
-        out1.apply("t1")
+        await async out1.apply("t1")
         sink.lock("t1", None, cont3)
 
     def cont2(_r: value):
@@ -1066,7 +1066,7 @@ actor link_update_racing_subscriber_commit_is_kept(t: testing.AsyncT):
     res = gs.linkage("t1", reqs, no_upds, out1)
     upds = [u.tail().tail().tail() for u in res.updates]
     r1.linkage("t1", no_reqs, upds, out1)
-    out1.apply("t1")
+    await async out1.apply("t1")
     gs.lock("t1", out1, cont1)
 ########################
 

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -949,6 +949,129 @@ actor link_subscriber_in_list_re_runs_on_publisher_update(t: testing.AsyncT):
 ########################
 
 
+# Commit fans out asynchronously through each session's container and list
+# transactions, so a following transaction can reach the shared transform
+# transactions while the previous transaction's commit is still in flight to
+# some of them. Config state survives such overlap: the commit invalidates
+# the candidate and the preserved diff re-configures at lock time against the
+# freshly committed base. The linked tree must survive it the same way: here
+# the publisher has seen tx1's commit when tx2 arrives, so it publishes an
+# update, but the subscriber has not, so the update reaches the subscriber
+# before the subscription it belongs to has committed there. The update must
+# still be in effect when the subscriber's lock-time re-configure recomputes
+# its output. Driving the transform transactions directly from the test actor
+# pins the delivery order (per-sender FIFO) that the production stack leaves
+# to scheduling. The container and list transactions route linkage messages
+# by peeling one path level per hop, so the test peels the same levels. The
+# sink transform stands in for the lower layer; the out sessions' apply
+# before it locks is the sweep of late output pushes that Session.lock
+# performs.
+actor link_update_racing_subscriber_commit_is_kept(t: testing.AsyncT):
+    root_path = ttt.PathRoot("top")
+    network_path = ttt.PathElem(q("network"), root_path)
+    gs_path = ttt.PathElem(q("global-settings"), network_path)
+    router_path = ttt.PathElem(q("router"), network_path)
+    r1_keys: dict[gdata.Id, gdata.Node] = {q("name"): gdata.Leaf("r1"), q("id"): gdata.Leaf(1)}
+    r1_keystr = gdata.Container(r1_keys).key_str([q("name"), q("id")])
+    r1_path = ttt.PathKey(r1_keystr, router_path, r1_keys)
+
+    gs_node = ttt.Transform(ttt.PassThrough) (gs_path, None)
+    r1_node = ttt.Transform(LinkedAsnSubscriber, None, _link_to_global_settings) (r1_path, None)
+    sink_node = ttt.Transform(ttt.PassThrough) (ttt.PathRoot("sink"), None)
+    gs = gs_node.newtrans()
+    r1 = r1_node.newtrans()
+    sink = sink_node.newtrans()
+
+    out1 = ttt.Session("out1", sink_node, None, None)
+    out2 = ttt.Session("out2", sink_node, None, None)
+
+    gs_asn11: gdata.Node = gdata.Container({q("asn"): gdata.Leaf(11)})
+    gs_asn22: gdata.Node = gdata.Container({q("asn"): gdata.Leaf(22)})
+    r1_cfg: gdata.Node = gdata.Container({q("name"): gdata.Leaf("r1"), q("id"): gdata.Leaf(1)})
+    no_reqs: list[ttt.LinkRequest] = []
+
+    expected_init = gdata.Container({
+        q("asn"): gdata.Leaf(11),
+        q("id"): gdata.Leaf(1),
+        q("name"): gdata.Leaf("r1"),
+        q("seen_asn"): gdata.Leaf(11),
+    })
+    expected_after_bump = gdata.Container({
+        q("asn"): gdata.Leaf(22),
+        q("id"): gdata.Leaf(1),
+        q("name"): gdata.Leaf("r1"),
+        q("seen_asn"): gdata.Leaf(22),
+    })
+
+    def cont7(_r: value):
+        testing.assertEqual(
+            sink.get().prsrc(deterministic=True),
+            expected_after_bump.prsrc(deterministic=True),
+        )
+        t.success()
+
+    def cont6(_r: value):
+        gs.commit("t2", True)
+        r1.commit("t2", True)
+        sink.commit("t2", True)
+        sink.wait_complete("t2", cont7)
+
+    # Output pushes are fire-and-forget messages into the out sessions, so
+    # each transaction waits a beat for in-flight pushes to land before the
+    # apply sweeps them into the sink, standing in for the scheduling
+    # distance the production stack provides. The interleaving under test
+    # stays pinned by per-sender FIFO ordering.
+    def cont5b():
+        out2.apply("t2")
+        sink.lock("t2", None, cont6)
+
+    def cont5(_r: value):
+        after 0.05: cont5b()
+
+    def cont4(_r: value):
+        r1.lock("t2", out2, cont5)
+
+    def cont3b(_r: value):
+        testing.assertEqual(
+            sink.get().prsrc(deterministic=True),
+            expected_init.prsrc(deterministic=True),
+        )
+        res = gs.configure("t2", {'_': gs_asn22}, out2)
+        upds = [u.tail().tail().tail() for u in res.updates]
+        r1.linkage("t2", no_reqs, upds, out2)
+        # Only now is tx1's commit delivered to the subscriber.
+        r1.commit("t1", True)
+        gs.lock("t2", out2, cont4)
+
+    def cont3(_r: value):
+        # tx1 commits, but only the publisher and the sink see it before tx2
+        # runs; the subscriber's commit is still in flight.
+        gs.commit("t1", True)
+        sink.commit("t1", True)
+        sink.wait_complete("t1", cont3b)
+
+    def cont2b():
+        out1.apply("t1")
+        sink.lock("t1", None, cont3)
+
+    def cont2(_r: value):
+        after 0.05: cont2b()
+
+    def cont1(_r: value):
+        r1.lock("t1", out1, cont2)
+
+    no_upds: list[ttt.LinkUpdate] = []
+    gs.configure("t1", {'_': gs_asn11}, out1)
+    res = r1.configure("t1", {'_': r1_cfg}, out1)
+    reqs = [r.tail().tail() for r in res.requests]
+    res = gs.linkage("t1", reqs, no_upds, out1)
+    upds = [u.tail().tail().tail() for u in res.updates]
+    r1.linkage("t1", no_reqs, upds, out1)
+    out1.apply("t1")
+    gs.lock("t1", out1, cont1)
+########################
+
+
 # Subscriber transform for the test below: it reflects each linked
 # /netinfra/router entry as seen_<name> = <id>, so the test can assert which
 # router entries were delivered as linked input.

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -889,6 +889,9 @@ def _link_to_global_settings(conf: gdata.Node) -> list[ttt.TaggedPath]:
         gdata.FNode(q("global-settings")),
     ]))]
 
+class NoOutput(ttt.TransformFunction):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
+        return gdata.Container(), None
 
 # When the subscriber lives in a list and a later tx touches only the
 # publisher, the list element transactions are not configured in that tx.
@@ -899,7 +902,7 @@ actor link_subscriber_in_list_re_runs_on_publisher_update(t: testing.AsyncT):
     stack = ttt.Layer("top",
         ttt.Container({
             q("network"): ttt.Container({
-                q("global-settings"): ttt.Transform(ttt.PassThrough),
+                q("global-settings"): ttt.Transform(NoOutput),
                 q("router"): ttt.List(
                     ttt.Transform(LinkedAsnSubscriber, None, _link_to_global_settings),
                     [q("name"), q("id")],
@@ -926,7 +929,6 @@ actor link_subscriber_in_list_re_runs_on_publisher_update(t: testing.AsyncT):
     })
 
     expected_after_bump = gdata.Container({
-        q("asn"): gdata.Leaf(22),
         q("id"): gdata.Leaf(1),
         q("name"): gdata.Leaf("r1"),
         q("seen_asn"): gdata.Leaf(22),
@@ -947,7 +949,6 @@ actor link_subscriber_in_list_re_runs_on_publisher_update(t: testing.AsyncT):
 
     sess1.edit_config(cfg_init, cont1)
 ########################
-
 
 # Commit fans out asynchronously through each session's container and list
 # transactions, so a following transaction can reach the shared transform
@@ -975,9 +976,9 @@ actor link_update_racing_subscriber_commit_is_kept(t: testing.AsyncT):
     r1_keystr = gdata.Container(r1_keys).key_str([q("name"), q("id")])
     r1_path = ttt.PathKey(r1_keystr, router_path, r1_keys)
 
-    gs_node = ttt.Transform(ttt.PassThrough) (gs_path, None)
+    gs_node = ttt.Transform(NoOutput) (gs_path, None)
     r1_node = ttt.Transform(LinkedAsnSubscriber, None, _link_to_global_settings) (r1_path, None)
-    sink_node = ttt.Transform(ttt.PassThrough) (ttt.PathRoot("sink"), None)
+    sink_node = ttt.Transform(NoOutput) (ttt.PathRoot("sink"), None)
     gs = gs_node.newtrans()
     r1 = r1_node.newtrans()
     sink = sink_node.newtrans()
@@ -991,13 +992,11 @@ actor link_update_racing_subscriber_commit_is_kept(t: testing.AsyncT):
     no_reqs: list[ttt.LinkRequest] = []
 
     expected_init = gdata.Container({
-        q("asn"): gdata.Leaf(11),
         q("id"): gdata.Leaf(1),
         q("name"): gdata.Leaf("r1"),
         q("seen_asn"): gdata.Leaf(11),
     })
     expected_after_bump = gdata.Container({
-        q("asn"): gdata.Leaf(22),
         q("id"): gdata.Leaf(1),
         q("name"): gdata.Leaf("r1"),
         q("seen_asn"): gdata.Leaf(22),

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -2073,7 +2073,7 @@ class _TransformTransactionBase(_Transaction):
         ###
         if updates:
             self.candidate_link_updates[tid] = self.candidate_link_updates.get_def(tid, []) + updates
-        return self.configure(tid, {}, out, True, dbuf)
+        return self.configure(tid, {}, out, dbuf)
 
     # yield action
     def lock(self, actself, tid, out: ?Session, done, dbuf: ?swdb.Buffer=None):          # yield await

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -1909,7 +1909,7 @@ class _TransformTransactionBase(_Transaction):
     pending: list[(Transaction, str, ?Session, action(CfgResult)->None, ?swdb.Buffer)]
 
     linked: gdata.Node                                          # Active linked cfg tree per link tag
-    candidate_linked: dict[str, gdata.Node]                     # As above, per ongoing transaction
+    candidate_link_updates: dict[str, list[LinkUpdate]]         # Link updates received, per ongoing transaction
     subscriptions: list[TaggedPath]                             # Active linked data publishers (with tag)
     candidate_subscriptions: dict[str, list[TaggedPath]]        # As above, per ongoing transaction
     subscribers: list[TaggedPath]                               # Active linked data subscribers (with tag)
@@ -1937,7 +1937,7 @@ class _TransformTransactionBase(_Transaction):
         self.locker = None
         self.pending = []
         self.linked = gdata.Container()
-        self.candidate_linked = {}
+        self.candidate_link_updates = {}
         self.subscriptions = []
         self.candidate_subscriptions = {}
         self.subscribers = []
@@ -1981,7 +1981,7 @@ class _TransformTransactionBase(_Transaction):
                 req = self.link_requests(tid, merged)
                 upd = self.link_updates(tid, merged)
                 if not req:
-                    linked = self.candidate_linked.get_def(tid, self.linked)
+                    linked = self.linked_for(tid)
                     outmem = self.compute(tid, merged, linked, out)
                     self.essays[tid] = outmem
                     newout = outmem.0
@@ -1998,7 +1998,6 @@ class _TransformTransactionBase(_Transaction):
         req = []
         build_links = self.build_links
         if build_links is not None:
-            cand_linked = self.candidate_linked.get_def(tid, self.linked)
             cand_subs = self.candidate_subscriptions.get_def(tid, self.subscriptions)
             latest_subs = build_links(merged)
             for s in latest_subs:
@@ -2007,11 +2006,29 @@ class _TransformTransactionBase(_Transaction):
             for s in cand_subs:
                 if s not in latest_subs:
                     req.append(LinkRequest(s.tag, s.path, self.route_fpath, False))
-                    cand_linked = prune(cand_linked, s.path)
             self.candidate_subscriptions[tid] = latest_subs
-            self.candidate_linked[tid] = cand_linked
         #print('####', tid, '(Transform)', _format_path(self.path), 'link_requests:', len(req), err=True)
         return req
+
+    # The linked tree a transaction computes with is derived on use from the
+    # committed base: subscriptions dropped by the transaction are pruned, and
+    # the updates it has received are applied on top, each one replacing the
+    # publisher's subtree since a publisher resends its full state on every
+    # change. Updates from publishers outside the transaction's subscription
+    # view are ignored. Deriving late rather than snapshotting keeps a
+    # transaction correct when a concurrent commit replaces the committed base
+    # after updates were received: the lock-time re-configure then recomputes
+    # against the new base with the received updates still in effect.
+    def linked_for(self, tid):
+        subscriptions = self.candidate_subscriptions.get_def(tid, self.subscriptions)
+        linked = self.linked
+        for s in self.subscriptions:
+            if s not in subscriptions:
+                linked = prune(linked, s.path)
+        for u in self.candidate_link_updates.get_def(tid, []):
+            if TaggedPath(u.tag, u.publisher) in subscriptions:
+                linked = gdata.merge(prune(linked, u.publisher), u.config)
+        return linked
 
     def link_updates(self, tid, merged):
         cand_subscribers = self.candidate_subscribers.get_def(tid, self.subscribers)
@@ -2055,15 +2072,8 @@ class _TransformTransactionBase(_Transaction):
                 return CfgOk(empty = not self.running, updates=upd)
         ###
         if updates:
-            linked = self.candidate_linked.get_def(tid, self.linked)
-            subscriptions = self.candidate_subscriptions.get_def(tid, self.subscriptions)
-            for u in updates:
-                if TaggedPath(u.tag, u.publisher) in subscriptions:
-                    # The publisher resends its full state on every change, so
-                    # prune the existing config subtree at its path and merge the new one
-                    linked = gdata.merge(prune(linked, u.publisher), u.config)
-            self.candidate_linked[tid] = linked
-        return self.configure(tid, {}, out, dbuf)
+            self.candidate_link_updates[tid] = self.candidate_link_updates.get_def(tid, []) + updates
+        return self.configure(tid, {}, out, True, dbuf)
 
     # yield action
     def lock(self, actself, tid, out: ?Session, done, dbuf: ?swdb.Buffer=None):          # yield await
@@ -2123,7 +2133,8 @@ class _TransformTransactionBase(_Transaction):
         self.diffs.pop_def(tid, {})
         candidate = self.candidates.pop_def(tid, {})
         essay = self.essays.pop_def(tid, (None, None))
-        linked = self.candidate_linked.pop_def(tid, self.linked)
+        linked = self.linked_for(tid)
+        self.candidate_link_updates.pop_def(tid, [])
         subscriptions = self.candidate_subscriptions.pop_def(tid, self.subscriptions)
         subscribers = self.candidate_subscribers.pop_def(tid, self.subscribers)
         if tid == self.locker:


### PR DESCRIPTION
Linked input updates were previously matched against subscriptions immediately on arrival. This lead to incorrect results if one transaction requests a linked input, and a concurrent—but later committed—transaction modifies the linked data. The fix ensures that linked input updates are matched and pruned against the subscriptions that are active when a transaction is computed or committed, similar to how configuration diffs are always applied on top of the active configuration state.