### PR TITLE
Add embedded static asset serving to HttpServer

### DIFF
--- a/docs/operations/http-api.md
+++ b/docs/operations/http-api.md
@@ -296,3 +296,40 @@ specific transform layer. Use `/device/<name>/target` and
 southbound device config with the device's current running config. Use
 `/device/<name>/diff` and `/config-queue` when you are diagnosing rollout or
 approval behavior.
+
+## Embedded static assets (web UI)
+
+Applications can embed a built web UI (or any set of text files) into their
+binary and have the HTTP server serve it alongside the APIs. Pass a
+`static_assets` map (URL path -> file content) to `stratoweave.main()`; it is
+forwarded to `HttpServer` and installed by the `static_assets` module.
+
+Behavior:
+
+- Every asset is served on `GET <path>` on the same listener and port as the
+  APIs. `GET /` serves `/index.html` when present. Assets are served by a
+  catch-all `GET /*path` route that the router ranks below every static or
+  parameterized route, so registered API routes always take precedence and can
+  never be shadowed by an asset. Installing fails if the application already
+  registered its own root-level `GET` wildcard.
+- Assets under `/_app/immutable/` (content-hashed filenames) are served with
+  `Cache-Control: public, max-age=31536000, immutable`; everything else with
+  `no-cache`.
+- SPA fallback: a `GET` request that matches no route and carries an `Accept`
+  header that explicitly allows `text/html` (a browser navigation) receives
+  `/index.html`, so
+  client-side routed pages survive a browser refresh. Requests without such an
+  `Accept` header — API clients, curl — keep receiving a plain `404`, and
+  registered API routes always win over the fallback.
+- The flip side of route precedence: an asset whose path an existing GET
+  route already matches — including parameterized and wildcard routes such as
+  `/device/{name}/info` or `/restconf/data/*` — is unreachable. Keep asset
+  paths (`/index.html`, `/_app/...`) out of the API namespace.
+
+Limitations:
+
+- Only text assets can be served (response bodies are UTF-8 strings). Binary
+  files such as images or fonts must be inlined by the frontend build, e.g. as
+  data URIs.
+- `HEAD` is not supported by the HTTP server; use `curl -sD- -o /dev/null`
+  rather than `curl -I` when inspecting response headers.

--- a/src/http_server.act
+++ b/src/http_server.act
@@ -6,6 +6,7 @@ import net
 
 import device as swdev
 import restconf as swrestconf
+import static_assets as swstatic
 import tmf_api as swtmf_api
 import ttt as ttt
 import yang.data as ydata
@@ -42,7 +43,8 @@ actor HttpServer(
     enable_tmf_api: bool = False,
     restconf_root: str = "/restconf",
     address: str = "::",
-    port: int = 80
+    port: int = 80,
+    static_assets: ?dict[str, str] = None
 ):
     _ROUTER_CTX_DEVICE_KEY = "dev"
     http_log = logging.Logger(log_handler)
@@ -405,9 +407,11 @@ actor HttpServer(
         tmf_http = swtmf_api.TmfHttp(http_router_root, top_schema, cfs)
     restconf = swrestconf.RestconfServer(http_router_root, http_log, top_schema, cfs, restconf_root)
 
-    extra_routes = install_extra_routes
-    if extra_routes is not None:
-        extra_routes(http_router_root)
+    if install_extra_routes is not None:
+        install_extra_routes(http_router_root)
+
+    if static_assets is not None:
+        swstatic.install(http_router_root, static_assets)
 
     def _on_http_server_request(server, request, respond):
         http_router_root.serve(request, respond)

--- a/src/lib.act
+++ b/src/lib.act
@@ -22,7 +22,8 @@ TTT_DB_MAP_SIZE = 1 << 40
 
 def main(sysspec: swapp.SysSpec, env: Env, http: bool=True, netconf: bool=True,
          system_settings_files: ?list[str]=None,
-         system_settings: ?list[dict[str, ?value]]=None):
+         system_settings: ?list[dict[str, ?value]]=None,
+         static_assets: ?dict[str, str]=None):
     """Start a production StratoWeave application.
 
     This entrypoint wires together the standard runtime components used by a
@@ -35,6 +36,9 @@ def main(sysspec: swapp.SysSpec, env: Env, http: bool=True, netconf: bool=True,
         http (bool): When `True`, start the built-in HTTP server
         system_settings_files: AON system settings files, in precedence order
         system_settings: Decoded AON system settings applied after the files
+        static_assets: Optional embedded static assets (URL path -> text
+            content, e.g. a built web UI) served by the HTTP server alongside
+            the APIs, with SPA fallback; see the static_assets module
 
     Startup behavior:
         Any startup config files provided on the command line are merged and
@@ -80,7 +84,7 @@ def main(sysspec: swapp.SysSpec, env: Env, http: bool=True, netconf: bool=True,
         resolved_settings = swapp.SystemSettings.parse(
             env.argv, all_system_settings, environment
         )
-        _start(sysspec, env, resolved_settings, http, netconf)
+        _start(sysspec, env, resolved_settings, http, netconf, static_assets)
     except argconf.PrintHelp as exc:
         print(str(exc))
         env.exit(0)
@@ -93,7 +97,8 @@ def main(sysspec: swapp.SysSpec, env: Env, http: bool=True, netconf: bool=True,
 
 def _start(sysspec: swapp.SysSpec, env: Env,
            system_settings: swapp.SystemSettings,
-           http: bool, netconf: bool):
+           http: bool, netconf: bool,
+           static_assets: ?dict[str, str]=None):
     fcap = file.FileCap(env.cap)
     rfcap = file.ReadFileCap(fcap)
 
@@ -140,7 +145,7 @@ def _start(sysspec: swapp.SysSpec, env: Env,
         if http:
             tcpl_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
             enable_tmf = len(tmf.cfs.services_from_schema(top_schema)) > 0
-            swhttp.HttpServer(tcpl_cap, top_schema=top_schema, cfs=cfs, dev_registry=dev_registry, schema_for_layer=sysspec.schema_for_layer, enable_tmf_api=enable_tmf, log_handler=logh_http, port=system_settings.http_port)
+            swhttp.HttpServer(tcpl_cap, top_schema=top_schema, cfs=cfs, dev_registry=dev_registry, schema_for_layer=sysspec.schema_for_layer, static_assets=static_assets, enable_tmf_api=enable_tmf, log_handler=logh_http, port=system_settings.http_port)
 
         if netconf:
             nc_listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))

--- a/src/static_assets.act
+++ b/src/static_assets.act
@@ -1,0 +1,135 @@
+# Serving of embedded static assets (e.g. a built web UI) alongside the API
+# routes of an http_router.Router. Assets are plain in-memory strings served
+# by a catch-all `GET /*path` route. The router scores static and parameter
+# segments above wildcards, so every registered route takes precedence — an
+# asset can never shadow an API endpoint. The converse also holds: an asset
+# whose path an existing GET route matches (static, param or wildcard) is
+# unreachable; keep asset paths out of the API namespace. Registering the
+# catch-all fails at install time if another root-level GET wildcard exists.
+#
+# Only text content can be served (the http respond path UTF-8-encodes str
+# bodies); binary files (images, fonts, precompressed archives) must be
+# inlined by the asset build (e.g. as data URIs) before being embedded.
+
+import http_router
+
+
+_IMMUTABLE_CACHE = "public, max-age=31536000, immutable"
+_DEFAULT_CACHE = "no-cache"
+_FALLBACK_CONTENT_TYPE = "text/plain; charset=utf-8"
+_HTML_CONTENT_TYPE = "text/html; charset=utf-8"
+
+_CONTENT_TYPES: dict[str, str] = {
+    ".html": _HTML_CONTENT_TYPE,
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json",
+    ".map": "application/json",
+    ".svg": "image/svg+xml",
+    ".xml": "application/xml",
+    ".webmanifest": "application/manifest+json",
+    ".txt": _FALLBACK_CONTENT_TYPE,
+}
+
+
+def content_type(path: str) -> str:
+    """Best-effort Content-Type derived from the asset path's file extension."""
+    idx = path.rfind(".")
+    if idx < 0:
+        return _FALLBACK_CONTENT_TYPE
+    return _CONTENT_TYPES.get_def(path[idx:].lower(), _FALLBACK_CONTENT_TYPE)
+
+
+def _accepts_html(accept: str) -> bool:
+    """Whether Accept explicitly allows the text/html media type."""
+    for media_range in accept.split(","):
+        parts = media_range.split(";")
+        if parts[0].strip().lower() != "text/html":
+            continue
+
+        quality = 1.0
+        idx = 1
+        while idx < len(parts):
+            parameter = parts[idx].strip()
+            if "=" in parameter:
+                pair = parameter.split("=", 1)
+                if pair[0].strip().lower() == "q":
+                    try:
+                        quality = float(pair[1].strip())
+                    except ValueError:
+                        quality = 0.0
+                    break
+            idx += 1
+
+        if quality > 0.0 and quality <= 1.0:
+            return True
+    return False
+
+
+def _make_asset_handler(
+    prepared: dict[str, (body: str, ctype: str, cache: str)],
+    index_body: ?str,
+    spa_fallback: bool
+) -> proc(http_router.Context, proc(int, dict[str, str], str) -> None) -> None:
+    """Handler for the catch-all GET route: exact asset, SPA fallback, or 404."""
+    def handler(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
+        entry = prepared.get(ctx.path)
+        if entry is not None:
+            respond(200, {"Content-Type": entry.ctype, "Cache-Control": entry.cache}, entry.body)
+            return
+        # Serve the SPA entry page only for navigation-like requests whose
+        # Accept header explicitly allows text/html. Everything else (API
+        # clients, subresource fetches) keeps getting a plain 404.
+        idx = index_body
+        if spa_fallback and idx is not None:
+            accept = ctx.request.headers.get("accept")
+            if accept is not None and _accepts_html(accept):
+                respond(200, {"Content-Type": _HTML_CONTENT_TYPE, "Cache-Control": _DEFAULT_CACHE, "Vary": "Accept"}, idx)
+                return
+            # A cache must keep this response separate from the HTML
+            # representation selected for the same URL by Accept.
+            respond(404, {"Vary": "Accept"}, "")
+            return
+        respond(404, {}, "")
+    return handler
+
+
+def install(
+    router: http_router.Router,
+    assets: dict[str, str],
+    index_path: str = "/index.html",
+    immutable_prefix: str = "/_app/immutable/",
+    spa_fallback: bool = True
+):
+    """Serve embedded static assets, optionally with a SPA fallback.
+
+    Assets (normalized URL path -> content) are served by a catch-all
+    `GET /*path` route. The router prefers static and parameter segments over
+    wildcards, so registered routes always win and API endpoints can never be
+    shadowed by an asset. The flip side: an asset whose path an existing GET
+    route already matches is unreachable — keep asset paths (e.g. /index.html
+    and a hashed-asset subtree) out of the API namespace.
+
+    Assets under immutable_prefix get a long-lived immutable Cache-Control
+    (content-hashed filenames); everything else is no-cache. When index_path
+    is present in assets, "/" serves it, and with spa_fallback enabled any
+    other unmatched GET request that accepts text/html gets it too
+    (client-side routed pages survive a browser refresh).
+
+    Raises ValueError if the router already has a root-level GET wildcard
+    route. Requests for other methods are not affected and still reach the
+    router's not-found handler.
+    """
+    prepared: dict[str, (body: str, ctype: str, cache: str)] = {}
+    for path, body in assets.items():
+        if not path.startswith("/"):
+            raise ValueError("Embedded asset path must start with '/': " + path)
+        cache = _IMMUTABLE_CACHE if path.startswith(immutable_prefix) else _DEFAULT_CACHE
+        prepared[path] = (body=body, ctype=content_type(path), cache=cache)
+
+    index_body = assets.get(index_path)
+    if index_body is not None:
+        prepared["/"] = (body=index_body, ctype=_HTML_CONTENT_TYPE, cache=_DEFAULT_CACHE)
+
+    router.get("/*path", _make_asset_handler(prepared, index_body, spa_fallback))

--- a/src/test_static_assets.act
+++ b/src/test_static_assets.act
@@ -1,0 +1,162 @@
+import http
+import http_router
+import testing
+
+import static_assets as swstatic
+
+
+class _ResponseCapture(object):
+    def __init__(self, on_done: ?proc(_ResponseCapture) -> None = None):
+        self.status = 0
+        self.headers = {}
+        self.body = ""
+        self.on_done = on_done
+
+    def respond(self, status: int, headers: dict[str, str], body: str):
+        self.status = status
+        self.headers = headers
+        self.body = body
+        on_done = self.on_done
+        if on_done is not None:
+            on_done(self)
+
+
+def _request(method: str, path: str, headers: dict[str, str] = {}, body: bytes = b"") -> http.Request:
+    return http.Request(method, path, b"1.1", headers, body)
+
+
+def _serve_expect(
+    t: testing.EnvT,
+    r: http_router.Router,
+    request: http.Request,
+    expected_status: int,
+    expected_body: str,
+    expected_headers: dict[str, str],
+    next: ?proc() -> None = None
+):
+    def done(res: _ResponseCapture):
+        try:
+            testing.assertEqual(res.status, expected_status)
+            testing.assertEqual(res.body, expected_body)
+            for name, val in expected_headers.items():
+                testing.assertEqual(res.headers.get_def(name, "<missing header>"), val)
+            cont = next
+            if cont is not None:
+                cont()
+            else:
+                t.success()
+        except Exception as e:
+            t.failure(e)
+
+    try:
+        res = _ResponseCapture(done)
+        r.serve(request, res.respond)
+    except Exception as e:
+        t.failure(e)
+
+
+_INDEX_BODY = "<!doctype html><title>ui</title>"
+
+
+def _assets() -> dict[str, str]:
+    return {
+        "/index.html": _INDEX_BODY,
+        "/_app/version.json": r'{"version":"0.2.0"}',
+        "/_app/immutable/chunks/a.js": "console.log(1)",
+    }
+
+
+def _test_content_type():
+    testing.assertEqual(swstatic.content_type("/index.html"), "text/html; charset=utf-8")
+    testing.assertEqual(swstatic.content_type("/_app/immutable/chunks/a.js"), "text/javascript; charset=utf-8")
+    testing.assertEqual(swstatic.content_type("/_app/immutable/entry/start.mjs"), "text/javascript; charset=utf-8")
+    testing.assertEqual(swstatic.content_type("/_app/immutable/assets/root.css"), "text/css; charset=utf-8")
+    testing.assertEqual(swstatic.content_type("/_app/version.json"), "application/json")
+    testing.assertEqual(swstatic.content_type("/chunk.js.map"), "application/json")
+    testing.assertEqual(swstatic.content_type("/logo.svg"), "image/svg+xml")
+    testing.assertEqual(swstatic.content_type("/robots.txt"), "text/plain; charset=utf-8")
+    testing.assertEqual(swstatic.content_type("/no-extension"), "text/plain; charset=utf-8")
+    testing.assertEqual(swstatic.content_type("/unknown.bin"), "text/plain; charset=utf-8")
+
+
+actor _test_serves_assets_with_cache_headers(t: testing.EnvT):
+    r = http_router.Router()
+
+    def after_index_alias():
+        _serve_expect(t, r, _request("GET", "/index.html"), 200, _INDEX_BODY,
+            {"Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-cache"})
+
+    def after_root():
+        _serve_expect(t, r, _request("GET", "/"), 200, _INDEX_BODY,
+            {"Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-cache"}, after_index_alias)
+
+    def after_version():
+        _serve_expect(t, r, _request("GET", "/_app/version.json"), 200, r'{"version":"0.2.0"}',
+            {"Content-Type": "application/json", "Cache-Control": "no-cache"}, after_root)
+
+    try:
+        swstatic.install(r, _assets())
+        _serve_expect(t, r, _request("GET", "/_app/immutable/chunks/a.js"), 200, "console.log(1)",
+            {"Content-Type": "text/javascript; charset=utf-8", "Cache-Control": "public, max-age=31536000, immutable"},
+            after_version)
+    except Exception as e:
+        t.failure(e)
+
+
+actor _test_spa_fallback_heuristic(t: testing.EnvT):
+    r = http_router.Router()
+
+    def after_zero_quality():
+        _serve_expect(t, r, _request("GET", "/services/foo", {"accept": "TEXT/HTML"}),
+            200, _INDEX_BODY, {"Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-cache", "Vary": "Accept"})
+
+    def after_post():
+        # An explicit q=0 means that HTML is not acceptable.
+        _serve_expect(t, r, _request("GET", "/services/foo", {"accept": "application/json, text/html;q=0"}),
+            404, "", {"Vary": "Accept"}, after_zero_quality)
+
+    def after_non_get():
+        # Query strings do not confuse the fallback.
+        _serve_expect(t, r, _request("GET", "/services/l3vpn-site/new?clone=x", {"accept": "text/html"}),
+            200, _INDEX_BODY, {"Vary": "Accept"}, after_post)
+
+    def after_no_accept():
+        # Other methods never reach the asset route; the router's default
+        # not-found handler answers.
+        _serve_expect(t, r, _request("POST", "/services/foo", {"accept": "text/html"}), 404, "", {}, after_non_get)
+
+    def after_api_accept():
+        _serve_expect(t, r, _request("GET", "/services/foo"), 404, "", {"Vary": "Accept"}, after_no_accept)
+
+    def after_navigation():
+        _serve_expect(t, r, _request("GET", "/services/foo", {"accept": "*/*"}), 404, "", {"Vary": "Accept"}, after_api_accept)
+
+    try:
+        swstatic.install(r, _assets())
+        _serve_expect(t, r, _request("GET", "/services/foo", {"accept": "text/html,application/xhtml+xml;q=0.9"}),
+            200, _INDEX_BODY, {"Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-cache", "Vary": "Accept"},
+            after_navigation)
+    except Exception as e:
+        t.failure(e)
+
+
+def _test_rejects_relative_paths():
+    relative_raised = 0
+    try:
+        swstatic.install(http_router.Router(), {"index.html": "x"})
+    except ValueError:
+        relative_raised = 1
+    testing.assertEqual(relative_raised, 1)
+
+
+actor _test_no_index_no_fallback(t: testing.EnvT):
+    r = http_router.Router()
+
+    def after_missing():
+        _serve_expect(t, r, _request("GET", "/", {"accept": "text/html"}), 404, "", {})
+
+    try:
+        swstatic.install(r, {"/_app/immutable/chunks/a.js": "console.log(1)"})
+        _serve_expect(t, r, _request("GET", "/services/foo", {"accept": "text/html"}), 404, "", {}, after_missing)
+    except Exception as e:
+        t.failure(e)


### PR DESCRIPTION
Applications can pass static_assets (URL path -> text content) to stratoweave.main() / HttpServer to serve an embedded web UI on the same listener as the APIs. Assets are served for GET requests from the router's not-found handler, so registered routes always take precedence and API endpoints can never be shadowed by an asset.

Content-Type is derived from the file extension. Content-hashed assets under /_app/immutable/ get an immutable Cache-Control, everything else is no-cache, and "/" serves /index.html. A SPA fallback returns index.html for unmatched GETs whose Accept names text/html (browser navigations), so client-side routed pages survive a refresh while API clients keep getting real 404s.

Response bodies are str, so only text assets can be embedded; binary files must be inlined by the frontend build (e.g. as data URIs). Defaults to None -- no behavior change for existing callers. First consumer is SORESPO's embedded Web UI.

https://github.com/stratoweave/sorespo/pull/355 uses this for embedding webui into the binary.

Down the line we want to move core webui into SW and expose interface so sorespo like implementations can extend it ie. with service views and stuff.