### PR TITLE
Configure the northbound NETCONF server SSH transport

### DIFF
--- a/docs/operations/devices.md
+++ b/docs/operations/devices.md
@@ -160,9 +160,8 @@ library does not support is rejected by the YANG enumeration; anything that
 slips past is logged and leaves the device disconnected rather than retrying a
 connection that can never come up.
 
-Northbound NETCONF server transport settings are not configurable yet -- the
-plumbing is in `NetconfServer(ssh_transport=...)`, but nothing in the model
-drives it.
+The northbound NETCONF server has its own equivalent settings, configured as
+system settings rather than as intent; see [Running StratoWeave](run.md).
 
 ## RFS models still define the service-specific southbound data
 

--- a/docs/operations/run.md
+++ b/docs/operations/run.md
@@ -37,39 +37,62 @@ StratoWeave orchestrator.
 
 ```console title="Inspect runtime options for a StratoWeave orchestrator"
 out/bin/sorespo --help
-Usage: /sorespo [--db DB] [--exit-on-done] [--help] [--http-port HTTP-PORT] [--netconf-host-key NETCONF-HOST-KEY] [--netconf-password NETCONF-PASSWORD] [--netconf-port NETCONF-PORT] [--netconf-user NETCONF-USER] FILE [FILE ...]
+Usage: sorespo [OPTIONS] [--] [FILE ...]
 
-Positional arguments:
-  FILE           Config XML file(s)
+Arguments:
+  FILE ...
+      Startup configuration files, applied in order
+      env: STRATOWEAVE_STARTUP_CONFIG_FILES; default: []
 
 Options:
-  --db DB        LMDB directory for TTT persistence
-  --exit-on-done Exit after startup config has been applied
-  --help         show this help message
-  --http-port HTTP-PORT HTTP listen port
-  --netconf-host-key NETCONF-HOST-KEY SSH host key file for NETCONF; ephemeral in-memory key if unset
-  --netconf-password NETCONF-PASSWORD NETCONF SSH password (v1 static credential)
-  --netconf-port NETCONF-PORT NETCONF SSH listen port
-  --netconf-user NETCONF-USER NETCONF SSH username (v1 static credential)
+  --db TEXT
+      TTT database: an LMDB path or a database URL
+      env: STRATOWEAVE_DB; optional
+  --exit-on-done / --no-exit-on-done
+      Exit after startup config has been applied
+      env: STRATOWEAVE_EXIT_ON_DONE; default: False
+  --http.port INT
+      HTTP listen port
+      env: STRATOWEAVE_HTTP__PORT; default: 80
+  --netconf.port INT
+      NETCONF SSH listen port
+      env: STRATOWEAVE_NETCONF__PORT; default: 830
+  --netconf.user TEXT
+      NETCONF SSH username (v1 static credential)
+      env: STRATOWEAVE_NETCONF__USER; default: admin
+  ...
 ```
 
-The required `FILE` arguments are startup configuration documents that are
-loaded in the order given. In practice, operators often keep a base system
-configuration in one file and add environment-specific overlays as later
-arguments.
+Every setting has the same three spellings: a key in an AON settings file, an
+environment variable, and a command-line option. They resolve in that order,
+so the command line wins. Settings that belong to one subsystem share a path,
+which is a nesting in the settings file and a `__` separator in the
+environment.
 
-The most important runtime options are:
+```aon title="system.aon"
+db = "/var/lib/sorespo"
+http:
+    port = 8080
+netconf:
+    port = 1830
+    user = "netops"
+```
 
-- `--db` enables LMDB-backed persistence, specifying the directory in which
-  to store the database. If you omit this option, your StratoWeave
-  orchestrator will run in a stateless mode and all configuration will be
+The `FILE` arguments are startup configuration documents, applied in the order
+given. Operators often keep a base system configuration in one file and add
+environment-specific overlays as later arguments.
+
+The most important settings are:
+
+- `--db` enables persistence, taking either an LMDB directory or a database
+  URL. Without it the orchestrator runs stateless and all configuration is
   lost on shutdown.
-- `--http-port` changes the HTTP listener, which defaults to `80`.
-- `--netconf-port` changes the NETCONF over SSH listener, which defaults to
+- `--http.port` changes the HTTP listener, which defaults to `80`.
+- `--netconf.port` changes the NETCONF over SSH listener, which defaults to
   `830`.
-- `--netconf-host-key` points to a persistent SSH host key. If you omit it,
-  SORESPO generates an ephemeral in-memory key at startup.
-- `--netconf-user` and `--netconf-password` configure the built-in static
+- `--netconf.ssh.host-key` points to a persistent SSH host key. If you omit
+  it, an ephemeral in-memory key is generated at startup.
+- `--netconf.user` and `--netconf.password` configure the built-in static
   NETCONF credentials. They default to `admin` / `admin` and should be
   overridden outside local testing.
 - `--exit-on-done` applies the supplied startup configuration and then exits
@@ -79,25 +102,25 @@ The most important runtime options are:
 ### NETCONF server SSH transport
 
 The SSH transport the northbound NETCONF server offers is configured under
-`netconf_ssh`, through the same three sources as every other system setting.
-Leave it alone and the SSH library's defaults apply.
+`netconf.ssh`. Leave it alone and the SSH library's defaults apply.
 
 ```aon title="system.aon"
-netconf_ssh:
-    cipher = ["aes256-gcm@openssh.com", "aes256-ctr"]
-    host_key_algorithm = ["ssh-ed25519"]
-    rekey_after_seconds = 3600
+netconf:
+    ssh:
+        cipher = ["aes256-gcm@openssh.com", "aes256-ctr"]
+        host_key_algorithm = ["ssh-ed25519"]
+        rekey_after_seconds = 3600
 ```
 
-The same settings are `--netconf-ssh.cipher` on the command line, repeated once
-per value, and `STRATOWEAVE_NETCONF_SSH__CIPHER` in the environment.
+The same settings are `--netconf.ssh.cipher` on the command line, repeated once
+per value, and `STRATOWEAVE_NETCONF__SSH__CIPHER` in the environment.
 
 The algorithm lists (`cipher`, `mac`, `key_exchange`, `host_key_algorithm`,
 `public_key_algorithm`, `compression_algorithm`) are ordered preference lists,
 most preferred first, and an empty one means the library default. The rest are
 `compression_level` (1-9, default 7), `rekey_after_bytes`,
-`rekey_after_seconds` and `minimum_rsa_bits`. Both rekey limits take `0` to
-mean unset: no byte limit beyond the negotiated cipher's own, and no
+`rekey_after_seconds` and `minimum_rsa_bits`. Both rekey limits are optional:
+unset means no byte limit beyond the negotiated cipher's own, and no
 time-based rekeying.
 
 An algorithm name the SSH library does not support fails at startup rather

--- a/docs/operations/run.md
+++ b/docs/operations/run.md
@@ -76,6 +76,35 @@ The most important runtime options are:
   instead of continuing to serve traffic. This is useful for CI validation or
   one-shot initialization jobs.
 
+### NETCONF server SSH transport
+
+The SSH transport the northbound NETCONF server offers is configured under
+`netconf_ssh`, through the same three sources as every other system setting.
+Leave it alone and the SSH library's defaults apply.
+
+```aon title="system.aon"
+netconf_ssh:
+    cipher = ["aes256-gcm@openssh.com", "aes256-ctr"]
+    host_key_algorithm = ["ssh-ed25519"]
+    rekey_after_seconds = 3600
+```
+
+The same settings are `--netconf-ssh.cipher` on the command line, repeated once
+per value, and `STRATOWEAVE_NETCONF_SSH__CIPHER` in the environment.
+
+The algorithm lists (`cipher`, `mac`, `key_exchange`, `host_key_algorithm`,
+`public_key_algorithm`, `compression_algorithm`) are ordered preference lists,
+most preferred first, and an empty one means the library default. The rest are
+`compression_level` (1-9, default 7), `rekey_after_bytes`,
+`rekey_after_seconds` and `minimum_rsa_bits`. Both rekey limits take `0` to
+mean unset: no byte limit beyond the negotiated cipher's own, and no
+time-based rekeying.
+
+An algorithm name the SSH library does not support fails at startup rather
+than on the first connection. The equivalent settings for connections *to*
+devices live in the device's `ssh` container, described in
+[Device management](devices.md).
+
 ### Acton Runtime System
 As for any Acton application, you can also configure the [Acton Runtime System](https://acton.guide/rts.html).
 

--- a/fleetmgr/Justfile
+++ b/fleetmgr/Justfile
@@ -10,11 +10,11 @@ build:
 
 # Start one RFS-only bottom node without the fleet manager supervisor.
 flotilla:
-	out/bin/flotilla --http-port 18201 --netconf-port 12901
+	out/bin/flotilla --http.port 18201 --netconf.port 12901
 
 # Start the top, which spawns ten flotillas, with the 20-device demo.
 demo:
-	out/bin/fleetmgr --http-port 18200 --netconf-port 12900 demo.xml
+	out/bin/fleetmgr --http.port 18200 --netconf.port 12900 demo.xml
 
 # Submit the two-device IOS XE demo campaign.
 upgrade:

--- a/fleetmgr/src/fleetmgr/supervisor.act
+++ b/fleetmgr/src/fleetmgr/supervisor.act
@@ -11,8 +11,8 @@ def flotilla_command(index: int) -> list[str]:
     return [
         FLOTILLA_BIN,
         "--rts-wthreads", "2",
-        "--http-port", str(BASE_HTTP_PORT + index),
-        "--netconf-port", str(BASE_NETCONF_PORT + index),
+        "--http.port", str(BASE_HTTP_PORT + index),
+        "--netconf.port", str(BASE_NETCONF_PORT + index),
     ]
 
 

--- a/minisys/test/test_persistence_restart.sh
+++ b/minisys/test/test_persistence_restart.sh
@@ -37,7 +37,7 @@ wait_for_http() {
 start_mini() {
     (
         cd "$ROOT_DIR"
-        exec "$BIN_FILE" --db "$DB_PATH" --http-port "$PORT"
+        exec "$BIN_FILE" --db "$DB_PATH" --http.port "$PORT"
     ) >/dev/null 2>&1 &
     PID=$!
     wait_for_http

--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -1,6 +1,7 @@
 import logging
 import net
 import ssh
+import ssh_config
 import testing
 import std.xml as xml
 
@@ -19,28 +20,22 @@ CONNECTED     = 2
 TRANSACTION   = 3
 
 def ssh_transport_config(cfg: DeviceMetaConfigSsh) -> ssh.TransportConfig:
-    """Build an SSH TransportConfig from a device's ssh container.
-
-    An empty algorithm leaf-list means "no preference": pass None so the SSH
-    library uses its own default list rather than an empty negotiation set.
-    The library validates the algorithm names and the numeric ranges, raising
-    ValueError on anything it does not support.
-    """
+    """Build an SSH TransportConfig from a device's ssh container."""
     # Bind the optionals to locals: narrowing does not carry through an
     # attribute access.
     rekey_bytes = cfg.rekey_after_bytes
     rekey_seconds = cfg.rekey_after_seconds
-    return ssh.TransportConfig(
-        ciphers=[ssh.Cipher(n) for n in cfg.cipher] if len(cfg.cipher) > 0 else None,
-        macs=[ssh.Mac(n) for n in cfg.mac] if len(cfg.mac) > 0 else None,
-        key_exchanges=[ssh.KeyExchange(n) for n in cfg.key_exchange] if len(cfg.key_exchange) > 0 else None,
-        host_key_algorithms=[ssh.HostKeyAlgorithm(n) for n in cfg.host_key_algorithm] if len(cfg.host_key_algorithm) > 0 else None,
-        public_key_algorithms=[ssh.PublicKeyAlgorithm(n) for n in cfg.public_key_algorithm] if len(cfg.public_key_algorithm) > 0 else None,
-        compression_algorithms=[ssh.CompressionAlgorithm(n) for n in cfg.compression_algorithm] if len(cfg.compression_algorithm) > 0 else None,
-        compression_level=int(cfg.compression_level),
-        rekey_after_bytes=int(rekey_bytes) if rekey_bytes is not None else None,
-        rekey_after_seconds=int(rekey_seconds) if rekey_seconds is not None else None,
-        minimum_rsa_bits=int(cfg.minimum_rsa_bits))
+    return ssh_config.transport_config(
+        cfg.cipher,
+        cfg.mac,
+        cfg.key_exchange,
+        cfg.host_key_algorithm,
+        cfg.public_key_algorithm,
+        cfg.compression_algorithm,
+        int(cfg.compression_level),
+        int(rekey_bytes) if rekey_bytes is not None else None,
+        int(rekey_seconds) if rekey_seconds is not None else None,
+        int(cfg.minimum_rsa_bits))
 
 
 class MockRoot(yadata.MNode):

--- a/src/app.act
+++ b/src/app.act
@@ -1,6 +1,8 @@
 import argconf
 import file
 import logging
+import ssh
+import ssh_config
 import std.xml as xml
 
 import db as swdb
@@ -35,6 +37,122 @@ class SysSpec(value):
         return self.schema_for_layer(layer)
 
 
+class SshTransportSettings(value):
+    """SSH transport settings for a listening or connecting SSH endpoint.
+
+    Empty algorithm lists mean "no preference" and leave the SSH library
+    default in place. A rekey limit of None uses the negotiated cipher's RFC
+    4344 volume limit for bytes, and disables time-based rekeying for seconds.
+    """
+    ciphers: list[str]
+    macs: list[str]
+    key_exchanges: list[str]
+    host_key_algorithms: list[str]
+    public_key_algorithms: list[str]
+    compression_algorithms: list[str]
+    compression_level: int
+    rekey_after_bytes: ?int
+    rekey_after_seconds: ?int
+    minimum_rsa_bits: int
+
+    def __init__(self, ciphers: list[str], macs: list[str],
+                 key_exchanges: list[str], host_key_algorithms: list[str],
+                 public_key_algorithms: list[str],
+                 compression_algorithms: list[str],
+                 compression_level: int, rekey_after_bytes: ?int,
+                 rekey_after_seconds: ?int, minimum_rsa_bits: int):
+        self.ciphers = ciphers
+        self.macs = macs
+        self.key_exchanges = key_exchanges
+        self.host_key_algorithms = host_key_algorithms
+        self.public_key_algorithms = public_key_algorithms
+        self.compression_algorithms = compression_algorithms
+        self.compression_level = compression_level
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits
+
+    @staticmethod
+    def declare(p: argconf.Parser, prefix: str):
+        """Declare the transport settings for one endpoint under `prefix`."""
+        p.add_str_list(
+            prefix + ".cipher", default=[],
+            help="Ciphers to offer, most preferred first"
+        )
+        p.add_str_list(
+            prefix + ".mac", default=[],
+            help="MAC algorithms to offer, most preferred first"
+        )
+        p.add_str_list(
+            prefix + ".key_exchange", default=[],
+            help="Key exchange algorithms to offer, most preferred first"
+        )
+        p.add_str_list(
+            prefix + ".host_key_algorithm", default=[],
+            help="Host key algorithms to offer, most preferred first"
+        )
+        p.add_str_list(
+            prefix + ".public_key_algorithm", default=[],
+            help="Public key algorithms to accept, most preferred first"
+        )
+        p.add_str_list(
+            prefix + ".compression_algorithm", default=[],
+            help="Compression algorithms to offer, most preferred first"
+        )
+        p.add_int(
+            prefix + ".compression_level", default=7,
+            help="zlib compression level, 1 (fastest) to 9 (smallest)"
+        )
+        p.add_int(
+            prefix + ".rekey_after_bytes", default=0,
+            help="Rekey after this many bytes; 0 uses the cipher's own limit"
+        )
+        p.add_int(
+            prefix + ".rekey_after_seconds", default=0,
+            help="Rekey after this many seconds; 0 disables time-based rekeying"
+        )
+        p.add_int(
+            prefix + ".minimum_rsa_bits", default=1024,
+            help="Reject RSA keys shorter than this"
+        )
+
+    @staticmethod
+    def read(args: argconf.Config, prefix: str) -> SshTransportSettings:
+        """Read the settings declared by `declare` under the same prefix."""
+        def opt_int(name: str) -> ?int:
+            # argconf has no notion of an optional setting -- a declaration
+            # without a default makes it required -- so 0 is the unset value
+            # for both rekey limits, the way "" is for db and netconf_host_key.
+            limit = args.get_int(prefix + "." + name)
+            return limit if limit != 0 else None
+
+        return SshTransportSettings(
+            args.get_str_list(prefix + ".cipher"),
+            args.get_str_list(prefix + ".mac"),
+            args.get_str_list(prefix + ".key_exchange"),
+            args.get_str_list(prefix + ".host_key_algorithm"),
+            args.get_str_list(prefix + ".public_key_algorithm"),
+            args.get_str_list(prefix + ".compression_algorithm"),
+            args.get_int(prefix + ".compression_level"),
+            opt_int("rekey_after_bytes"),
+            opt_int("rekey_after_seconds"),
+            args.get_int(prefix + ".minimum_rsa_bits"))
+
+    def transport_config(self) -> ssh.TransportConfig:
+        """Build the SSH TransportConfig these settings describe."""
+        return ssh_config.transport_config(
+            self.ciphers,
+            self.macs,
+            self.key_exchanges,
+            self.host_key_algorithms,
+            self.public_key_algorithms,
+            self.compression_algorithms,
+            self.compression_level,
+            self.rekey_after_bytes,
+            self.rekey_after_seconds,
+            self.minimum_rsa_bits)
+
+
 class SystemSettings(value):
     startup_config_files: list[str]
     db_spec: ?str
@@ -43,12 +161,14 @@ class SystemSettings(value):
     netconf_host_key_path: ?str
     netconf_user: str
     netconf_password: str
+    netconf_ssh: SshTransportSettings
     exit_on_done: bool
 
     def __init__(self, startup_config_files: list[str], db_spec: ?str,
                  http_port: int, netconf_port: int,
                  netconf_host_key_path: ?str,
                  netconf_user: str, netconf_password: str,
+                 netconf_ssh: SshTransportSettings,
                  exit_on_done: bool):
         self.startup_config_files = startup_config_files
         self.db_spec = db_spec
@@ -57,6 +177,7 @@ class SystemSettings(value):
         self.netconf_host_key_path = netconf_host_key_path
         self.netconf_user = netconf_user
         self.netconf_password = netconf_password
+        self.netconf_ssh = netconf_ssh
         self.exit_on_done = exit_on_done
 
     @staticmethod
@@ -82,6 +203,7 @@ class SystemSettings(value):
             "netconf_password", default="admin",
             help="NETCONF SSH password (v1 static credential)"
         )
+        SshTransportSettings.declare(p, "netconf_ssh")
         p.add_bool("exit_on_done", help="Exit after startup config has been applied")
         return p
 
@@ -99,6 +221,7 @@ class SystemSettings(value):
             args.get_opt_str("netconf_host_key"),
             args.get_str("netconf_user"),
             args.get_str("netconf_password"),
+            SshTransportSettings.read(args, "netconf_ssh"),
             args.get_bool("exit_on_done"))
 
 

--- a/src/app.act
+++ b/src/app.act
@@ -104,12 +104,12 @@ class SshTransportSettings(value):
             help="zlib compression level, 1 (fastest) to 9 (smallest)"
         )
         p.add_int(
-            prefix + ".rekey_after_bytes", default=0,
-            help="Rekey after this many bytes; 0 uses the cipher's own limit"
+            prefix + ".rekey_after_bytes",
+            help="Rekey after this many bytes; the cipher's own limit if unset"
         )
         p.add_int(
-            prefix + ".rekey_after_seconds", default=0,
-            help="Rekey after this many seconds; 0 disables time-based rekeying"
+            prefix + ".rekey_after_seconds",
+            help="Rekey after this many seconds; no time-based rekey if unset"
         )
         p.add_int(
             prefix + ".minimum_rsa_bits", default=1024,
@@ -119,13 +119,6 @@ class SshTransportSettings(value):
     @staticmethod
     def read(args: argconf.Config, prefix: str) -> SshTransportSettings:
         """Read the settings declared by `declare` under the same prefix."""
-        def opt_int(name: str) -> ?int:
-            # argconf has no notion of an optional setting -- a declaration
-            # without a default makes it required -- so 0 is the unset value
-            # for both rekey limits, the way "" is for db and netconf_host_key.
-            limit = args.get_int(prefix + "." + name)
-            return limit if limit != 0 else None
-
         return SshTransportSettings(
             args.get_str_list(prefix + ".cipher"),
             args.get_str_list(prefix + ".mac"),
@@ -134,8 +127,8 @@ class SshTransportSettings(value):
             args.get_str_list(prefix + ".public_key_algorithm"),
             args.get_str_list(prefix + ".compression_algorithm"),
             args.get_int(prefix + ".compression_level"),
-            opt_int("rekey_after_bytes"),
-            opt_int("rekey_after_seconds"),
+            args.get_opt_int(prefix + ".rekey_after_bytes"),
+            args.get_opt_int(prefix + ".rekey_after_seconds"),
             args.get_int(prefix + ".minimum_rsa_bits"))
 
     def transport_config(self) -> ssh.TransportConfig:
@@ -189,21 +182,21 @@ class SystemSettings(value):
             help="Startup configuration files, applied in order"
         )
         p.add_str("db", help="TTT database: an LMDB path or a database URL")
-        p.add_int("http_port", default=80, help="HTTP listen port")
-        p.add_int("netconf_port", default=830, help="NETCONF SSH listen port")
+        p.add_int("http.port", default=80, help="HTTP listen port")
+        p.add_int("netconf.port", default=830, help="NETCONF SSH listen port")
         p.add_str(
-            "netconf_host_key",
-            help="SSH host key file for NETCONF; ephemeral in-memory key if unset"
-        )
-        p.add_str(
-            "netconf_user", default="admin",
+            "netconf.user", default="admin",
             help="NETCONF SSH username (v1 static credential)"
         )
         p.add_str(
-            "netconf_password", default="admin",
+            "netconf.password", default="admin",
             help="NETCONF SSH password (v1 static credential)"
         )
-        SshTransportSettings.declare(p, "netconf_ssh")
+        p.add_str(
+            "netconf.ssh.host_key",
+            help="SSH host key file for NETCONF; ephemeral in-memory key if unset"
+        )
+        SshTransportSettings.declare(p, "netconf.ssh")
         p.add_bool("exit_on_done", help="Exit after startup config has been applied")
         return p
 
@@ -216,12 +209,12 @@ class SystemSettings(value):
         return SystemSettings(
             args.get_str_list("startup_config_files"),
             args.get_opt_str("db"),
-            args.get_int("http_port"),
-            args.get_int("netconf_port"),
-            args.get_opt_str("netconf_host_key"),
-            args.get_str("netconf_user"),
-            args.get_str("netconf_password"),
-            SshTransportSettings.read(args, "netconf_ssh"),
+            args.get_int("http.port"),
+            args.get_int("netconf.port"),
+            args.get_opt_str("netconf.ssh.host_key"),
+            args.get_str("netconf.user"),
+            args.get_str("netconf.password"),
+            SshTransportSettings.read(args, "netconf.ssh"),
             args.get_bool("exit_on_done"))
 
 

--- a/src/lib.act
+++ b/src/lib.act
@@ -144,7 +144,7 @@ def _start(sysspec: swapp.SysSpec, env: Env,
 
         if netconf:
             nc_listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
-            swnetconf.NetconfServer(nc_listen_cap, log_handler=logh_netconf, top_schema=top_schema, cfs=cfs, port=system_settings.netconf_port, username=system_settings.netconf_user, password=system_settings.netconf_password, host_key=netconf_host_key, subscription_schema=top_oper_schema)
+            swnetconf.NetconfServer(nc_listen_cap, log_handler=logh_netconf, top_schema=top_schema, cfs=cfs, port=system_settings.netconf_port, username=system_settings.netconf_user, password=system_settings.netconf_password, host_key=netconf_host_key, subscription_schema=top_oper_schema, ssh_transport=system_settings.netconf_ssh.transport_config())
 
         swapp.StartupConfigApplier(system_settings.startup_config_files, system_settings.exit_on_done, top_schema, cfs, env.exit, rfcap, logh)
         log.info("StratoWeave running..")

--- a/src/ssh_config.act
+++ b/src/ssh_config.act
@@ -1,0 +1,38 @@
+"""Build SSH transport configuration from plain values.
+
+Both directions need the same mapping: the southbound adapters read it from a
+device's `ssh` container in the intent tree, the northbound NETCONF server from
+system settings. This module holds the one mapping they share.
+"""
+
+import ssh
+
+
+def transport_config(ciphers: list[str],
+                     macs: list[str],
+                     key_exchanges: list[str],
+                     host_key_algorithms: list[str],
+                     public_key_algorithms: list[str],
+                     compression_algorithms: list[str],
+                     compression_level: int,
+                     rekey_after_bytes: ?int,
+                     rekey_after_seconds: ?int,
+                     minimum_rsa_bits: int) -> ssh.TransportConfig:
+    """Build an SSH TransportConfig from algorithm names and numeric limits.
+
+    An empty algorithm list means "no preference": pass None so the SSH library
+    uses its own default list rather than an empty negotiation set. The library
+    validates the algorithm names and the numeric ranges, raising ValueError on
+    anything it does not support.
+    """
+    return ssh.TransportConfig(
+        ciphers=[ssh.Cipher(n) for n in ciphers] if len(ciphers) > 0 else None,
+        macs=[ssh.Mac(n) for n in macs] if len(macs) > 0 else None,
+        key_exchanges=[ssh.KeyExchange(n) for n in key_exchanges] if len(key_exchanges) > 0 else None,
+        host_key_algorithms=[ssh.HostKeyAlgorithm(n) for n in host_key_algorithms] if len(host_key_algorithms) > 0 else None,
+        public_key_algorithms=[ssh.PublicKeyAlgorithm(n) for n in public_key_algorithms] if len(public_key_algorithms) > 0 else None,
+        compression_algorithms=[ssh.CompressionAlgorithm(n) for n in compression_algorithms] if len(compression_algorithms) > 0 else None,
+        compression_level=compression_level,
+        rekey_after_bytes=rekey_after_bytes,
+        rekey_after_seconds=rekey_after_seconds,
+        minimum_rsa_bits=minimum_rsa_bits)

--- a/src/test_argconf.act
+++ b/src/test_argconf.act
@@ -7,10 +7,11 @@ import testing
 
 
 _NETCONF_SSH_AON: str = r"""
-netconf_ssh:
-    cipher = ["aes256-ctr", "aes128-ctr"]
-    minimum_rsa_bits = 3072
-    rekey_after_seconds = 3600
+netconf:
+    ssh:
+        cipher = ["aes256-ctr", "aes128-ctr"]
+        minimum_rsa_bits = 3072
+        rekey_after_seconds = 3600
 """
 
 
@@ -18,15 +19,17 @@ def _test_stratoweave_system_settings():
     system_settings = [aon.decode("""
 db = "/var/lib/stratoweave"
 startup_config_files = ["base.xml"]
-http_port = 8081
-netconf_port = 1830
-netconf_user = "configured"
 exit_on_done = True
+http:
+    port = 8081
+netconf:
+    port = 1830
+    user = "configured"
 """, "stratoweave.aon")]
     resolved_settings = swapp.SystemSettings.parse(
-        ["stratoweave", "--http-port=8080", "startup.xml"],
+        ["stratoweave", "--http.port=8080", "startup.xml"],
         system_settings,
-        {"STRATOWEAVE_NETCONF_USER": "environment"}
+        {"STRATOWEAVE_NETCONF__USER": "environment"}
     )
 
     testing.assertEqual(resolved_settings.startup_config_files, ["startup.xml"])
@@ -703,9 +706,9 @@ def _test_netconf_ssh_from_all_three_sources():
     """SSH settings resolve from configuration, environment, and argv."""
     system_settings = [aon.decode(_NETCONF_SSH_AON, "stratoweave.aon")]
     settings = swapp.SystemSettings.parse(
-        ["stratoweave", "--netconf-ssh.key-exchange=curve25519-sha256"],
+        ["stratoweave", "--netconf.ssh.key-exchange=curve25519-sha256"],
         system_settings,
-        {"STRATOWEAVE_NETCONF_SSH__COMPRESSION_LEVEL": "3"}
+        {"STRATOWEAVE_NETCONF__SSH__COMPRESSION_LEVEL": "3"}
     )
 
     ssh_settings = settings.netconf_ssh
@@ -725,7 +728,7 @@ def _test_netconf_ssh_from_all_three_sources():
 def _test_netconf_ssh_rejects_unsupported_algorithm():
     """An unsupported algorithm name fails when the transport is built."""
     settings = swapp.SystemSettings.parse(
-        ["stratoweave", "--netconf-ssh.cipher=rot13-cbc"])
+        ["stratoweave", "--netconf.ssh.cipher=rot13-cbc"])
     try:
         settings.netconf_ssh.transport_config()
     except ValueError:

--- a/src/test_argconf.act
+++ b/src/test_argconf.act
@@ -1,8 +1,17 @@
 import argconf
 import aon
 import app as swapp
+import ssh
 
 import testing
+
+
+_NETCONF_SSH_AON: str = r"""
+netconf_ssh:
+    cipher = ["aes256-ctr", "aes128-ctr"]
+    minimum_rsa_bits = 3072
+    rekey_after_seconds = 3600
+"""
 
 
 def _test_stratoweave_system_settings():
@@ -672,3 +681,53 @@ route:
     testing.assertTrue("Usage: ip [OPTIONS] COMMAND\n" in root_help, "root usage")
     testing.assertTrue("\nCommands:\n  addr\n      Manage addresses\n  route\n" in root_help, "root commands")
     testing.assertTrue("  -v, --verbose / --no-verbose\n" in root_help, "root option")
+
+
+def _test_netconf_ssh_defaults_to_library_defaults():
+    """Unset SSH settings leave the SSH library's own defaults in place."""
+    settings = swapp.SystemSettings.parse(["stratoweave"])
+    ssh_settings = settings.netconf_ssh
+    testing.assertEqual(ssh_settings.ciphers, [])
+    testing.assertEqual(ssh_settings.rekey_after_bytes, None)
+    testing.assertEqual(ssh_settings.rekey_after_seconds, None)
+    testing.assertEqual(ssh_settings.compression_level, 7)
+    testing.assertEqual(ssh_settings.minimum_rsa_bits, 1024)
+
+    tc = ssh_settings.transport_config()
+    testing.assertEqual([str(c) for c in tc.ciphers], [str(c) for c in ssh.cipher.default])
+    testing.assertEqual(tc.rekey_after_bytes, None)
+    testing.assertEqual(tc.rekey_after_seconds, None)
+
+
+def _test_netconf_ssh_from_all_three_sources():
+    """SSH settings resolve from configuration, environment, and argv."""
+    system_settings = [aon.decode(_NETCONF_SSH_AON, "stratoweave.aon")]
+    settings = swapp.SystemSettings.parse(
+        ["stratoweave", "--netconf-ssh.key-exchange=curve25519-sha256"],
+        system_settings,
+        {"STRATOWEAVE_NETCONF_SSH__COMPRESSION_LEVEL": "3"}
+    )
+
+    ssh_settings = settings.netconf_ssh
+    testing.assertEqual(ssh_settings.ciphers, ["aes256-ctr", "aes128-ctr"])
+    testing.assertEqual(ssh_settings.key_exchanges, ["curve25519-sha256"])
+    testing.assertEqual(ssh_settings.compression_level, 3)
+    testing.assertEqual(ssh_settings.minimum_rsa_bits, 3072)
+    testing.assertEqual(ssh_settings.rekey_after_seconds, 3600)
+    testing.assertEqual(ssh_settings.rekey_after_bytes, None)
+
+    tc = ssh_settings.transport_config()
+    testing.assertEqual([str(c) for c in tc.ciphers], ["aes256-ctr", "aes128-ctr"])
+    testing.assertEqual([str(k) for k in tc.key_exchanges], ["curve25519-sha256"])
+    testing.assertEqual(tc.rekey_after_seconds, 3600)
+
+
+def _test_netconf_ssh_rejects_unsupported_algorithm():
+    """An unsupported algorithm name fails when the transport is built."""
+    settings = swapp.SystemSettings.parse(
+        ["stratoweave", "--netconf-ssh.cipher=rot13-cbc"])
+    try:
+        settings.netconf_ssh.transport_config()
+    except ValueError:
+        return
+    testing.error("expected ValueError for an unsupported cipher")


### PR DESCRIPTION
The device ssh container covers connections to devices. The listening side needs the same settings, but it is not intent, so it belongs in system settings alongside the port and the host key rather than in the tree. The settings live under netconf.ssh and resolve from AON files, the environment and argv like every other system setting. Empty algorithm lists leave the SSH library defaults in place.

The mapping from names and limits to a TransportConfig now lives in ssh_config, since the southbound adapters and the server both need it.

The second commit regroups the existing settings. The flat names were already emulating paths with a netconf_ prefix, so the two servers now own a path each: http.port, netconf.port, netconf.user, netconf.password, and the SSH transport below netconf.ssh, where the host key joins the rest of the SSH server settings. db and exit_on_done stay at the top since they belong to neither.

This renames command-line options and environment variables. In tree, fleetmgr and the minisys restart test move with it. Downstream, sorespo uses only --exit-on-done, which is unchanged, and orchino uses none.