### PR TITLE
Support leaf-list leafref links

### DIFF
--- a/src/test_ttt_links.act
+++ b/src/test_ttt_links.act
@@ -173,6 +173,36 @@ ys_link_in_dynstate = r"""module link-in-dynstate {
 }
 """
 
+ys_leaf_list_link = r"""module leaf-list-link {
+  yang-version "1.1";
+  namespace "http://example.com/leaf-list-link";
+  prefix "lll";
+  import stratoweave {
+    prefix sw;
+  }
+
+  container targets {
+    list target {
+      key id;
+      sw:transform example.Target;
+      leaf id {
+        type string;
+      }
+    }
+  }
+
+  container campaign {
+    sw:transform example.Campaign;
+    leaf-list target-id {
+      sw:link target;
+      type leafref {
+        path "/targets/target/id";
+      }
+    }
+  }
+}
+"""
+
 ########################
 # Helpers
 ########################
@@ -278,3 +308,19 @@ def _test_gen_build_target_links():
     extracted = ttt_links.extract_links(site, y)
     lines = ttt_links.gen_build_target_links("build_target_links_test", extracted)
     return "\n".join(lines)
+
+def _test_leaf_list_leafref_link():
+    """Each leaf-list value generates one keyed link demand."""
+    y = yang.compile([ys_leaf_list_link, swyang.stratoweave])
+    campaign = _as_inner(_find_child(y, "campaign"))
+    extracted = ttt_links.extract_links(campaign, y)
+
+    testing.assertEqual("target" in extracted, True)
+    field = extracted["target"]
+    testing.assertEqual(isinstance(field, ttt_links.MultiLinkedInput), True)
+
+    generated = "\n".join(
+        ttt_links.gen_build_target_links("build_leaf_list_links", extracted)
+    )
+    testing.assertEqual("get_opt_values" in generated, True)
+    testing.assertEqual("for _v0 in _ll0" in generated, True)

--- a/src/ttt_links.act
+++ b/src/ttt_links.act
@@ -118,8 +118,9 @@ def _collect_links(sn: schema.DNode, root: schema.DRoot, path_from_transform: li
             tag = ext.arg
             if tag is not None:
                 link: ?Link = None
-                if isinstance(sn, schema.DLeaf):
-                    # Leafref link: resolve from the leaf's compiled type
+                if isinstance(sn, schema.DNodeLeaf):
+                    # Leafref link: resolve from the leaf or leaf-list's
+                    # compiled type.
                     leaf_type = sn.type
                     if isinstance(leaf_type, schema.DTypeLeafref):
                         filter_path = xpath_to_spath(root, leaf_type.path, sn.module)
@@ -185,7 +186,7 @@ def extract_links(transform_node: schema.DNodeInner, root: schema.DRoot) -> dict
         elif isinstance(link, LeafrefLink):
             crosses_list = False
             for step in link.source_path_from_transform:
-                if isinstance(step, schema.DList):
+                if isinstance(step, schema.DList) or isinstance(step, schema.DLeafList):
                     crosses_list = True
             if crosses_list:
                 result[tag] = MultiLinkedInput(link)
@@ -214,10 +215,10 @@ def _gen_source_traversal(tag: str, link: LeafrefLink, indent: int) -> list[str]
     """Generate gdata traversal code that reads leafref source values.
 
     Walks source_path_from_transform and emits get_opt_cnt / get_opt_list /
-    get_opt_value calls for each schema step. Consecutive container steps are
-    collapsed into a single optional chain (using ?.). List steps produce a loop
-    over elements. Once the source leaf is reached, its value is captured in a
-    _vN variable and embedded in an FNode filter expression.
+    get_opt_value / get_opt_values calls for each schema step. Consecutive
+    container steps are collapsed into a single optional chain (using ?.).
+    List and leaf-list steps produce loops. Once a source value is reached, it
+    is embedded in an FNode filter expression.
     """
     lines = []
     path = link.source_path_from_transform
@@ -233,6 +234,15 @@ def _gen_source_traversal(tag: str, link: LeafrefLink, indent: int) -> list[str]
             vname = "_v{depth}"
             lines.append("{' ' * ind}{vname} = {cur}.{"?.".join(chain_parts)}")
             lines.append("{' ' * ind}if {vname} is not None:")
+            ind += 4
+            fnode = _gen_fnode(link.filter_path, value_match_var=vname)
+            lines.append("{' ' * ind}res.append(ttt.TaggedPath({repr(tag)}, {fnode}))")
+        elif isinstance(step, schema.DLeafList):
+            chain_parts.append("get_opt_values({qn})")
+            lname = "_ll{depth}"
+            lines.append("{' ' * ind}{lname} = {cur}.{"?.".join(chain_parts)}")
+            vname = "_v{depth}"
+            lines.append("{' ' * ind}for {vname} in {lname}:")
             ind += 4
             fnode = _gen_fnode(link.filter_path, value_match_var=vname)
             lines.append("{' ' * ind}res.append(ttt.TaggedPath({repr(tag)}, {fnode}))")


### PR DESCRIPTION
Let TTT leaf-list leafrefs demand each referenced list entry. This keeps linked inputs targeted and includes pre-existing data.