### PR TITLE
Serve subtree-filtered YANG-push subscriptions

### DIFF
--- a/src/netconf_server.act
+++ b/src/netconf_server.act
@@ -72,8 +72,10 @@ actor NetconfSession(pipe, log_handler: logging.Handler, top_schema: yschema.DRo
     YANG-push (RFC 8641) periodic subscriptions are served from the same cfs
     datastore via a per-session TttSubscriptionService, which drives TTT's native
     declare_subscriptions: establish/delete-subscription RPCs are routed to it and
-    it streams push-update notifications back over this session. session_seq makes
-    the per-session subscription owner ids unique on the shared cfs.
+    it streams push-update notifications back over this session. A subscription
+    may carry a datastore-subtree-filter, parsed against `top_schema`, so that
+    only the selected subtree is pushed. session_seq makes the per-session
+    subscription owner ids unique on the shared cfs.
 
     `on_close`, if given, is called with this session when its transport drops,
     so the owner can release its reference and let the session be reclaimed.
@@ -209,7 +211,7 @@ actor NetconfSession(pipe, log_handler: logging.Handler, top_schema: yschema.DRo
     var server: netconf.Server = netconf.Server(pipe=pipe, on_connect=_on_conn, on_rpc=on_rpc, capabilities=capabilities, log_handler=log_handler)
     # owner_prefix must be unique per session: TTT keys subscriptions by owner id,
     # so sessions sharing this cfs must not collide on "yp-<sub_id>".
-    service = yp_ttt.TttSubscriptionService(server, cfs, owner_prefix="yp-" + str(session_seq), log_handler=log_handler)
+    service = yp_ttt.TttSubscriptionService(server, cfs, top_schema, owner_prefix="yp-" + str(session_seq), log_handler=log_handler)
 
 
 actor NetconfServer(

--- a/src/test_netconf_server.act
+++ b/src/test_netconf_server.act
@@ -11,9 +11,13 @@ Two angles, both against a real TTT layer:
 YANG-push subscriptions are served per session by a TttSubscriptionService, and
 covered over the pipe: a periodic establish-subscription is accepted (returns a
 subscription-id), a raw on-change establish-subscription is rejected with an
-rpc-error (the client helper only builds periodic requests), and two sessions on
-one TTT layer stay isolated, with a datastore change reaching both. A loopback-SSH
-test also checks that a session's subscriptions are released when it closes.
+rpc-error (the client helper only builds periodic requests), a subtree filter
+narrows the push to the selected nodes (a container leaf, and one keyed list
+entry's oper subtree using the filter XML the device adapter emits), a filter
+outside the schema and an xpath filter are rejected without allocating an id,
+and two sessions on one TTT layer stay isolated, with a datastore change
+reaching both. A loopback-SSH test also
+checks that a session's subscriptions are released when it closes.
 """
 
 import logging
@@ -29,6 +33,7 @@ import yang.gdata as gdata
 import yang.schema as yschema
 
 import netconf_server as swnetconf
+import yp
 
 
 DEMO_NS = "urn:demo"
@@ -45,6 +50,62 @@ DEMO_YANG = r"""module demo {
 
 def _q(n: str) -> gdata.Id:
     return gdata.Id(DEMO_NS, n)
+
+
+# A fleet-shaped schema for the keyed-entry subscription test: /device{name}
+# with config under software and oper state under software/state, the shape a
+# top-tier fleet manager asks a flotilla for.
+FLEET_NS = "urn:demo-fleet"
+FLEET_YANG = r"""module demo-fleet {
+  yang-version "1.1";
+  namespace "urn:demo-fleet";
+  prefix df;
+  list device {
+    key name;
+    leaf name { type string; }
+    container software {
+      leaf target { type string; }
+      container state {
+        config false;
+        leaf status { type string; }
+      }
+    }
+  }
+}"""
+
+
+def _fq(n: str) -> gdata.Id:
+    return gdata.Id(FLEET_NS, n)
+
+
+class _FleetOperTransform(ttt.TransformFunction):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
+        return gdata.Container(), None
+
+
+actor _FleetOperPublisher(path: ttt.Path, update_oper: proc(?gdata.Node) -> None):
+    """Publishes software/state/status = "up-<name>" for one device entry."""
+    def on_conf(conf: gdata.Node, memory: ?gdata.Node):
+        name = conf.get_opt_str(_fq("name"))
+        if name is not None:
+            update_oper(gdata.Container({
+                _fq("software"): gdata.Container({
+                    _fq("state"): gdata.Container({
+                        _fq("status"): gdata.Leaf("up-" + name),
+                    }),
+                }),
+            }))
+
+
+def _fleet_oper_publisher(params: ttt.TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None:
+    act = _FleetOperPublisher(params.path, params.update_oper)
+    return act.on_conf
+
+
+def _fleet_layer() -> ttt.Layer:
+    return ttt.Layer("top", ttt.Container({
+        _fq("device"): ttt.List(ttt.Transform(_FleetOperTransform, _fleet_oper_publisher), [_fq("name")]),
+    }), None)
 
 
 def _demo_schema() -> yschema.DRoot:
@@ -529,3 +590,222 @@ actor _test_ssh_session_cleanup(t: testing.EnvT):
     server = swnetconf.NetconfServer(listen_cap, log_handler=lh, top_schema=schema, cfs=layer, address="127.0.0.1", port=0, on_listen=_on_listen)
 
     after 15.0: fail(ValueError("timed out waiting for session cleanup"))
+
+
+def _first_error_tag(err: netconf.NetconfError) -> ?str:
+    """The error-tag of the first rpc-error carried by err, if any."""
+    errs = err.rpc_error
+    if errs is not None:
+        if len(errs) > 0:
+            return errs[0].error_tag
+    return None
+
+
+actor _test_subscription_subtree_filter_narrows_push(t: testing.AsyncT):
+    """A datastore-subtree-filter narrows what a periodic subscription pushes:
+    with hostname and location configured, a filter that selects hostname
+    yields a push-update that carries hostname and not location."""
+    lh = logging.Handler("nctest")
+    schema = _demo_schema()
+    layer = _demo_layer()
+    caps = swnetconf.build_capabilities(schema)
+
+    pipes = netconf.actor_pipe_pair()
+    server = swnetconf.NetconfSession(pipes.server, lh, schema, layer, caps)
+
+    var done = False
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def _on_notif(c: netconf.Client, n: xml.Node):
+        if done:
+            return
+        pu = yp.parse_push_update(n)
+        if pu is not None:
+            payload = ""
+            for node in pu.contents:
+                payload = payload + node.encode()
+            if payload.find("hostname") == -1 or payload.find("r1") == -1:
+                fail(ValueError("filtered push lacks hostname: " + payload))
+            elif payload.find("location") != -1:
+                fail(ValueError("filtered push leaked location: " + payload))
+            else:
+                done = True
+                t.success()
+        else:
+            fail(ValueError("unexpected notification: " + n.encode()))
+
+    def _on_sub(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+
+    def _on_seed(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        filt = xml.decode('<system xmlns="urn:demo"><hostname/></system>')
+        c.establish_subscription(_on_sub, period=5, subtree_filter=[filt])
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            fail(ValueError("client connect failed: {e}"))
+            return
+        seed = xml.decode('<system xmlns="urn:demo"><hostname>r1</hostname><location>lab</location></system>')
+        c.edit_config([seed], _on_seed)
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, _on_notif, True, lh, pipe=pipes.client)
+    after 5.0: fail(ValueError("timed out waiting for a filtered push-update"))
+
+
+actor _test_subscription_rejects_bad_subtree_filter(t: testing.AsyncT):
+    """A subtree filter that names a node outside the schema fails the RPC with
+    invalid-value, and no subscription is allocated: deleting id 1 afterwards
+    is refused."""
+    lh = logging.Handler("nctest")
+    schema = _demo_schema()
+    layer = _demo_layer()
+    caps = swnetconf.build_capabilities(schema)
+
+    pipes = netconf.actor_pipe_pair()
+    server = swnetconf.NetconfSession(pipes.server, lh, schema, layer, caps)
+
+    var done = False
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def _on_del(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is None:
+            fail(ValueError("a rejected establish-subscription must not allocate an id"))
+        elif not done:
+            done = True
+            t.success()
+
+    def _on_sub(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError):
+        if err is not None:
+            tag = _first_error_tag(err)
+            if tag != "invalid-value":
+                fail(ValueError("expected invalid-value, got {tag}"))
+            else:
+                c.delete_subscription(_on_del, 1)
+        else:
+            fail(ValueError("expected the bad subtree filter to be rejected"))
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            fail(ValueError("client connect failed: {e}"))
+            return
+        filt = xml.decode('<nosuch xmlns="urn:demo"/>')
+        c.establish_subscription(_on_sub, period=5, subtree_filter=[filt])
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, None, True, lh, pipe=pipes.client)
+    after 5.0: fail(ValueError("timed out waiting for the bad filter to be rejected"))
+
+
+actor _test_subscription_rejects_xpath_filter(t: testing.AsyncT):
+    """A datastore-xpath-filter is rejected with operation-not-supported: only
+    subtree filters are served."""
+    lh = logging.Handler("nctest")
+    schema = _demo_schema()
+    layer = _demo_layer()
+    caps = swnetconf.build_capabilities(schema)
+
+    pipes = netconf.actor_pipe_pair()
+    server = swnetconf.NetconfSession(pipes.server, lh, schema, layer, caps)
+
+    var done = False
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def _on_sub(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError):
+        if err is not None:
+            tag = _first_error_tag(err)
+            if tag != "operation-not-supported":
+                fail(ValueError("expected operation-not-supported, got {tag}"))
+            elif not done:
+                done = True
+                t.success()
+        else:
+            fail(ValueError("expected the xpath filter to be rejected"))
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            fail(ValueError("client connect failed: {e}"))
+            return
+        c.establish_subscription(_on_sub, period=5, xpath_filter="/system")
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, None, True, lh, pipe=pipes.client)
+    after 5.0: fail(ValueError("timed out waiting for the xpath filter to be rejected"))
+
+
+actor _test_subscription_subtree_filter_keyed_entry_oper(t: testing.AsyncT):
+    """A filter for one keyed list entry's oper subtree, sent as the filter XML
+    the device adapter emits, pushes that entry's state and nothing else: not
+    the other entry, and not the entry's own config under software."""
+    lh = logging.Handler("nctest")
+    schema = yang.compile([FLEET_YANG])
+    layer = _fleet_layer()
+    caps = swnetconf.build_capabilities(schema)
+
+    pipes = netconf.actor_pipe_pair()
+    server = swnetconf.NetconfSession(pipes.server, lh, schema, layer, caps)
+
+    var done = False
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def _on_notif(c: netconf.Client, n: xml.Node):
+        if done:
+            return
+        pu = yp.parse_push_update(n)
+        if pu is not None:
+            payload = ""
+            for node in pu.contents:
+                payload = payload + node.encode()
+            if payload.find("cpe-16") != -1:
+                fail(ValueError("filtered push leaked another entry: " + payload))
+            elif payload.find("target") != -1:
+                fail(ValueError("filtered push leaked unselected config: " + payload))
+            elif payload.find("up-cpe-17") != -1:
+                done = True
+                t.success()
+            # Otherwise the entry's oper state is not published yet; the next
+            # sample carries it and pushes again.
+        else:
+            fail(ValueError("unexpected notification: " + n.encode()))
+
+    def _on_sub(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+
+    def _on_seed(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        # /device{cpe-17}/software/state, rendered the way NetconfDriver._yp_ensure
+        # renders a SubscriptionSpec filter onto the wire.
+        filt = gdata.FNode(_fq("device"), children=[
+            gdata.FNode(_fq("name"), value_match="cpe-17"),
+            gdata.FNode(_fq("software"), children=[gdata.FNode(_fq("state"))]),
+        ])
+        c.establish_subscription(_on_sub, period=5, subtree_filter=filt.to_filter_xml(deterministic=True))
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            fail(ValueError("client connect failed: {e}"))
+            return
+        seed = [
+            xml.decode('<device xmlns="urn:demo-fleet"><name>cpe-16</name><software><target>2.0</target></software></device>'),
+            xml.decode('<device xmlns="urn:demo-fleet"><name>cpe-17</name><software><target>2.0</target></software></device>'),
+        ]
+        c.edit_config(seed, _on_seed)
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, _on_notif, True, lh, pipe=pipes.client)
+    after 5.0: fail(ValueError("timed out waiting for the keyed entry's filtered push-update"))

--- a/src/yp_ttt.act
+++ b/src/yp_ttt.act
@@ -1,19 +1,21 @@
-"""TTT-backed YANG-push for the northbound NETCONF server (periodic / full-tree).
+"""TTT-backed YANG-push for the northbound NETCONF server (periodic).
 
 TttSubscriptionService is the NETCONF binding that serves dynamic YANG-push
 (RFC 8641) subscriptions straight from a ttt.Layer datastore via TTT's native
 subscription mechanism (declare_subscriptions). On establish-subscription it
 declares a TTT subscription; TTT samples the datastore on the spec period and
 pushes the current merged tree to our callback, which we frame as a NETCONF
-push-update notification carrying the full datastore-contents.
+push-update notification carrying the datastore-contents.
 
 Supported v1 subset, enforced before a subscription is accepted (anything outside
 it gets an rpc-error rather than being silently served as something else):
 
   - periodic subscriptions only; on-change is not supported;
   - the running or operational datastore;
-  - no filter - the whole datastore is pushed, so a request that carries a
-    subtree/xpath filter is rejected rather than quietly widened.
+  - no filter, or a datastore-subtree-filter (RFC 6241 subtree filtering). The
+    filter is parsed against the served schema into a gdata filter and handed to
+    TTT, which samples only the selected subtree, so each push carries just the
+    filtered data. A datastore-xpath-filter is rejected.
 
 Known deviation, still under discussion: TTT subscriptions are
 periodic-with-change-suppression, so a subscription only pushes when the datastore
@@ -28,21 +30,35 @@ import std.xml as xml
 
 import ttt
 import yang.gdata as gdata
+import yang.schema as yschema
+import yang.xml as yxml
 
 from netconf import Server
 import yp
 
 
-actor TttSubscriptionService(server: Server, cfs: ttt.Layer,
+def parse_subtree_filter(schema: yschema.DRoot, nodes: list[xml.Node]) -> gdata.FNode:
+    """Turn the data nodes of a datastore-subtree-filter into a gdata filter.
+
+    The nodes are the top-level data nodes carried inside the anydata element,
+    so wrap them in the NETCONF <filter> element that from_filter_xml expects.
+    Raises ValueError when a node is not in the schema or a value does not
+    parse."""
+    wrapper = xml.Node("filter", attributes=[("type", "subtree")], children=nodes)
+    return yxml.from_filter_xml(schema, wrapper)
+
+
+actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRoot,
                              owner_prefix: str="yp",
                              log_handler: ?logging.Handler=None):
     """Serves YANG-push subscriptions for one NETCONF session from cfs.
 
     Route establish-subscription / delete-subscription here from the server's
     on_rpc (gate with yp.is_subscription_rpc); call shutdown when the session
-    closes so TTT stops sampling for it. owner_prefix must be unique per session:
-    TTT keys subscriptions by owner id, so two sessions sharing one cfs must not
-    collide."""
+    closes so TTT stops sampling for it. schema is the served top-level schema;
+    subtree filters are parsed against it. owner_prefix must be unique per
+    session: TTT keys subscriptions by owner id, so two sessions sharing one cfs
+    must not collide."""
 
     _log = logging.Logger(log_handler)
     var active: set[int] = set()
@@ -59,12 +75,6 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer,
             return local == "running" or local == "operational"
         return False
 
-    def _has_filter(op: xml.Node) -> bool:
-        for c in op.children:
-            if c.tag == "datastore-subtree-filter" or c.tag == "datastore-xpath-filter":
-                return True
-        return False
-
     def _has_on_change(op: xml.Node) -> bool:
         for c in op.children:
             if c.tag == "on-change":
@@ -77,7 +87,7 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer,
         return []
 
     def _on_tree(sub_id: int, tree: ?gdata.Node, err: ?Exception) -> None:
-        """TTT subscription callback: a fresh full merged tree (or an error).
+        """TTT subscription callback: a fresh merged tree (or an error).
         Frame it as a push-update, unless the subscription is already gone."""
         if sub_id in active:
             if err is not None:
@@ -85,6 +95,31 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer,
             else:
                 server.send_notification(yp.build_notification(
                     yp.event_time_now(), yp.build_push_update(sub_id, _contents(tree))))
+
+    def _establish(message_id: str, pp: int, subtree_filter: ?list[xml.Node]) -> None:
+        """Declare a periodic TTT subscription and reply with its id.
+
+        A subtree filter that does not parse against the schema fails the RPC
+        with invalid-value, and no id is allocated."""
+        filt: ?gdata.FNode = None
+        if subtree_filter is not None:
+            try:
+                filt = parse_subtree_filter(schema, subtree_filter)
+            except Exception as e:
+                server.send_error(message_id, "invalid-value",
+                    "bad datastore-subtree-filter: {e}")
+                return
+        sub_id = next_id
+        next_id += 1
+        active.add(sub_id)
+        period_s = float(pp) / 100.0
+        scope = "filtered" if filt is not None else "full"
+        _log.info("establish-subscription id={sub_id} mode=periodic period={period_s}s scope={scope}")
+        # Reply with the id BEFORE the subscription can push (ordering).
+        server.send_reply(message_id, [yp.build_subscription_id_reply(sub_id)])
+        spec = gdata.SubscriptionSpec(filt, period=period_s)
+        cfs.declare_subscriptions(_owner_id(sub_id),
+            (lambda tree, err: _on_tree(sub_id, tree, err)), {spec})
 
     def handle_rpc(message_id: str, op: xml.Node) -> None:
         """Handle a subscription RPC. Route here when is_subscription_rpc."""
@@ -103,20 +138,11 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer,
                 elif not _datastore_supported(params.datastore):
                     server.send_error(message_id, "invalid-value",
                         "unsupported datastore; this server serves running and operational")
-                elif _has_filter(op):
+                elif params.xpath_filter is not None:
                     server.send_error(message_id, "operation-not-supported",
-                        "filtered subscriptions are not supported; the whole datastore is pushed")
+                        "xpath filters are not supported; use a datastore-subtree-filter")
                 else:
-                    sub_id = next_id
-                    next_id += 1
-                    active.add(sub_id)
-                    period_s = float(pp) / 100.0
-                    _log.info("establish-subscription id={sub_id} mode=periodic period={period_s}s")
-                    # Reply with the id BEFORE the subscription can push (ordering).
-                    server.send_reply(message_id, [yp.build_subscription_id_reply(sub_id)])
-                    spec = gdata.SubscriptionSpec(None, period=period_s)
-                    cfs.declare_subscriptions(_owner_id(sub_id),
-                        (lambda tree, err: _on_tree(sub_id, tree, err)), {spec})
+                    _establish(message_id, pp, params.subtree_filter)
             else:
                 server.send_error(message_id, "missing-element",
                     "a periodic <period> is required")


### PR DESCRIPTION
The northbound NETCONF server rejected every establish-subscription that carried a datastore-subtree-filter. A top-tier fleet manager that asks a flotilla for one entry, such as /device{cpe-17}/software/state, got an rpc-error, and its NETCONF adapter has no fallback, so the subscriber only ever saw the error.

The parts below the binding already handle filters: a TTT layer samples a subscription with the filter in its SubscriptionSpec, and from_filter_xml turns subtree-filter XML into a gdata filter for get. The binding now takes the served schema, parses the subtree filter with it, and declares the TTT subscription with that filter, so each push carries only the selected subtree. A filter that does not parse fails the RPC with invalid-value before an id is allocated. An xpath filter is still refused with operation-not-supported.

Tests cover a filter on one leaf, a filter for one keyed list entry's oper subtree sent as the filter XML the device adapter emits, a filter outside the schema, and an xpath filter.
