### PR TITLE
Read only the list entries that a filter names

### DIFF
--- a/src/test_ttt_oper_read.act
+++ b/src/test_ttt_oper_read.act
@@ -54,6 +54,25 @@ def _service_cfg() -> gdata.Node:
     })
 
 
+def _three_service_cfg() -> gdata.Node:
+    return gdata.Container({
+        q("service"): gdata.List([q("name")], [
+            gdata.Container({
+                q("name"): gdata.Leaf("svc-a"),
+                q("enabled"): gdata.Leaf(True),
+            }),
+            gdata.Container({
+                q("name"): gdata.Leaf("svc-b"),
+                q("enabled"): gdata.Leaf(True),
+            }),
+            gdata.Container({
+                q("name"): gdata.Leaf("svc-c"),
+                q("enabled"): gdata.Leaf(True),
+            }),
+        ]),
+    })
+
+
 def _service_oper_all() -> gdata.Node:
     return gdata.Container({
         q("service"): gdata.List([q("name")], [
@@ -307,6 +326,91 @@ actor get_data_scans_with_element_predicate(t: testing.AsyncT):
         t.success()
 
     layer.edit_config(_service_cfg(), cont)
+
+
+actor get_data_absent_exact_key_reads_nothing(t: testing.AsyncT):
+    """A key the list does not hold is absent, not the rest of the list.
+
+    An exact-key read looks its keys up instead of walking the list, so the
+    case worth pinning is the lookup that misses: it must answer None rather
+    than fall back to everything the list holds.
+    """
+    layer = ttt.Layer("top", ttt.Container({
+        q("service"): ttt.List(ttt.Transform(OperTransform, OperPublisherCtor), [q("name")]),
+    }), None)
+
+    def cont(_r: value):
+        after 0: check()
+
+    def check():
+        filt = gdata.FNode(q("service"), children=[
+            gdata.FNode(q("name"), value_match="svc-nope"),
+            gdata.FNode(q("status")),
+        ])
+        testing.assertEqual(layer.newsession().get_data(filt), None)
+        t.success()
+
+    layer.edit_config(_service_cfg(), cont)
+
+
+def _service_names(data: ?gdata.Node) -> list[str]:
+    """Get the name of every service entry, in the order that the read gave."""
+    names = []
+    if data is not None:
+        lst = data.children.get(q("service"))
+        if isinstance(lst, gdata.List):
+            for elem in lst.elements:
+                name = elem.get_opt_str(q("name"))
+                if name is not None:
+                    names.append(name)
+    return names
+
+
+actor get_data_exact_keys_read_only_those_entries(t: testing.AsyncT):
+    """Read the two entries that the filter names, out of three.
+
+    The read routes straight to the entries that the filter names, so this
+    test names more than one key, and checks that the entry that nobody names
+    stays out of the result.
+
+    The test sorts before it compares, and asserts nothing about the order it
+    got. The order of the entries of a TTT list means nothing, and the read
+    passes on the order that its own structures give rather than sorting. Do
+    not add an order check here.
+    """
+    layer = ttt.Layer("top", ttt.Container({
+        q("service"): ttt.List(ttt.Transform(OperTransform, OperPublisherCtor), [q("name")]),
+    }), None)
+    var attempts = 0
+
+    def cont(_r: value):
+        after 0: check()
+
+    def check():
+        attempts += 1
+        # The two branches select different children, so that the filter merge
+        # keeps them apart and the read gets two keys to route.
+        filt = gdata.FNode(children=[
+            gdata.FNode(q("service"), children=[
+                gdata.FNode(q("name"), value_match="svc-c"),
+                gdata.FNode(q("status")),
+            ]),
+            gdata.FNode(q("service"), children=[
+                gdata.FNode(q("name"), value_match="svc-a"),
+                gdata.FNode(q("metrics"), children=[gdata.FNode(q("rx"))]),
+            ]),
+        ])
+        got = sorted(_service_names(layer.newsession().get_data(filt)))
+        if got != ["svc-a", "svc-c"]:
+            if attempts > 100:
+                t.failure(ValueError("Timed out waiting for the two named services, got {got}"))
+                return
+            after 0.01: check()
+            return
+        testing.assertEqual(got, ["svc-a", "svc-c"])
+        t.success()
+
+    layer.edit_config(_three_service_cfg(), cont)
 
 
 actor read_data_merges_config_and_oper(t: testing.AsyncT):

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -1384,13 +1384,13 @@ class _List(_Node):
         filter_branches = exact_list_filter_branches(filters, self.key_names)
         scan_filters = list_element_filters(filters)
         res = []
-        # TODO: when filter_branches is not None, fetch only those exact keys
-        # from ListState instead of enumerating all committed entries.
-        for key, node in self.liststate.all().items():
+        if filter_branches is not None:
+            nodes = self.liststate.some(list(filter_branches.keys()))
+        else:
+            nodes = self.liststate.all()
+        for key, node in nodes.items():
             element_filters = scan_filters
             if filter_branches is not None:
-                if key not in filter_branches:
-                    continue
                 element_filters = filter_branches[key]
             if len(element_filters) == 0:
                 elem = node.get_data()
@@ -1546,6 +1546,28 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
             return {k: elems[k] for k in elems if k not in provisional}
         else:
             return {k: node for k, node in elems.items()}
+
+    # TODO: change the parameter to Iterable[str], so that a caller does not
+    # have to build a list. The Acton compiler does not accept a protocol type
+    # on an actor method parameter. The call then fails the back pass with
+    # "qInst [] ... => action(Iterable[E_1, str], E_1)".
+    def some(keys: list[str]):
+        """Get the committed node for each key in `keys`.
+
+        The result follows the order of `keys`. That order, and the order that
+        `all` gives, come from the structures that hold the keys. Both are
+        stable while the process runs, and neither means anything: TTT never
+        sets `user_order` on a list that it builds, and `acquire` takes new
+        keys from a set, so a list does not hold its entries in the order that
+        configured them. Give the caller the order that the structures give.
+        Do not sort to hide it.
+
+        The method omits a key that the list does not hold. It also omits a
+        provisional key, as `all` does. A read of the entries that a filter
+        names then costs as much as those entries, and not as much as the
+        whole list.
+        """
+        return {k: elems[k] for k in keys if k in elems and k not in provisional}
 
     def is_empty() -> bool:
         return len(elems) == 0 and len(active) == 0 and len(provisional) == 0
@@ -1795,13 +1817,13 @@ class _ListTransaction(_Transaction):
         filter_branches = exact_list_filter_branches(filters, self.key_names)
         scan_filters = list_element_filters(filters)
         res = []
-        # TODO: when filter_branches is not None, fetch only those exact keys
-        # from ListState instead of enumerating all committed entries.
-        for key, node in self.liststate.all().items():
+        if filter_branches is not None:
+            nodes = self.liststate.some(list(filter_branches.keys()))
+        else:
+            nodes = self.liststate.all()
+        for key, node in nodes.items():
             element_filters = scan_filters
             if filter_branches is not None:
-                if key not in filter_branches:
-                    continue
                 element_filters = filter_branches[key]
             if len(element_filters) == 0:
                 if key in self.elems:


### PR DESCRIPTION
A filtered read that names its list entries by key already routes to those entries, but it got there by walking every committed entry and discarding the rest, so reading one entry cost what the whole list costs. Both get_data implementations carried a TODO about it. ListState.some() looks the named keys up instead, and omits keys the list does not hold along with provisional ones, so a read still cannot see an entry an uncommitted transaction holds.

This is what makes a path-addressed read cheap in the size of the list it addresses. It matters most for the RFC 8040 existence check that runs on every RESTCONF PATCH and PUT, which the TTT scale profile measured at ~6.5 us per existing device per write. Scoping that check is a separate branch that builds on this one.

The result now follows the order of the keys the filter names rather than the order the list holds its entries. Neither order means anything: TTT never sets user_order on a list it builds, and acquire takes new keys from a set, so a list does not hold its entries in the order that configured them. The read passes on the order its own structures give rather than sorting, and the docstring and the test both say not to depend on it.

some() takes a list[str] and not an Iterable[str] because the Acton compiler rejects a protocol type on an actor method parameter: the call fails the back pass with "qInst [] ... => action(Iterable[E_1, str], E_1)". A TODO records that, and there is a seven-line reproduction for an upstream issue.
