### PR TITLE
Poll the RFS entry every 100 ms in the minisys router

### DIFF
--- a/minisys/src/mini/cfs.act
+++ b/minisys/src/mini/cfs.act
@@ -43,7 +43,7 @@ actor RouterTransform(path: ttt.Path, update_dynstate: proc(?y_0.netinfra__netin
         dst = y1_oper.dst(lambda r, e: on_rfs_state(r, e, router_name))
         rfs = y1_oper.subs.rfs.entry(router_name)
         want.add(dst.deliver({
-            rfs.base_config.state.current_datetime.subscribe(period=1.0)
+            rfs.base_config.state.current_datetime.subscribe(period=0.1)
         }))
         _subs.declare(want)
 


### PR DESCRIPTION
The CFS router reads its RFS entry once a second, and its test allows
200 ms for the router's state to appear. Whether the first read lands
before or after the RFS transform's first publish then decides the run:
on main, 4 of 10 runs of netinfra_router_oper failed. A read every
100 ms puts a second read inside the window. On-change delivery between
layers will remove the race for good.