### PR TITLE
Serve XPath-filtered YANG-push subscriptions

### DIFF
--- a/src/netconf_server.act
+++ b/src/netconf_server.act
@@ -73,9 +73,10 @@ actor NetconfSession(pipe, log_handler: logging.Handler, top_schema: yschema.DRo
     datastore via a per-session TttSubscriptionService, which drives TTT's native
     declare_subscriptions: establish/delete-subscription RPCs are routed to it and
     it streams push-update notifications back over this session. A subscription
-    may carry a datastore-subtree-filter, parsed against `subscription_schema`
-    when supplied so operational-only nodes can be selected. session_seq makes
-    the per-session subscription owner ids unique on the shared cfs.
+    may carry a datastore-subtree-filter or datastore-xpath-filter, parsed
+    against `subscription_schema` when supplied so operational-only nodes can be
+    selected. session_seq makes the per-session subscription owner ids unique on
+    the shared cfs.
 
     `on_close`, if given, is called with this session when its transport drops,
     so the owner can release its reference and let the session be reclaimed.

--- a/src/test_netconf_server.act
+++ b/src/test_netconf_server.act
@@ -11,13 +11,12 @@ Two angles, both against a real TTT layer:
 YANG-push subscriptions are served per session by a TttSubscriptionService, and
 covered over the pipe: a periodic establish-subscription is accepted (returns a
 subscription-id), a raw on-change establish-subscription is rejected with an
-rpc-error (the client helper only builds periodic requests), a subtree filter
-narrows the push to the selected nodes (a container leaf, and one keyed list
-entry's oper subtree using the filter XML the device adapter emits), a filter
-outside the schema and an xpath filter are rejected without allocating an id,
+rpc-error (the client helper only builds periodic requests), subtree and XPath
+filters narrow the push to selected nodes (a container leaf, and one keyed list
+entry's oper subtree), invalid filters are rejected without allocating an id,
 and two sessions on one TTT layer stay isolated, with a datastore change
-reaching both. A loopback-SSH test also
-checks that a session's subscriptions are released when it closes.
+reaching both. A loopback-SSH test also checks that a session's subscriptions
+are released when it closes.
 """
 
 import logging
@@ -718,9 +717,9 @@ actor _test_subscription_rejects_bad_subtree_filter(t: testing.AsyncT):
     after 5.0: fail(ValueError("timed out waiting for the bad filter to be rejected"))
 
 
-actor _test_subscription_rejects_xpath_filter(t: testing.AsyncT):
-    """A datastore-xpath-filter is rejected with operation-not-supported: only
-    subtree filters are served."""
+actor _test_subscription_rejects_bad_xpath_filter(t: testing.AsyncT):
+    """An XPath filter that names a node outside the schema fails with
+    invalid-value and does not allocate a subscription id."""
     lh = logging.Handler("nctest")
     schema = _demo_schema()
     layer = _demo_layer()
@@ -735,31 +734,38 @@ actor _test_subscription_rejects_xpath_filter(t: testing.AsyncT):
             done = True
             t.failure(e)
 
+    def _on_del(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is None:
+            fail(ValueError("a rejected establish-subscription must not allocate an id"))
+        elif not done:
+            done = True
+            t.success()
+
     def _on_sub(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError):
         if err is not None:
             tag = _first_error_tag(err)
-            if tag != "operation-not-supported":
-                fail(ValueError("expected operation-not-supported, got {tag}"))
-            elif not done:
-                done = True
-                t.success()
+            if tag != "invalid-value":
+                fail(ValueError("expected invalid-value, got {tag}"))
+            else:
+                c.delete_subscription(_on_del, 1)
         else:
-            fail(ValueError("expected the xpath filter to be rejected"))
+            fail(ValueError("expected the bad XPath filter to be rejected"))
 
     def _on_connect(c: netconf.Client, e: ?Exception):
         if e is not None:
             fail(ValueError("client connect failed: {e}"))
             return
-        c.establish_subscription(_on_sub, period=5, xpath_filter="/system")
+        c.establish_subscription(_on_sub, period=5,
+            xpath_filter="/d:system/d:nosuch", xpath_nsdefs=[("d", DEMO_NS)])
 
     client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, None, True, lh, pipe=pipes.client)
-    after 5.0: fail(ValueError("timed out waiting for the xpath filter to be rejected"))
+    after 5.0: fail(ValueError("timed out waiting for the bad XPath filter to be rejected"))
 
 
-actor _test_subscription_subtree_filter_keyed_entry_oper(t: testing.AsyncT):
-    """A filter for one keyed list entry's oper subtree, sent as the filter XML
-    the device adapter emits, pushes that entry's state and nothing else: not
-    the other entry, and not the entry's own config under software."""
+actor _test_subscription_subtree_and_xpath_filters_keyed_entry_oper(t: testing.AsyncT):
+    """Subtree and XPath filters for one keyed list entry's oper subtree push
+    that entry's state and nothing else: not the other entry, and not the
+    entry's own config under software."""
     lh = logging.Handler("nctest")
     schema = yang.compile([FLEET_CONFIG_YANG])
     oper_schema = yang.compile([FLEET_YANG])
@@ -771,10 +777,20 @@ actor _test_subscription_subtree_filter_keyed_entry_oper(t: testing.AsyncT):
                                       subscription_schema=oper_schema)
 
     var done = False
+    var phase = "subtree"
     def fail(e: Exception):
         if not done:
             done = True
             t.failure(e)
+
+    def _on_deleted(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        phase = "xpath"
+        c.establish_subscription(_on_sub, period=5,
+            xpath_filter="/df:device[df:name='cpe-17']/df:software/df:state",
+            xpath_nsdefs=[("df", FLEET_NS)])
 
     def _on_notif(c: netconf.Client, n: xml.Node):
         if done:
@@ -789,8 +805,16 @@ actor _test_subscription_subtree_filter_keyed_entry_oper(t: testing.AsyncT):
             elif payload.find("target") != -1:
                 fail(ValueError("filtered push leaked unselected config: " + payload))
             elif payload.find("up-cpe-17") != -1:
-                done = True
-                t.success()
+                if phase == "subtree":
+                    phase = "deleting"
+                    sid = pu.sub_id
+                    if sid is not None:
+                        c.delete_subscription(_on_deleted, sid)
+                    else:
+                        fail(ValueError("filtered push-update missing subscription id"))
+                elif phase == "xpath":
+                    done = True
+                    t.success()
             # Otherwise the entry's oper state is not published yet; the next
             # sample carries it and pushes again.
         else:

--- a/src/yp.act
+++ b/src/yp.act
@@ -46,8 +46,8 @@ class EstablishParams(object):
     A subscription is either periodic (periodic_period set) or on-change (on_change
     True, with optional dampening_period and sync_on_start). subtree_filter
     carries the top-level data nodes from datastore-subtree-filter, if present.
-    xpath_filter is captured so bindings can reject it when they cannot honour it.
-    datastore is captured but not enforced here.
+    xpath_filter carries the datastore XPath expression, if present. datastore is
+    captured but not enforced here.
     """
     datastore: ?str
     periodic_period: ?int    # centiseconds; None if no <period> was given
@@ -333,7 +333,12 @@ def parse_establish_subscription(op: xml.Node) -> EstablishParams:
                 sync_on_start = False
     sf = _child_by_tag(op, "datastore-subtree-filter")
     subtree_filter = sf.children if sf is not None else None
-    xpath_filter = _text_of(_child_by_tag(op, "datastore-xpath-filter"))
+    xf = _child_by_tag(op, "datastore-xpath-filter")
+    xpath_filter: ?str = None
+    if xf is not None:
+        # Preserve presence of an empty element so the binding rejects the empty
+        # expression instead of accidentally widening it to an unfiltered request.
+        xpath_filter = xf.text if xf.text is not None else ""
     return EstablishParams(datastore, period, on_change, dampening_period, sync_on_start, subtree_filter, xpath_filter)
 
 

--- a/src/yp_ttt.act
+++ b/src/yp_ttt.act
@@ -12,10 +12,11 @@ it gets an rpc-error rather than being silently served as something else):
 
   - periodic subscriptions only; on-change is not supported;
   - the running or operational datastore;
-  - no filter, or a datastore-subtree-filter (RFC 6241 subtree filtering). The
-    filter is parsed against the served schema into a gdata filter and handed to
-    TTT, which samples only the selected subtree, so each push carries just the
-    filtered data. A datastore-xpath-filter is rejected.
+  - no filter, a datastore-subtree-filter (RFC 6241 subtree filtering), or a
+    datastore-xpath-filter in the subset supported by acton-yang. Filters are
+    parsed against the served schema into a gdata filter and handed to TTT,
+    which samples only the selected subtree, so each push carries just the
+    filtered data.
 
 Known deviation, still under discussion: TTT subscriptions are
 periodic-with-change-suppression, so a subscription only pushes when the datastore
@@ -29,6 +30,7 @@ import logging
 import std.xml as xml
 
 import ttt
+import yang.filter_xpath as filter_xpath
 import yang.gdata as gdata
 import yang.schema as yschema
 import yang.xml as yxml
@@ -56,9 +58,9 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRo
     Route establish-subscription / delete-subscription here from the server's
     on_rpc (gate with yp.is_subscription_rpc); call shutdown when the session
     closes so TTT stops sampling for it. schema is the served top-level schema;
-    subtree filters are parsed against it. owner_prefix must be unique per
-    session: TTT keys subscriptions by owner id, so two sessions sharing one cfs
-    must not collide."""
+    subtree and XPath filters are parsed against it. owner_prefix must be unique
+    per session: TTT keys subscriptions by owner id, so two sessions sharing one
+    cfs must not collide."""
 
     _log = logging.Logger(log_handler)
     var active: set[int] = set()
@@ -96,18 +98,30 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRo
                 server.send_notification(yp.build_notification(
                     yp.event_time_now(), yp.build_push_update(sub_id, _contents(tree))))
 
-    def _establish(message_id: str, pp: int, subtree_filter: ?list[xml.Node]) -> None:
+    def _establish(message_id: str, pp: int, subtree_filter: ?list[xml.Node],
+                   xpath_filter: ?str) -> None:
         """Declare a periodic TTT subscription and reply with its id.
 
-        A subtree filter that does not parse against the schema fails the RPC
-        with invalid-value, and no id is allocated."""
+        A filter that does not parse against the schema fails the RPC with
+        invalid-value, and no id is allocated."""
         filt: ?gdata.FNode = None
-        if subtree_filter is not None:
+        if subtree_filter is not None and xpath_filter is not None:
+            server.send_error(message_id, "invalid-value",
+                "choose either datastore-subtree-filter or datastore-xpath-filter")
+            return
+        elif subtree_filter is not None:
             try:
                 filt = parse_subtree_filter(schema, subtree_filter)
             except Exception as e:
                 server.send_error(message_id, "invalid-value",
                     "bad datastore-subtree-filter: {e}")
+                return
+        elif xpath_filter is not None:
+            try:
+                filt = filter_xpath.from_xpath(schema, xpath_filter)
+            except Exception as e:
+                server.send_error(message_id, "invalid-value",
+                    "bad datastore-xpath-filter: {e}")
                 return
         sub_id = next_id
         next_id += 1
@@ -138,11 +152,9 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRo
                 elif not _datastore_supported(params.datastore):
                     server.send_error(message_id, "invalid-value",
                         "unsupported datastore; this server serves running and operational")
-                elif params.xpath_filter is not None:
-                    server.send_error(message_id, "operation-not-supported",
-                        "xpath filters are not supported; use a datastore-subtree-filter")
                 else:
-                    _establish(message_id, pp, params.subtree_filter)
+                    _establish(message_id, pp, params.subtree_filter,
+                               params.xpath_filter)
             else:
                 server.send_error(message_id, "missing-element",
                     "a periodic <period> is required")


### PR DESCRIPTION
Northbound YANG-push subscriptions currently reject datastore XPath filters even though acton-yang can translate the supported location-path subset into the same FNode representation used by subtree filters.

This parses XPath filters against the operational subscription schema before creating the subscription and reuses the existing TTT filtered sampling path. Invalid, empty, or conflicting filters return invalid-value without allocating an ID or widening the subscription.