### PR TITLE
Support instance-rooted delivery

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -28,8 +28,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
-        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
+        url="https://github.com/stratoweave/acton-yang/archive/a4ebb78c7cc75912b083f7395fd0fd294a2f43bc.zip",
+        hash="N-V-__8AAFaFKADPehkA-iHnOAy-xtwGmNuoHaO0Fr4KIsRU"
     )
 }
 zig_dependencies = {}

--- a/docs/reference/subscriptions.md
+++ b/docs/reference/subscriptions.md
@@ -9,7 +9,8 @@ reconciled by `yang.gdata.SubscriptionManager`.
 - one stable owner id
 - one update callback
 
-The callback receives one merged gdata tree for that owner.
+The callback receives one merged gdata tree for that owner or, for a
+destination rooted at a node, one instance of that node per call.
 
 The public shape is intentionally small:
 
@@ -147,6 +148,78 @@ want = set([
 subs.declare(want)
 ```
 
+### Where A Destination Is Rooted
+
+A destination decides where each delivered tree starts. The module-level
+`dst` is rooted at the top: the callback receives the whole subscribed
+tree, as above. Every generated container and keyed list has a `dst` of
+its own, rooted at that node: the callback receives one instance of the
+node at a time. Its arguments are the keys of every list on the way
+down, as a named tuple with a field per key named after the list and
+the key; the instance itself, typed, or `None` when it is gone; and an
+error, as on the top-rooted callback. A node with no list above it has
+no keys argument. The types come with the `dst`, so the callback needs
+no annotations.
+
+```acton
+import mini.layers.y_1_oper as y1_oper
+
+def on_device(keys, device, err):
+    if err is not None:
+        ...
+    elif keys is not None:
+        if device is None:
+            forget(keys.device_name)    # the device is gone
+        else:
+            record(keys.device_name, device)
+
+def on_synced():
+    ...                             # every device held at declaration has been delivered
+
+dev = y1_oper.subs.device
+subs.declare({
+    dev.dst(on_device).deliver({
+        dev.subscribe(period=1.0),
+    }),
+}, synced=on_synced)
+```
+
+Rooted below another list, the keys tuple carries that list's keys too:
+a destination at `devices.device.interfaces.interface` hands its
+callback `keys.device_name`, `keys.interface_name` and the interface.
+
+The first pass delivers every instance the filter selects, one call each,
+and then calls `synced`. After that each read delivers the instances that
+changed since the last one, whatever the size of the list, so a
+subscriber to a hundred thousand devices is called with one device. The
+filters handed to a rooted destination must lead to its node, and they
+are read on one period. A destination rooted at a container receives
+that container, or `None` when it is gone.
+
+`synced` belongs to the declaration, not to one destination: it is
+called once, when every delivery in that `declare` has had its first
+pass, the first read of each spec. A first read that ends in an error
+still counts: the error, then `synced`. A declaration that adds nothing
+new installs the new callbacks and nothing more: nothing is delivered
+again and `synced` fires at once, since there is nothing to wait for. A
+rooted destination is served by a TTT layer; a device provider answers it
+with an error, and counts its first read as its first pass.
+
+At the gdata level the root is an `FNode` path with one child per level
+and no predicates, carried by `Dst(deliver, root=...)`; the destination
+stamps it on the specs it delivers, so two destinations with the same
+filters but different roots are served apart. A rooted delivery is a
+spine: a tree from the top down to the one instance, every list on the
+way holding one entry with its keys, with an `Absent` holding its keys
+where a list entry is gone and nothing where a container is gone.
+`gdata.instances` splits a tree into such spines and `gdata.gone` turns
+one into the report of its instance gone. A generated `dst` wraps the
+callback in a lambda that converts the spine to the keys and the
+instance first; the provider calls it, so the conversion runs in the
+provider and no actor stands between provider and consumer. After an owner's first pass the provider
+calls `synced` with the owner id, sent after the data so it arrives after
+it; the manager counts those for the declaration.
+
 ### On-Change Subscriptions
 
 Omitting `period` creates an on-change `SubscriptionSpec`:
@@ -237,3 +310,8 @@ Each `declare(...)` call is the consumer's complete desired state. The
 actor drops the reads no longer wanted, starts changed ones over, keeps
 the rest with their latest trees, and calls `synced` once every read of
 the declaration has run.
+
+A consumer rooted at a node has one read, and instead of one view gets,
+after each read, every instance that differs from the last read and
+every instance gone, each as a tree from the top down to that one
+instance.

--- a/docs/reference/subscriptions.md
+++ b/docs/reference/subscriptions.md
@@ -224,55 +224,16 @@ rejected by that driver.
 
 ## Internal Model
 
-`SubscriptionManager` is the declarative owner-facing API. Internally,
-StratoWeave splits subscriptions into two layers:
+`SubscriptionManager` is the declarative owner-facing API. Below it, a TTT
+layer serves each consumer from a `Subscription` actor of the consumer's
+own, outside the Layer actor. The consumer's filters fold into one read
+per period: the union of the filters declared with that period, read in
+one pass. Each read runs on its period, and every delivery is the reads'
+latest trees merged into one view, sent straight to the consumer, by
+reference when there is one read. The Layer keeps only which actor serves
+which consumer.
 
-- `SubscriptionOwner`: one logical subscriber with one callback and one
-  desired `set[SubscriptionSpec]`
-- `SharedSubscription`: one physical device subscription keyed by the
-  canonical `SubscriptionSpec` and shared by one or more owners
-
-This means two transforms can declare the same `SubscriptionSpec` and
-the device layer will only keep one physical poll running. Each
-`SharedSubscription` tracks its current `latest` subtree and the set of
-owner ids that depend on it.
-
-Each `declare(...)` call is treated as the owner's complete desired
-state. The device layer diffs the previous and new sets, removes dropped
-specs from the owner's membership, creates newly needed shared
-subscriptions, and reuses unchanged ones. The owner does not manage
-handles or explicit cancellation.
-
-## Merged Tree Delivery
-
-The owner callback receives one merged operational tree rather than one
-callback per subscription. Internally, `_merge_subscription_tree(...)`
-walks the owner's desired `SubscriptionSpec` set, looks up the latest
-subtree for each active shared subscription, and patches those subtrees
-together into one gdata tree.
-
-The merge order is made deterministic by sorting the owner's spec set
-before merging. This avoids depending on set iteration order when
-combining overlapping subtrees.
-
-Today the merge starts from an empty `Container({})` and repeatedly
-applies `yang.gdata.patch(...)` for each available subtree. There is a
-TODO in `yang.gdata.patch(...)` to accept `None` as the empty base so
-callers do not need to synthesize that root container.
-
-## Change Detection And Snapshots
-
-After building the merged tree, the device layer compares it to the
-owner's previously delivered merged tree. If the merged tree changed, or
-if an error is being reported, the callback is invoked.
-
-The cached previous tree is currently stored as a detached snapshot, not
-as a direct reference to the last merged tree. The reason is that
-`yang.gdata.Node` is not yet a truly immutable persistent tree. Patch
-and merge operations can still reuse mutable internals, so retaining an
-older tree by reference is not a safe snapshot boundary.
-
-The current workaround is to snapshot the merged tree before caching it.
-That is intentionally conservative. The longer-term fix is to make
-`yang.gdata.Node` properly immutable, likely with Merkle-style structure
-sharing and cheap change detection, so this extra snapshot can go away.
+Each `declare(...)` call is the consumer's complete desired state. The
+actor drops the reads no longer wanted, starts changed ones over, keeps
+the rest with their latest trees, and calls `synced` once every read of
+the declaration has run.

--- a/gen_adata/Build.act
+++ b/gen_adata/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x7d1c1e932a731ef0
 dependencies = {
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
-        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
+        url="https://github.com/stratoweave/acton-yang/archive/a4ebb78c7cc75912b083f7395fd0fd294a2f43bc.zip",
+        hash="N-V-__8AAFaFKADPehkA-iHnOAy-xtwGmNuoHaO0Fr4KIsRU"
     )
 }
 zig_dependencies = {}

--- a/minisys/Build.act
+++ b/minisys/Build.act
@@ -11,8 +11,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
-        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
+        url="https://github.com/stratoweave/acton-yang/archive/a4ebb78c7cc75912b083f7395fd0fd294a2f43bc.zip",
+        hash="N-V-__8AAFaFKADPehkA-iHnOAy-xtwGmNuoHaO0Fr4KIsRU"
     )
 }
 zig_dependencies = {}

--- a/minisys/gen/Build.act
+++ b/minisys/gen/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
-        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
+        url="https://github.com/stratoweave/acton-yang/archive/a4ebb78c7cc75912b083f7395fd0fd294a2f43bc.zip",
+        hash="N-V-__8AAFaFKADPehkA-iHnOAy-xtwGmNuoHaO0Fr4KIsRU"
     )
 }
 zig_dependencies = {}

--- a/minisys/src/mini/cfs.act
+++ b/minisys/src/mini/cfs.act
@@ -25,25 +25,24 @@ class PContainer(base.PContainer):
 
 
 actor RouterTransform(path: ttt.Path, update_dynstate: proc(?y_0.netinfra__netinfra__router__dynstate)->None, update_oper: proc(?y0_oper.netinfra__netinfra__router_entry)->None, lower_tree_provider: ?ygdata.TreeProvider):
+    """Publishes the router's state from its RFS entry below, delivered
+    rooted at the entry, so the callback gets that one entry."""
     oper = base.Router.new_state(path)
     _subs = ygdata.SubscriptionManager(lower_tree_provider!, str(path))
 
-    def on_rfs_state(root: ?y1_oper.root, err: ?Exception, router_name: str):
+    def on_rfs_state(keys, rfs, err):
+        # rfs is the one entry the filter selects, holding the leaves it selected; keys names it
         if err is not None:
             print("RouterTransform RFS subscription error: {err}", err=True)
             return
-
-        r = root!.rfs.get(router_name)
-        if r is not None:
-            oper.state.current_datetime = r.base_config?.state.current_datetime
+        oper.state.current_datetime = rfs?.base_config?.state.current_datetime
         update_oper(oper)
 
     def subscribe(router_name: str):
-        want: set[ygdata.Delivery] = set()
-        dst = y1_oper.dst(lambda r, e: on_rfs_state(r, e, router_name))
-        rfs = y1_oper.subs.rfs.entry(router_name)
-        want.add(dst.deliver({
-            rfs.base_config.state.current_datetime.subscribe(period=0.1)
+        want = set()
+        rfs = y1_oper.subs.rfs
+        want.add(rfs.dst(on_rfs_state).deliver({
+            rfs.entry(router_name).base_config.state.current_datetime.subscribe(period=0.1)
         }))
         _subs.declare(want)
 

--- a/minisys/src/mini/devices/ietf_oper.act
+++ b/minisys/src/mini/devices/ietf_oper.act
@@ -10706,6 +10706,26 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
 _breaker64: None = None
 class ietf_netconf_acm__nacm__groups__group_entry_subs(SubscriptionNode):
     name: SubscriptionNode
@@ -10721,6 +10741,23 @@ class ietf_netconf_acm__nacm__groups__group_entry_subs(SubscriptionNode):
         return direct
 
 _breaker65: None = None
+proc def ietf_netconf_acm__nacm__groups__group_deliver(cb: action(?(group_name: str), ?ietf_netconf_acm__nacm__groups__group_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(group_name: str) = None
+    inst: ?ietf_netconf_acm__nacm__groups__group_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_netconf_acm, 'nacm'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_netconf_acm, 'groups'))
+            e3 = _one(_at(c2, ygdata.Id(NS_ietf_netconf_acm, 'group')), 'group')
+            keys = (group_name=e3.get_str(ygdata.Id(NS_ietf_netconf_acm, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = ietf_netconf_acm__nacm__groups__group_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_netconf_acm__nacm__groups__group_subs(SubscriptionNode):
     name: SubscriptionNode
     user_name: SubscriptionNode
@@ -10736,11 +10773,31 @@ class ietf_netconf_acm__nacm__groups__group_subs(SubscriptionNode):
         base_path = self._path!.parent
         return ietf_netconf_acm__nacm__groups__group_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_netconf_acm, 'group'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(group_name: str), ?ietf_netconf_acm__nacm__groups__group_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_netconf_acm__nacm__groups__group_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.user_name]
         return direct
 
 _breaker66: None = None
+proc def ietf_netconf_acm__nacm__groups_deliver(cb: action(?ietf_netconf_acm__nacm__groups, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_netconf_acm__nacm__groups = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_netconf_acm, 'nacm'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_netconf_acm, 'groups'))
+            here = _present(c2)
+            if here is not None:
+                inst = ietf_netconf_acm__nacm__groups.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_netconf_acm__nacm__groups_subs(SubscriptionNode):
     group: ietf_netconf_acm__nacm__groups__group_subs
 
@@ -10751,6 +10808,12 @@ class ietf_netconf_acm__nacm__groups_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.group]
         return direct
+
+    def dst(self, cb: action(?ietf_netconf_acm__nacm__groups, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_netconf_acm__nacm__groups_deliver(cb, n, err), root=self.filt())
 
 _breaker67: None = None
 class ietf_netconf_acm__nacm__rule_list__rule_entry_subs(SubscriptionNode):
@@ -10779,6 +10842,23 @@ class ietf_netconf_acm__nacm__rule_list__rule_entry_subs(SubscriptionNode):
         return direct
 
 _breaker68: None = None
+proc def ietf_netconf_acm__nacm__rule_list__rule_deliver(cb: action(?(rule_list_name: str, rule_name: str), ?ietf_netconf_acm__nacm__rule_list__rule_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rule_list_name: str, rule_name: str) = None
+    inst: ?ietf_netconf_acm__nacm__rule_list__rule_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_netconf_acm, 'nacm'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_netconf_acm, 'rule-list')), 'rule-list')
+            e3 = _one(_at(e2, ygdata.Id(NS_ietf_netconf_acm, 'rule')), 'rule')
+            keys = (rule_list_name=e2.get_str(ygdata.Id(NS_ietf_netconf_acm, 'name')), rule_name=e3.get_str(ygdata.Id(NS_ietf_netconf_acm, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = ietf_netconf_acm__nacm__rule_list__rule_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_netconf_acm__nacm__rule_list__rule_subs(SubscriptionNode):
     name: SubscriptionNode
     module_name: SubscriptionNode
@@ -10806,6 +10886,12 @@ class ietf_netconf_acm__nacm__rule_list__rule_subs(SubscriptionNode):
         base_path = self._path!.parent
         return ietf_netconf_acm__nacm__rule_list__rule_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_netconf_acm, 'rule'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rule_list_name: str, rule_name: str), ?ietf_netconf_acm__nacm__rule_list__rule_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_netconf_acm__nacm__rule_list__rule_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.module_name, self.rpc_name, self.notification_name, self.path, self.access_operations, self.action_, self.comment]
         return direct
@@ -10827,6 +10913,22 @@ class ietf_netconf_acm__nacm__rule_list_entry_subs(SubscriptionNode):
         return direct
 
 _breaker70: None = None
+proc def ietf_netconf_acm__nacm__rule_list_deliver(cb: action(?(rule_list_name: str), ?ietf_netconf_acm__nacm__rule_list_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rule_list_name: str) = None
+    inst: ?ietf_netconf_acm__nacm__rule_list_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_netconf_acm, 'nacm'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_netconf_acm, 'rule-list')), 'rule-list')
+            keys = (rule_list_name=e2.get_str(ygdata.Id(NS_ietf_netconf_acm, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = ietf_netconf_acm__nacm__rule_list_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_netconf_acm__nacm__rule_list_subs(SubscriptionNode):
     name: SubscriptionNode
     group: SubscriptionNode
@@ -10844,11 +10946,30 @@ class ietf_netconf_acm__nacm__rule_list_subs(SubscriptionNode):
         base_path = self._path!.parent
         return ietf_netconf_acm__nacm__rule_list_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_netconf_acm, 'rule-list'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rule_list_name: str), ?ietf_netconf_acm__nacm__rule_list_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_netconf_acm__nacm__rule_list_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.group, self.rule]
         return direct
 
 _breaker71: None = None
+proc def ietf_netconf_acm__nacm_deliver(cb: action(?ietf_netconf_acm__nacm, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_netconf_acm__nacm = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_netconf_acm, 'nacm'))
+            here = _present(c1)
+            if here is not None:
+                inst = ietf_netconf_acm__nacm.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_netconf_acm__nacm_subs(SubscriptionNode):
     enable_nacm: SubscriptionNode
     read_default: SubscriptionNode
@@ -10878,7 +10999,27 @@ class ietf_netconf_acm__nacm_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enable_nacm, self.read_default, self.write_default, self.exec_default, self.enable_external_groups, self.denied_operations, self.denied_data_writes, self.denied_notifications, self.groups, self.rule_list]
         return direct
 
+    def dst(self, cb: action(?ietf_netconf_acm__nacm, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_netconf_acm__nacm_deliver(cb, n, err), root=self.filt())
+
 _breaker72: None = None
+proc def ietf_system__system__clock_deliver(cb: action(?ietf_system__system__clock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system__clock = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'clock'))
+            here = _present(c2)
+            if here is not None:
+                inst = ietf_system__system__clock.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system__clock_subs(SubscriptionNode):
     timezone_name: SubscriptionNode
     timezone_utc_offset: SubscriptionNode
@@ -10892,7 +11033,31 @@ class ietf_system__system__clock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.timezone_name, self.timezone_utc_offset]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system__clock, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__clock_deliver(cb, n, err), root=self.filt())
+
 _breaker73: None = None
+proc def ietf_system__system__ntp__server__udp_deliver(cb: action(?(server_name: str), ?ietf_system__system__ntp__server__udp, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(server_name: str) = None
+    inst: ?ietf_system__system__ntp__server__udp = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'ntp'))
+            e3 = _one(_at(c2, ygdata.Id(NS_ietf_system, 'server')), 'server')
+            c4 = _at(e3, ygdata.Id(NS_ietf_system, 'udp'))
+            keys = (server_name=e3.get_str(ygdata.Id(NS_ietf_system, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = ietf_system__system__ntp__server__udp.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_system__system__ntp__server__udp_subs(SubscriptionNode):
     address: SubscriptionNode
     port: SubscriptionNode
@@ -10905,6 +11070,12 @@ class ietf_system__system__ntp__server__udp_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.address, self.port]
         return direct
+
+    def dst(self, cb: action(?(server_name: str), ?ietf_system__system__ntp__server__udp, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__ntp__server__udp_deliver(cb, n, err), root=self.filt())
 
 _breaker74: None = None
 class ietf_system__system__ntp__server_entry_subs(SubscriptionNode):
@@ -10927,6 +11098,23 @@ class ietf_system__system__ntp__server_entry_subs(SubscriptionNode):
         return direct
 
 _breaker75: None = None
+proc def ietf_system__system__ntp__server_deliver(cb: action(?(server_name: str), ?ietf_system__system__ntp__server_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(server_name: str) = None
+    inst: ?ietf_system__system__ntp__server_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'ntp'))
+            e3 = _one(_at(c2, ygdata.Id(NS_ietf_system, 'server')), 'server')
+            keys = (server_name=e3.get_str(ygdata.Id(NS_ietf_system, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = ietf_system__system__ntp__server_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_system__system__ntp__server_subs(SubscriptionNode):
     name: SubscriptionNode
     udp: ietf_system__system__ntp__server__udp_subs
@@ -10948,11 +11136,31 @@ class ietf_system__system__ntp__server_subs(SubscriptionNode):
         base_path = self._path!.parent
         return ietf_system__system__ntp__server_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_system, 'server'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(server_name: str), ?ietf_system__system__ntp__server_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__ntp__server_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.udp, self.association_type, self.iburst, self.prefer]
         return direct
 
 _breaker76: None = None
+proc def ietf_system__system__ntp_deliver(cb: action(?ietf_system__system__ntp, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system__ntp = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'ntp'))
+            here = _present(c2)
+            if here is not None:
+                inst = ietf_system__system__ntp.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system__ntp_subs(SubscriptionNode):
     enabled: SubscriptionNode
     server: ietf_system__system__ntp__server_subs
@@ -10966,7 +11174,31 @@ class ietf_system__system__ntp_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.server]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system__ntp, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__ntp_deliver(cb, n, err), root=self.filt())
+
 _breaker77: None = None
+proc def ietf_system__system__dns_resolver__server__udp_and_tcp_deliver(cb: action(?(server_name: str), ?ietf_system__system__dns_resolver__server__udp_and_tcp, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(server_name: str) = None
+    inst: ?ietf_system__system__dns_resolver__server__udp_and_tcp = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'dns-resolver'))
+            e3 = _one(_at(c2, ygdata.Id(NS_ietf_system, 'server')), 'server')
+            c4 = _at(e3, ygdata.Id(NS_ietf_system, 'udp-and-tcp'))
+            keys = (server_name=e3.get_str(ygdata.Id(NS_ietf_system, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = ietf_system__system__dns_resolver__server__udp_and_tcp.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_system__system__dns_resolver__server__udp_and_tcp_subs(SubscriptionNode):
     address: SubscriptionNode
     port: SubscriptionNode
@@ -10979,6 +11211,12 @@ class ietf_system__system__dns_resolver__server__udp_and_tcp_subs(SubscriptionNo
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.address, self.port]
         return direct
+
+    def dst(self, cb: action(?(server_name: str), ?ietf_system__system__dns_resolver__server__udp_and_tcp, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__dns_resolver__server__udp_and_tcp_deliver(cb, n, err), root=self.filt())
 
 _breaker78: None = None
 class ietf_system__system__dns_resolver__server_entry_subs(SubscriptionNode):
@@ -10995,6 +11233,23 @@ class ietf_system__system__dns_resolver__server_entry_subs(SubscriptionNode):
         return direct
 
 _breaker79: None = None
+proc def ietf_system__system__dns_resolver__server_deliver(cb: action(?(server_name: str), ?ietf_system__system__dns_resolver__server_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(server_name: str) = None
+    inst: ?ietf_system__system__dns_resolver__server_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'dns-resolver'))
+            e3 = _one(_at(c2, ygdata.Id(NS_ietf_system, 'server')), 'server')
+            keys = (server_name=e3.get_str(ygdata.Id(NS_ietf_system, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = ietf_system__system__dns_resolver__server_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_system__system__dns_resolver__server_subs(SubscriptionNode):
     name: SubscriptionNode
     udp_and_tcp: ietf_system__system__dns_resolver__server__udp_and_tcp_subs
@@ -11010,11 +11265,32 @@ class ietf_system__system__dns_resolver__server_subs(SubscriptionNode):
         base_path = self._path!.parent
         return ietf_system__system__dns_resolver__server_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_system, 'server'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(server_name: str), ?ietf_system__system__dns_resolver__server_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__dns_resolver__server_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.udp_and_tcp]
         return direct
 
 _breaker80: None = None
+proc def ietf_system__system__dns_resolver__options_deliver(cb: action(?ietf_system__system__dns_resolver__options, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system__dns_resolver__options = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'dns-resolver'))
+            c3 = _at(c2, ygdata.Id(NS_ietf_system, 'options'))
+            here = _present(c3)
+            if here is not None:
+                inst = ietf_system__system__dns_resolver__options.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system__dns_resolver__options_subs(SubscriptionNode):
     timeout: SubscriptionNode
     attempts: SubscriptionNode
@@ -11028,7 +11304,27 @@ class ietf_system__system__dns_resolver__options_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.timeout, self.attempts]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system__dns_resolver__options, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__dns_resolver__options_deliver(cb, n, err), root=self.filt())
+
 _breaker81: None = None
+proc def ietf_system__system__dns_resolver_deliver(cb: action(?ietf_system__system__dns_resolver, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system__dns_resolver = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'dns-resolver'))
+            here = _present(c2)
+            if here is not None:
+                inst = ietf_system__system__dns_resolver.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system__dns_resolver_subs(SubscriptionNode):
     search: SubscriptionNode
     server: ietf_system__system__dns_resolver__server_subs
@@ -11044,7 +11340,31 @@ class ietf_system__system__dns_resolver_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.search, self.server, self.options]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system__dns_resolver, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__dns_resolver_deliver(cb, n, err), root=self.filt())
+
 _breaker82: None = None
+proc def ietf_system__system__radius__server__udp_deliver(cb: action(?(server_name: str), ?ietf_system__system__radius__server__udp, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(server_name: str) = None
+    inst: ?ietf_system__system__radius__server__udp = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'radius'))
+            e3 = _one(_at(c2, ygdata.Id(NS_ietf_system, 'server')), 'server')
+            c4 = _at(e3, ygdata.Id(NS_ietf_system, 'udp'))
+            keys = (server_name=e3.get_str(ygdata.Id(NS_ietf_system, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = ietf_system__system__radius__server__udp.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_system__system__radius__server__udp_subs(SubscriptionNode):
     address: SubscriptionNode
     authentication_port: SubscriptionNode
@@ -11059,6 +11379,12 @@ class ietf_system__system__radius__server__udp_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.address, self.authentication_port, self.shared_secret]
         return direct
+
+    def dst(self, cb: action(?(server_name: str), ?ietf_system__system__radius__server__udp, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__radius__server__udp_deliver(cb, n, err), root=self.filt())
 
 _breaker83: None = None
 class ietf_system__system__radius__server_entry_subs(SubscriptionNode):
@@ -11077,6 +11403,23 @@ class ietf_system__system__radius__server_entry_subs(SubscriptionNode):
         return direct
 
 _breaker84: None = None
+proc def ietf_system__system__radius__server_deliver(cb: action(?(server_name: str), ?ietf_system__system__radius__server_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(server_name: str) = None
+    inst: ?ietf_system__system__radius__server_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'radius'))
+            e3 = _one(_at(c2, ygdata.Id(NS_ietf_system, 'server')), 'server')
+            keys = (server_name=e3.get_str(ygdata.Id(NS_ietf_system, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = ietf_system__system__radius__server_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_system__system__radius__server_subs(SubscriptionNode):
     name: SubscriptionNode
     udp: ietf_system__system__radius__server__udp_subs
@@ -11094,11 +11437,32 @@ class ietf_system__system__radius__server_subs(SubscriptionNode):
         base_path = self._path!.parent
         return ietf_system__system__radius__server_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_system, 'server'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(server_name: str), ?ietf_system__system__radius__server_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__radius__server_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.udp, self.authentication_type]
         return direct
 
 _breaker85: None = None
+proc def ietf_system__system__radius__options_deliver(cb: action(?ietf_system__system__radius__options, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system__radius__options = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'radius'))
+            c3 = _at(c2, ygdata.Id(NS_ietf_system, 'options'))
+            here = _present(c3)
+            if here is not None:
+                inst = ietf_system__system__radius__options.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system__radius__options_subs(SubscriptionNode):
     timeout: SubscriptionNode
     attempts: SubscriptionNode
@@ -11112,7 +11476,27 @@ class ietf_system__system__radius__options_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.timeout, self.attempts]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system__radius__options, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__radius__options_deliver(cb, n, err), root=self.filt())
+
 _breaker86: None = None
+proc def ietf_system__system__radius_deliver(cb: action(?ietf_system__system__radius, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system__radius = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'radius'))
+            here = _present(c2)
+            if here is not None:
+                inst = ietf_system__system__radius.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system__radius_subs(SubscriptionNode):
     server: ietf_system__system__radius__server_subs
     options: ietf_system__system__radius__options_subs
@@ -11125,6 +11509,12 @@ class ietf_system__system__radius_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.server, self.options]
         return direct
+
+    def dst(self, cb: action(?ietf_system__system__radius, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__radius_deliver(cb, n, err), root=self.filt())
 
 _breaker87: None = None
 class ietf_system__system__authentication__user__authorized_key_entry_subs(SubscriptionNode):
@@ -11143,6 +11533,24 @@ class ietf_system__system__authentication__user__authorized_key_entry_subs(Subsc
         return direct
 
 _breaker88: None = None
+proc def ietf_system__system__authentication__user__authorized_key_deliver(cb: action(?(user_name: str, authorized_key_name: str), ?ietf_system__system__authentication__user__authorized_key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(user_name: str, authorized_key_name: str) = None
+    inst: ?ietf_system__system__authentication__user__authorized_key_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'authentication'))
+            e3 = _one(_at(c2, ygdata.Id(NS_ietf_system, 'user')), 'user')
+            e4 = _one(_at(e3, ygdata.Id(NS_ietf_system, 'authorized-key')), 'authorized-key')
+            keys = (user_name=e3.get_str(ygdata.Id(NS_ietf_system, 'name')), authorized_key_name=e4.get_str(ygdata.Id(NS_ietf_system, 'name')))
+            here = _present(e4)
+            if here is not None:
+                inst = ietf_system__system__authentication__user__authorized_key_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_system__system__authentication__user__authorized_key_subs(SubscriptionNode):
     name: SubscriptionNode
     algorithm: SubscriptionNode
@@ -11159,6 +11567,12 @@ class ietf_system__system__authentication__user__authorized_key_subs(Subscriptio
         ]
         base_path = self._path!.parent
         return ietf_system__system__authentication__user__authorized_key_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_system, 'authorized-key'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(user_name: str, authorized_key_name: str), ?ietf_system__system__authentication__user__authorized_key_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__authentication__user__authorized_key_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.algorithm, self.key_data]
@@ -11181,6 +11595,23 @@ class ietf_system__system__authentication__user_entry_subs(SubscriptionNode):
         return direct
 
 _breaker90: None = None
+proc def ietf_system__system__authentication__user_deliver(cb: action(?(user_name: str), ?ietf_system__system__authentication__user_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(user_name: str) = None
+    inst: ?ietf_system__system__authentication__user_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'authentication'))
+            e3 = _one(_at(c2, ygdata.Id(NS_ietf_system, 'user')), 'user')
+            keys = (user_name=e3.get_str(ygdata.Id(NS_ietf_system, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = ietf_system__system__authentication__user_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_system__system__authentication__user_subs(SubscriptionNode):
     name: SubscriptionNode
     password: SubscriptionNode
@@ -11198,11 +11629,31 @@ class ietf_system__system__authentication__user_subs(SubscriptionNode):
         base_path = self._path!.parent
         return ietf_system__system__authentication__user_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_system, 'user'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(user_name: str), ?ietf_system__system__authentication__user_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__authentication__user_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.password, self.authorized_key]
         return direct
 
 _breaker91: None = None
+proc def ietf_system__system__authentication_deliver(cb: action(?ietf_system__system__authentication, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system__authentication = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'authentication'))
+            here = _present(c2)
+            if here is not None:
+                inst = ietf_system__system__authentication.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system__authentication_subs(SubscriptionNode):
     user_authentication_order: SubscriptionNode
     user: ietf_system__system__authentication__user_subs
@@ -11216,7 +11667,26 @@ class ietf_system__system__authentication_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.user_authentication_order, self.user]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system__authentication, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system__authentication_deliver(cb, n, err), root=self.filt())
+
 _breaker92: None = None
+proc def ietf_system__system_deliver(cb: action(?ietf_system__system, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system'))
+            here = _present(c1)
+            if here is not None:
+                inst = ietf_system__system.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system_subs(SubscriptionNode):
     contact: SubscriptionNode
     hostname: SubscriptionNode
@@ -11242,7 +11712,27 @@ class ietf_system__system_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.contact, self.hostname, self.location, self.clock, self.ntp, self.dns_resolver, self.radius, self.authentication]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system_deliver(cb, n, err), root=self.filt())
+
 _breaker93: None = None
+proc def ietf_system__system_state__platform_deliver(cb: action(?ietf_system__system_state__platform, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system_state__platform = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system-state'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'platform'))
+            here = _present(c2)
+            if here is not None:
+                inst = ietf_system__system_state__platform.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system_state__platform_subs(SubscriptionNode):
     os_name: SubscriptionNode
     os_release: SubscriptionNode
@@ -11260,7 +11750,27 @@ class ietf_system__system_state__platform_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.os_name, self.os_release, self.os_version, self.machine]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system_state__platform, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system_state__platform_deliver(cb, n, err), root=self.filt())
+
 _breaker94: None = None
+proc def ietf_system__system_state__clock_deliver(cb: action(?ietf_system__system_state__clock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system_state__clock = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system-state'))
+            c2 = _at(c1, ygdata.Id(NS_ietf_system, 'clock'))
+            here = _present(c2)
+            if here is not None:
+                inst = ietf_system__system_state__clock.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system_state__clock_subs(SubscriptionNode):
     current_datetime: SubscriptionNode
     boot_datetime: SubscriptionNode
@@ -11274,7 +11784,26 @@ class ietf_system__system_state__clock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.current_datetime, self.boot_datetime]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system_state__clock, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system_state__clock_deliver(cb, n, err), root=self.filt())
+
 _breaker95: None = None
+proc def ietf_system__system_state_deliver(cb: action(?ietf_system__system_state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_system__system_state = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_system, 'system-state'))
+            here = _present(c1)
+            if here is not None:
+                inst = ietf_system__system_state.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_system__system_state_subs(SubscriptionNode):
     platform: ietf_system__system_state__platform_subs
     clock: ietf_system__system_state__clock_subs
@@ -11288,7 +11817,30 @@ class ietf_system__system_state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.platform, self.clock]
         return direct
 
+    def dst(self, cb: action(?ietf_system__system_state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_system__system_state_deliver(cb, n, err), root=self.filt())
+
 _breaker96: None = None
+proc def ietf_interfaces__interfaces__interface__statistics_deliver(cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface__statistics, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str) = None
+    inst: ?ietf_interfaces__interfaces__interface__statistics = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_interfaces, 'statistics'))
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = ietf_interfaces__interfaces__interface__statistics.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces__interface__statistics_subs(SubscriptionNode):
     discontinuity_time: SubscriptionNode
     in_octets: SubscriptionNode
@@ -11326,6 +11878,12 @@ class ietf_interfaces__interfaces__interface__statistics_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.discontinuity_time, self.in_octets, self.in_unicast_pkts, self.in_broadcast_pkts, self.in_multicast_pkts, self.in_discards, self.in_errors, self.in_unknown_protos, self.out_octets, self.out_unicast_pkts, self.out_broadcast_pkts, self.out_multicast_pkts, self.out_discards, self.out_errors]
         return direct
 
+    def dst(self, cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface__statistics, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces__interface__statistics_deliver(cb, n, err), root=self.filt())
+
 _breaker97: None = None
 class ietf_interfaces__interfaces__interface__ipv4__address_entry_subs(SubscriptionNode):
     ip: SubscriptionNode
@@ -11345,6 +11903,24 @@ class ietf_interfaces__interfaces__interface__ipv4__address_entry_subs(Subscript
         return direct
 
 _breaker98: None = None
+proc def ietf_interfaces__interfaces__interface__ipv4__address_deliver(cb: action(?(interface_name: str, address_ip: str), ?ietf_interfaces__interfaces__interface__ipv4__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str, address_ip: str) = None
+    inst: ?ietf_interfaces__interfaces__interface__ipv4__address_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv4'))
+            e4 = _one(_at(c3, ygdata.Id(NS_ietf_ip, 'address')), 'address')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')), address_ip=e4.get_str(ygdata.Id(NS_ietf_ip, 'ip')))
+            here = _present(e4)
+            if here is not None:
+                inst = ietf_interfaces__interfaces__interface__ipv4__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces__interface__ipv4__address_subs(SubscriptionNode):
     ip: SubscriptionNode
     prefix_length: SubscriptionNode
@@ -11363,6 +11939,12 @@ class ietf_interfaces__interfaces__interface__ipv4__address_subs(SubscriptionNod
         ]
         base_path = self._path!.parent
         return ietf_interfaces__interfaces__interface__ipv4__address_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_ip, 'address'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(interface_name: str, address_ip: str), ?ietf_interfaces__interfaces__interface__ipv4__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces__interface__ipv4__address_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.netmask, self.origin]
@@ -11385,6 +11967,24 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry_subs(Subscrip
         return direct
 
 _breaker100: None = None
+proc def ietf_interfaces__interfaces__interface__ipv4__neighbor_deliver(cb: action(?(interface_name: str, neighbor_ip: str), ?ietf_interfaces__interfaces__interface__ipv4__neighbor_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str, neighbor_ip: str) = None
+    inst: ?ietf_interfaces__interfaces__interface__ipv4__neighbor_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv4'))
+            e4 = _one(_at(c3, ygdata.Id(NS_ietf_ip, 'neighbor')), 'neighbor')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')), neighbor_ip=e4.get_str(ygdata.Id(NS_ietf_ip, 'ip')))
+            here = _present(e4)
+            if here is not None:
+                inst = ietf_interfaces__interfaces__interface__ipv4__neighbor_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces__interface__ipv4__neighbor_subs(SubscriptionNode):
     ip: SubscriptionNode
     link_layer_address: SubscriptionNode
@@ -11402,11 +12002,34 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_subs(SubscriptionNo
         base_path = self._path!.parent
         return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_ip, 'neighbor'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(interface_name: str, neighbor_ip: str), ?ietf_interfaces__interfaces__interface__ipv4__neighbor_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces__interface__ipv4__neighbor_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin]
         return direct
 
 _breaker101: None = None
+proc def ietf_interfaces__interfaces__interface__ipv4_deliver(cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface__ipv4, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str) = None
+    inst: ?ietf_interfaces__interfaces__interface__ipv4 = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv4'))
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = ietf_interfaces__interfaces__interface__ipv4.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces__interface__ipv4_subs(SubscriptionNode):
     enabled: SubscriptionNode
     forwarding: SubscriptionNode
@@ -11425,6 +12048,12 @@ class ietf_interfaces__interfaces__interface__ipv4_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.enabled, self.forwarding, self.mtu, self.address, self.neighbor]
         return direct
+
+    def dst(self, cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface__ipv4, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces__interface__ipv4_deliver(cb, n, err), root=self.filt())
 
 _breaker102: None = None
 class ietf_interfaces__interfaces__interface__ipv6__address_entry_subs(SubscriptionNode):
@@ -11445,6 +12074,24 @@ class ietf_interfaces__interfaces__interface__ipv6__address_entry_subs(Subscript
         return direct
 
 _breaker103: None = None
+proc def ietf_interfaces__interfaces__interface__ipv6__address_deliver(cb: action(?(interface_name: str, address_ip: str), ?ietf_interfaces__interfaces__interface__ipv6__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str, address_ip: str) = None
+    inst: ?ietf_interfaces__interfaces__interface__ipv6__address_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv6'))
+            e4 = _one(_at(c3, ygdata.Id(NS_ietf_ip, 'address')), 'address')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')), address_ip=e4.get_str(ygdata.Id(NS_ietf_ip, 'ip')))
+            here = _present(e4)
+            if here is not None:
+                inst = ietf_interfaces__interfaces__interface__ipv6__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces__interface__ipv6__address_subs(SubscriptionNode):
     ip: SubscriptionNode
     prefix_length: SubscriptionNode
@@ -11463,6 +12110,12 @@ class ietf_interfaces__interfaces__interface__ipv6__address_subs(SubscriptionNod
         ]
         base_path = self._path!.parent
         return ietf_interfaces__interfaces__interface__ipv6__address_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_ip, 'address'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(interface_name: str, address_ip: str), ?ietf_interfaces__interfaces__interface__ipv6__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces__interface__ipv6__address_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.origin, self.status]
@@ -11489,6 +12142,24 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry_subs(Subscrip
         return direct
 
 _breaker105: None = None
+proc def ietf_interfaces__interfaces__interface__ipv6__neighbor_deliver(cb: action(?(interface_name: str, neighbor_ip: str), ?ietf_interfaces__interfaces__interface__ipv6__neighbor_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str, neighbor_ip: str) = None
+    inst: ?ietf_interfaces__interfaces__interface__ipv6__neighbor_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv6'))
+            e4 = _one(_at(c3, ygdata.Id(NS_ietf_ip, 'neighbor')), 'neighbor')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')), neighbor_ip=e4.get_str(ygdata.Id(NS_ietf_ip, 'ip')))
+            here = _present(e4)
+            if here is not None:
+                inst = ietf_interfaces__interfaces__interface__ipv6__neighbor_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces__interface__ipv6__neighbor_subs(SubscriptionNode):
     ip: SubscriptionNode
     link_layer_address: SubscriptionNode
@@ -11510,11 +12181,35 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_subs(SubscriptionNo
         base_path = self._path!.parent
         return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_ip, 'neighbor'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(interface_name: str, neighbor_ip: str), ?ietf_interfaces__interfaces__interface__ipv6__neighbor_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces__interface__ipv6__neighbor_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin, self.is_router, self.state]
         return direct
 
 _breaker106: None = None
+proc def ietf_interfaces__interfaces__interface__ipv6__autoconf_deliver(cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface__ipv6__autoconf, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str) = None
+    inst: ?ietf_interfaces__interfaces__interface__ipv6__autoconf = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv6'))
+            c4 = _at(c3, ygdata.Id(NS_ietf_ip, 'autoconf'))
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = ietf_interfaces__interfaces__interface__ipv6__autoconf.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces__interface__ipv6__autoconf_subs(SubscriptionNode):
     create_global_addresses: SubscriptionNode
     create_temporary_addresses: SubscriptionNode
@@ -11532,7 +12227,30 @@ class ietf_interfaces__interfaces__interface__ipv6__autoconf_subs(SubscriptionNo
         direct: list[SubscriptionNode] = [self.create_global_addresses, self.create_temporary_addresses, self.temporary_valid_lifetime, self.temporary_preferred_lifetime]
         return direct
 
+    def dst(self, cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface__ipv6__autoconf, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces__interface__ipv6__autoconf_deliver(cb, n, err), root=self.filt())
+
 _breaker107: None = None
+proc def ietf_interfaces__interfaces__interface__ipv6_deliver(cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface__ipv6, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str) = None
+    inst: ?ietf_interfaces__interfaces__interface__ipv6 = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv6'))
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = ietf_interfaces__interfaces__interface__ipv6.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces__interface__ipv6_subs(SubscriptionNode):
     enabled: SubscriptionNode
     forwarding: SubscriptionNode
@@ -11555,6 +12273,12 @@ class ietf_interfaces__interfaces__interface__ipv6_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.enabled, self.forwarding, self.mtu, self.address, self.neighbor, self.dup_addr_detect_transmits, self.autoconf]
         return direct
+
+    def dst(self, cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface__ipv6, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces__interface__ipv6_deliver(cb, n, err), root=self.filt())
 
 _breaker108: None = None
 class ietf_interfaces__interfaces__interface_entry_subs(SubscriptionNode):
@@ -11599,6 +12323,22 @@ class ietf_interfaces__interfaces__interface_entry_subs(SubscriptionNode):
         return direct
 
 _breaker109: None = None
+proc def ietf_interfaces__interfaces__interface_deliver(cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str) = None
+    inst: ?ietf_interfaces__interfaces__interface_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = ietf_interfaces__interfaces__interface_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces__interface_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -11642,11 +12382,30 @@ class ietf_interfaces__interfaces__interface_subs(SubscriptionNode):
         base_path = self._path!.parent
         return ietf_interfaces__interfaces__interface_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_interfaces, 'interface'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(interface_name: str), ?ietf_interfaces__interfaces__interface_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces__interface_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.enabled, self.link_up_down_trap_enable, self.admin_status, self.oper_status, self.last_change, self.if_index, self.phys_address, self.higher_layer_if, self.lower_layer_if, self.speed, self.statistics, self.ipv4, self.ipv6]
         return direct
 
 _breaker110: None = None
+proc def ietf_interfaces__interfaces_deliver(cb: action(?ietf_interfaces__interfaces, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_interfaces__interfaces = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces'))
+            here = _present(c1)
+            if here is not None:
+                inst = ietf_interfaces__interfaces.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_interfaces__interfaces_subs(SubscriptionNode):
     interface: ietf_interfaces__interfaces__interface_subs
 
@@ -11658,7 +12417,30 @@ class ietf_interfaces__interfaces_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.interface]
         return direct
 
+    def dst(self, cb: action(?ietf_interfaces__interfaces, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_deliver(cb, n, err), root=self.filt())
+
 _breaker111: None = None
+proc def ietf_interfaces__interfaces_state__interface__statistics_deliver(cb: action(?(interface_name: str), ?ietf_interfaces__interfaces_state__interface__statistics, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str) = None
+    inst: ?ietf_interfaces__interfaces_state__interface__statistics = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces-state'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_interfaces, 'statistics'))
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = ietf_interfaces__interfaces_state__interface__statistics.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces_state__interface__statistics_subs(SubscriptionNode):
     discontinuity_time: SubscriptionNode
     in_octets: SubscriptionNode
@@ -11696,6 +12478,12 @@ class ietf_interfaces__interfaces_state__interface__statistics_subs(Subscription
         direct: list[SubscriptionNode] = [self.discontinuity_time, self.in_octets, self.in_unicast_pkts, self.in_broadcast_pkts, self.in_multicast_pkts, self.in_discards, self.in_errors, self.in_unknown_protos, self.out_octets, self.out_unicast_pkts, self.out_broadcast_pkts, self.out_multicast_pkts, self.out_discards, self.out_errors]
         return direct
 
+    def dst(self, cb: action(?(interface_name: str), ?ietf_interfaces__interfaces_state__interface__statistics, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_state__interface__statistics_deliver(cb, n, err), root=self.filt())
+
 _breaker112: None = None
 class ietf_interfaces__interfaces_state__interface__ipv4__address_entry_subs(SubscriptionNode):
     ip: SubscriptionNode
@@ -11715,6 +12503,24 @@ class ietf_interfaces__interfaces_state__interface__ipv4__address_entry_subs(Sub
         return direct
 
 _breaker113: None = None
+proc def ietf_interfaces__interfaces_state__interface__ipv4__address_deliver(cb: action(?(interface_name: str, address_ip: str), ?ietf_interfaces__interfaces_state__interface__ipv4__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str, address_ip: str) = None
+    inst: ?ietf_interfaces__interfaces_state__interface__ipv4__address_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces-state'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv4'))
+            e4 = _one(_at(c3, ygdata.Id(NS_ietf_ip, 'address')), 'address')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')), address_ip=e4.get_str(ygdata.Id(NS_ietf_ip, 'ip')))
+            here = _present(e4)
+            if here is not None:
+                inst = ietf_interfaces__interfaces_state__interface__ipv4__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces_state__interface__ipv4__address_subs(SubscriptionNode):
     ip: SubscriptionNode
     prefix_length: SubscriptionNode
@@ -11733,6 +12539,12 @@ class ietf_interfaces__interfaces_state__interface__ipv4__address_subs(Subscript
         ]
         base_path = self._path!.parent
         return ietf_interfaces__interfaces_state__interface__ipv4__address_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_ip, 'address'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(interface_name: str, address_ip: str), ?ietf_interfaces__interfaces_state__interface__ipv4__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_state__interface__ipv4__address_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.netmask, self.origin]
@@ -11755,6 +12567,24 @@ class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry_subs(Su
         return direct
 
 _breaker115: None = None
+proc def ietf_interfaces__interfaces_state__interface__ipv4__neighbor_deliver(cb: action(?(interface_name: str, neighbor_ip: str), ?ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str, neighbor_ip: str) = None
+    inst: ?ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces-state'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv4'))
+            e4 = _one(_at(c3, ygdata.Id(NS_ietf_ip, 'neighbor')), 'neighbor')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')), neighbor_ip=e4.get_str(ygdata.Id(NS_ietf_ip, 'ip')))
+            here = _present(e4)
+            if here is not None:
+                inst = ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_subs(SubscriptionNode):
     ip: SubscriptionNode
     link_layer_address: SubscriptionNode
@@ -11772,11 +12602,34 @@ class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_subs(Subscrip
         base_path = self._path!.parent
         return ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_ip, 'neighbor'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(interface_name: str, neighbor_ip: str), ?ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_state__interface__ipv4__neighbor_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin]
         return direct
 
 _breaker116: None = None
+proc def ietf_interfaces__interfaces_state__interface__ipv4_deliver(cb: action(?(interface_name: str), ?ietf_interfaces__interfaces_state__interface__ipv4, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str) = None
+    inst: ?ietf_interfaces__interfaces_state__interface__ipv4 = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces-state'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv4'))
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = ietf_interfaces__interfaces_state__interface__ipv4.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces_state__interface__ipv4_subs(SubscriptionNode):
     forwarding: SubscriptionNode
     mtu: SubscriptionNode
@@ -11793,6 +12646,12 @@ class ietf_interfaces__interfaces_state__interface__ipv4_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.forwarding, self.mtu, self.address, self.neighbor]
         return direct
+
+    def dst(self, cb: action(?(interface_name: str), ?ietf_interfaces__interfaces_state__interface__ipv4, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_state__interface__ipv4_deliver(cb, n, err), root=self.filt())
 
 _breaker117: None = None
 class ietf_interfaces__interfaces_state__interface__ipv6__address_entry_subs(SubscriptionNode):
@@ -11813,6 +12672,24 @@ class ietf_interfaces__interfaces_state__interface__ipv6__address_entry_subs(Sub
         return direct
 
 _breaker118: None = None
+proc def ietf_interfaces__interfaces_state__interface__ipv6__address_deliver(cb: action(?(interface_name: str, address_ip: str), ?ietf_interfaces__interfaces_state__interface__ipv6__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str, address_ip: str) = None
+    inst: ?ietf_interfaces__interfaces_state__interface__ipv6__address_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces-state'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv6'))
+            e4 = _one(_at(c3, ygdata.Id(NS_ietf_ip, 'address')), 'address')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')), address_ip=e4.get_str(ygdata.Id(NS_ietf_ip, 'ip')))
+            here = _present(e4)
+            if here is not None:
+                inst = ietf_interfaces__interfaces_state__interface__ipv6__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces_state__interface__ipv6__address_subs(SubscriptionNode):
     ip: SubscriptionNode
     prefix_length: SubscriptionNode
@@ -11831,6 +12708,12 @@ class ietf_interfaces__interfaces_state__interface__ipv6__address_subs(Subscript
         ]
         base_path = self._path!.parent
         return ietf_interfaces__interfaces_state__interface__ipv6__address_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_ip, 'address'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(interface_name: str, address_ip: str), ?ietf_interfaces__interfaces_state__interface__ipv6__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_state__interface__ipv6__address_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.origin, self.status]
@@ -11857,6 +12740,24 @@ class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry_subs(Su
         return direct
 
 _breaker120: None = None
+proc def ietf_interfaces__interfaces_state__interface__ipv6__neighbor_deliver(cb: action(?(interface_name: str, neighbor_ip: str), ?ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str, neighbor_ip: str) = None
+    inst: ?ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces-state'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv6'))
+            e4 = _one(_at(c3, ygdata.Id(NS_ietf_ip, 'neighbor')), 'neighbor')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')), neighbor_ip=e4.get_str(ygdata.Id(NS_ietf_ip, 'ip')))
+            here = _present(e4)
+            if here is not None:
+                inst = ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_subs(SubscriptionNode):
     ip: SubscriptionNode
     link_layer_address: SubscriptionNode
@@ -11878,11 +12779,34 @@ class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_subs(Subscrip
         base_path = self._path!.parent
         return ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_ip, 'neighbor'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(interface_name: str, neighbor_ip: str), ?ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_state__interface__ipv6__neighbor_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin, self.is_router, self.state]
         return direct
 
 _breaker121: None = None
+proc def ietf_interfaces__interfaces_state__interface__ipv6_deliver(cb: action(?(interface_name: str), ?ietf_interfaces__interfaces_state__interface__ipv6, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str) = None
+    inst: ?ietf_interfaces__interfaces_state__interface__ipv6 = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces-state'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            c3 = _at(e2, ygdata.Id(NS_ietf_ip, 'ipv6'))
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = ietf_interfaces__interfaces_state__interface__ipv6.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces_state__interface__ipv6_subs(SubscriptionNode):
     forwarding: SubscriptionNode
     mtu: SubscriptionNode
@@ -11899,6 +12823,12 @@ class ietf_interfaces__interfaces_state__interface__ipv6_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.forwarding, self.mtu, self.address, self.neighbor]
         return direct
+
+    def dst(self, cb: action(?(interface_name: str), ?ietf_interfaces__interfaces_state__interface__ipv6, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_state__interface__ipv6_deliver(cb, n, err), root=self.filt())
 
 _breaker122: None = None
 class ietf_interfaces__interfaces_state__interface_entry_subs(SubscriptionNode):
@@ -11937,6 +12867,22 @@ class ietf_interfaces__interfaces_state__interface_entry_subs(SubscriptionNode):
         return direct
 
 _breaker123: None = None
+proc def ietf_interfaces__interfaces_state__interface_deliver(cb: action(?(interface_name: str), ?ietf_interfaces__interfaces_state__interface_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(interface_name: str) = None
+    inst: ?ietf_interfaces__interfaces_state__interface_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces-state'))
+            e2 = _one(_at(c1, ygdata.Id(NS_ietf_interfaces, 'interface')), 'interface')
+            keys = (interface_name=e2.get_str(ygdata.Id(NS_ietf_interfaces, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = ietf_interfaces__interfaces_state__interface_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class ietf_interfaces__interfaces_state__interface_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -11974,11 +12920,30 @@ class ietf_interfaces__interfaces_state__interface_subs(SubscriptionNode):
         base_path = self._path!.parent
         return ietf_interfaces__interfaces_state__interface_entry_subs(SubscriptionPath(ygdata.Id(NS_ietf_interfaces, 'interface'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(interface_name: str), ?ietf_interfaces__interfaces_state__interface_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_state__interface_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.type, self.admin_status, self.oper_status, self.last_change, self.if_index, self.phys_address, self.higher_layer_if, self.lower_layer_if, self.speed, self.statistics, self.ipv4, self.ipv6]
         return direct
 
 _breaker124: None = None
+proc def ietf_interfaces__interfaces_state_deliver(cb: action(?ietf_interfaces__interfaces_state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?ietf_interfaces__interfaces_state = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_ietf_interfaces, 'interfaces-state'))
+            here = _present(c1)
+            if here is not None:
+                inst = ietf_interfaces__interfaces_state.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class ietf_interfaces__interfaces_state_subs(SubscriptionNode):
     interface: ietf_interfaces__interfaces_state__interface_subs
 
@@ -11989,6 +12954,12 @@ class ietf_interfaces__interfaces_state_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.interface]
         return direct
+
+    def dst(self, cb: action(?ietf_interfaces__interfaces_state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: ietf_interfaces__interfaces_state_deliver(cb, n, err), root=self.filt())
 
 _breaker125: None = None
 class root_subs(SubscriptionNode):
@@ -12012,17 +12983,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/minisys/src/mini/layers/y_0_oper.act
+++ b/minisys/src/mini/layers/y_0_oper.act
@@ -1157,7 +1157,41 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
 _breaker13: None = None
+proc def netinfra__netinfra__global_settings_deliver(cb: action(?netinfra__netinfra__global_settings, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?netinfra__netinfra__global_settings = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_netinfra, 'netinfra'))
+            c2 = _at(c1, ygdata.Id(NS_netinfra, 'global-settings'))
+            here = _present(c2)
+            if here is not None:
+                inst = netinfra__netinfra__global_settings.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class netinfra__netinfra__global_settings_subs(SubscriptionNode):
     asn: SubscriptionNode
 
@@ -1169,7 +1203,30 @@ class netinfra__netinfra__global_settings_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.asn]
         return direct
 
+    def dst(self, cb: action(?netinfra__netinfra__global_settings, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: netinfra__netinfra__global_settings_deliver(cb, n, err), root=self.filt())
+
 _breaker14: None = None
+proc def netinfra__netinfra__router__dynstate_deliver(cb: action(?(router_name: str), ?netinfra__netinfra__router__dynstate, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(router_name: str) = None
+    inst: ?netinfra__netinfra__router__dynstate = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_netinfra, 'netinfra'))
+            e2 = _one(_at(c1, ygdata.Id(NS_netinfra, 'router')), 'router')
+            c3 = _at(e2, ygdata.Id(NS_netinfra, 'dynstate'))
+            keys = (router_name=e2.get_str(ygdata.Id(NS_netinfra, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = netinfra__netinfra__router__dynstate.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class netinfra__netinfra__router__dynstate_subs(SubscriptionNode):
     current_datetime: SubscriptionNode
 
@@ -1181,7 +1238,30 @@ class netinfra__netinfra__router__dynstate_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.current_datetime]
         return direct
 
+    def dst(self, cb: action(?(router_name: str), ?netinfra__netinfra__router__dynstate, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: netinfra__netinfra__router__dynstate_deliver(cb, n, err), root=self.filt())
+
 _breaker15: None = None
+proc def netinfra__netinfra__router__state_deliver(cb: action(?(router_name: str), ?netinfra__netinfra__router__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(router_name: str) = None
+    inst: ?netinfra__netinfra__router__state = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_netinfra, 'netinfra'))
+            e2 = _one(_at(c1, ygdata.Id(NS_netinfra, 'router')), 'router')
+            c3 = _at(e2, ygdata.Id(NS_netinfra, 'state'))
+            keys = (router_name=e2.get_str(ygdata.Id(NS_netinfra, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = netinfra__netinfra__router__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class netinfra__netinfra__router__state_subs(SubscriptionNode):
     current_datetime: SubscriptionNode
 
@@ -1192,6 +1272,12 @@ class netinfra__netinfra__router__state_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.current_datetime]
         return direct
+
+    def dst(self, cb: action(?(router_name: str), ?netinfra__netinfra__router__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: netinfra__netinfra__router__state_deliver(cb, n, err), root=self.filt())
 
 _breaker16: None = None
 class netinfra__netinfra__router_entry_subs(SubscriptionNode):
@@ -1216,6 +1302,22 @@ class netinfra__netinfra__router_entry_subs(SubscriptionNode):
         return direct
 
 _breaker17: None = None
+proc def netinfra__netinfra__router_deliver(cb: action(?(router_name: str), ?netinfra__netinfra__router_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(router_name: str) = None
+    inst: ?netinfra__netinfra__router_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_netinfra, 'netinfra'))
+            e2 = _one(_at(c1, ygdata.Id(NS_netinfra, 'router')), 'router')
+            keys = (router_name=e2.get_str(ygdata.Id(NS_netinfra, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = netinfra__netinfra__router_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class netinfra__netinfra__router_subs(SubscriptionNode):
     name: SubscriptionNode
     id: SubscriptionNode
@@ -1239,11 +1341,30 @@ class netinfra__netinfra__router_subs(SubscriptionNode):
         base_path = self._path!.parent
         return netinfra__netinfra__router_entry_subs(SubscriptionPath(ygdata.Id(NS_netinfra, 'router'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(router_name: str), ?netinfra__netinfra__router_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: netinfra__netinfra__router_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.id, self.type, self.mock, self.dynstate, self.state]
         return direct
 
 _breaker18: None = None
+proc def netinfra__netinfra_deliver(cb: action(?netinfra__netinfra, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?netinfra__netinfra = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_netinfra, 'netinfra'))
+            here = _present(c1)
+            if here is not None:
+                inst = netinfra__netinfra.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class netinfra__netinfra_subs(SubscriptionNode):
     global_settings: netinfra__netinfra__global_settings_subs
     router: netinfra__netinfra__router_subs
@@ -1257,7 +1378,26 @@ class netinfra__netinfra_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.global_settings, self.router]
         return direct
 
+    def dst(self, cb: action(?netinfra__netinfra, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: netinfra__netinfra_deliver(cb, n, err), root=self.filt())
+
 _breaker19: None = None
+proc def netinfra__p_container_deliver(cb: action(?netinfra__p_container, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?netinfra__p_container = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_netinfra, 'p-container'))
+            here = _present(c1)
+            if here is not None:
+                inst = netinfra__p_container.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class netinfra__p_container_subs(SubscriptionNode):
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -1266,6 +1406,12 @@ class netinfra__p_container_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = []
         return direct
+
+    def dst(self, cb: action(?netinfra__p_container, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: netinfra__p_container_deliver(cb, n, err), root=self.filt())
 
 _breaker20: None = None
 class l3vpn__l3vpn__endpoint_entry_subs(SubscriptionNode):
@@ -1296,6 +1442,22 @@ class l3vpn__l3vpn__endpoint_entry_subs(SubscriptionNode):
         return direct
 
 _breaker21: None = None
+proc def l3vpn__l3vpn__endpoint_deliver(cb: action(?(l3vpn_name: str, endpoint_device: str, endpoint_interface_name: str), ?l3vpn__l3vpn__endpoint_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(l3vpn_name: str, endpoint_device: str, endpoint_interface_name: str) = None
+    inst: ?l3vpn__l3vpn__endpoint_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_l3vpn, 'l3vpn')), 'l3vpn')
+            e2 = _one(_at(e1, ygdata.Id(NS_l3vpn, 'endpoint')), 'endpoint')
+            keys = (l3vpn_name=e1.get_str(ygdata.Id(NS_l3vpn, 'name')), endpoint_device=e2.get_str(ygdata.Id(NS_l3vpn, 'device')), endpoint_interface_name=e2.get_str(ygdata.Id(NS_l3vpn, 'interface-name')))
+            here = _present(e2)
+            if here is not None:
+                inst = l3vpn__l3vpn__endpoint_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class l3vpn__l3vpn__endpoint_subs(SubscriptionNode):
     device: SubscriptionNode
     interface_name: SubscriptionNode
@@ -1326,6 +1488,12 @@ class l3vpn__l3vpn__endpoint_subs(SubscriptionNode):
         base_path = self._path!.parent
         return l3vpn__l3vpn__endpoint_entry_subs(SubscriptionPath(ygdata.Id(NS_l3vpn, 'endpoint'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(l3vpn_name: str, endpoint_device: str, endpoint_interface_name: str), ?l3vpn__l3vpn__endpoint_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: l3vpn__l3vpn__endpoint_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.device, self.interface_name, self.ipv4_address, self.prefix_length, self.mtu, self.vlan_id, self.enabled, self.site_code, self.description]
         return direct
@@ -1355,6 +1523,21 @@ class l3vpn__l3vpn_entry_subs(SubscriptionNode):
         return direct
 
 _breaker23: None = None
+proc def l3vpn__l3vpn_deliver(cb: action(?(l3vpn_name: str), ?l3vpn__l3vpn_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(l3vpn_name: str) = None
+    inst: ?l3vpn__l3vpn_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_l3vpn, 'l3vpn')), 'l3vpn')
+            keys = (l3vpn_name=e1.get_str(ygdata.Id(NS_l3vpn, 'name')))
+            here = _present(e1)
+            if here is not None:
+                inst = l3vpn__l3vpn_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class l3vpn__l3vpn_subs(SubscriptionNode):
     name: SubscriptionNode
     customer_name: SubscriptionNode
@@ -1380,6 +1563,12 @@ class l3vpn__l3vpn_subs(SubscriptionNode):
         base_path = self._path!.parent
         return l3vpn__l3vpn_entry_subs(SubscriptionPath(ygdata.Id(NS_l3vpn, 'l3vpn'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(l3vpn_name: str), ?l3vpn__l3vpn_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: l3vpn__l3vpn_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.customer_name, self.vpn_id, self.service_mtu, self.enabled, self.description, self.endpoint]
         return direct
@@ -1402,17 +1591,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/minisys/src/mini/layers/y_1_oper.act
+++ b/minisys/src/mini/layers/y_1_oper.act
@@ -3094,6 +3094,26 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
 _breaker35: None = None
 class stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
@@ -3111,6 +3131,23 @@ class stratoweave_rfs__device__address__initial_credentials_entry_subs(Subscript
         return direct
 
 _breaker36: None = None
+proc def stratoweave_rfs__device__address__initial_credentials_deliver(cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__device__address__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'address')), 'address')
+            e3 = _one(_at(e2, ygdata.Id(NS_stratoweave_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), address_name=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), initial_credentials_username=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'username')), initial_credentials_password=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'password')), initial_credentials_key=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3129,6 +3166,12 @@ class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNod
         ]
         base_path = self._path!.parent
         return stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__address__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__address__initial_credentials_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
@@ -3153,6 +3196,22 @@ class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
         return direct
 
 _breaker38: None = None
+proc def stratoweave_rfs__device__address_deliver(cb: action(?(device_name: str, address_name: str), ?stratoweave_rfs__device__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str) = None
+    inst: ?stratoweave_rfs__device__address_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'address')), 'address')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), address_name=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__device__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -3171,6 +3230,12 @@ class stratoweave_rfs__device__address_subs(SubscriptionNode):
         ]
         base_path = self._path!.parent
         return stratoweave_rfs__device__address_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'address'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(device_name: str, address_name: str), ?stratoweave_rfs__device__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__address_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
@@ -3191,6 +3256,23 @@ class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
         return direct
 
 _breaker40: None = None
+proc def stratoweave_rfs__device__credentials__key_deliver(cb: action(?(device_name: str, key_key: str), ?stratoweave_rfs__device__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, key_key: str) = None
+    inst: ?stratoweave_rfs__device__credentials__key_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'credentials'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'key')), 'key')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), key_key=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__credentials__key_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -3206,11 +3288,33 @@ class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'key'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, key_key: str), ?stratoweave_rfs__device__credentials__key_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__credentials__key_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
 _breaker41: None = None
+proc def stratoweave_rfs__device__credentials_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__credentials = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'credentials'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__credentials.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3225,6 +3329,12 @@ class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
+
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__credentials, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__credentials_deliver(cb, n, err), root=self.filt())
 
 _breaker42: None = None
 class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
@@ -3243,6 +3353,22 @@ class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
         return direct
 
 _breaker43: None = None
+proc def stratoweave_rfs__device__initial_credentials_deliver(cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__device__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), initial_credentials_username=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'username')), initial_credentials_password=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'password')), initial_credentials_key=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__device__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3262,11 +3388,33 @@ class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
 _breaker44: None = None
+proc def stratoweave_rfs__device__ssh_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__ssh = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'ssh'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__ssh.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
     cipher: SubscriptionNode
     mac: SubscriptionNode
@@ -3296,6 +3444,12 @@ class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__ssh, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__ssh_deliver(cb, n, err), root=self.filt())
+
 _breaker45: None = None
 class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
@@ -3315,6 +3469,23 @@ class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
         return direct
 
 _breaker46: None = None
+proc def stratoweave_rfs__device__mock__module_deliver(cb: action(?(device_name: str, module_name: str), ?stratoweave_rfs__device__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, module_name: str) = None
+    inst: ?stratoweave_rfs__device__mock__module_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'module')), 'module')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), module_name=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock__module_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -3334,11 +3505,33 @@ class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__mock__module_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'module'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, module_name: str), ?stratoweave_rfs__device__mock__module_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock__module_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
 _breaker47: None = None
+proc def stratoweave_rfs__device__mock_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__mock = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
     module: stratoweave_rfs__device__mock__module_subs
@@ -3352,7 +3545,29 @@ class stratoweave_rfs__device__mock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.module]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__mock, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock_deliver(cb, n, err), root=self.filt())
+
 _breaker48: None = None
+proc def stratoweave_rfs__device__debug_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__debug = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'debug'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__debug.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -3364,7 +3579,29 @@ class stratoweave_rfs__device__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__debug, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__debug_deliver(cb, n, err), root=self.filt())
+
 _breaker49: None = None
+proc def stratoweave_rfs__device__feature_flags_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__feature_flags = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'feature-flags'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__feature_flags.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -3375,6 +3612,12 @@ class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
+
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__feature_flags, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__feature_flags_deliver(cb, n, err), root=self.filt())
 
 _breaker50: None = None
 class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
@@ -3391,6 +3634,23 @@ class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
         return direct
 
 _breaker51: None = None
+proc def stratoweave_rfs__device__software__veto_deliver(cb: action(?(device_name: str, veto_holder: str), ?stratoweave_rfs__device__software__veto_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, veto_holder: str) = None
+    inst: ?stratoweave_rfs__device__software__veto_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'veto')), 'veto')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), veto_holder=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'holder')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__veto_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -3405,6 +3665,12 @@ class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
         ]
         base_path = self._path!.parent
         return stratoweave_rfs__device__software__veto_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'veto'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(device_name: str, veto_holder: str), ?stratoweave_rfs__device__software__veto_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__veto_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.holder, self.reason]
@@ -3433,6 +3699,24 @@ class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode)
         return direct
 
 _breaker53: None = None
+proc def stratoweave_rfs__device__software__state__job_deliver(cb: action(?(device_name: str, job_name: str), ?stratoweave_rfs__device__software__state__job_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, job_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__job_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            e4 = _one(_at(c3, ygdata.Id(NS_stratoweave_rfs, 'job')), 'job')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), job_name=e4.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__job_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -3456,11 +3740,35 @@ class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'job'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, job_name: str), ?stratoweave_rfs__device__software__state__job_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__job_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
 _breaker54: None = None
+proc def stratoweave_rfs__device__software__state__precheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__precheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__precheck = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            c4 = _at(c3, ygdata.Id(NS_stratoweave_rfs, 'precheck'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__precheck.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -3476,7 +3784,31 @@ class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__precheck, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__precheck_deliver(cb, n, err), root=self.filt())
+
 _breaker55: None = None
+proc def stratoweave_rfs__device__software__state__postcheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__postcheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__postcheck = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            c4 = _at(c3, ygdata.Id(NS_stratoweave_rfs, 'postcheck'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__postcheck.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -3492,7 +3824,30 @@ class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__postcheck, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__postcheck_deliver(cb, n, err), root=self.filt())
+
 _breaker56: None = None
+proc def stratoweave_rfs__device__software__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
     status: SubscriptionNode
     running_release: SubscriptionNode
@@ -3512,7 +3867,29 @@ class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.status, self.running_release, self.job, self.precheck, self.postcheck]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state_deliver(cb, n, err), root=self.filt())
+
 _breaker57: None = None
+proc def stratoweave_rfs__device__software_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software_subs(SubscriptionNode):
     upgrade_campaign: SubscriptionNode
     target_release: SubscriptionNode
@@ -3534,7 +3911,29 @@ class stratoweave_rfs__device__software_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.upgrade_campaign, self.target_release, self.image_url, self.allow_staging, self.veto, self.state]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software_deliver(cb, n, err), root=self.filt())
+
 _breaker58: None = None
+proc def stratoweave_rfs__device__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__state_subs(SubscriptionNode):
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -3543,6 +3942,12 @@ class stratoweave_rfs__device__state_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = []
         return direct
+
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__state_deliver(cb, n, err), root=self.filt())
 
 _breaker59: None = None
 class stratoweave_rfs__device_entry_subs(SubscriptionNode):
@@ -3581,6 +3986,21 @@ class stratoweave_rfs__device_entry_subs(SubscriptionNode):
         return direct
 
 _breaker60: None = None
+proc def stratoweave_rfs__device_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e1)
+            if here is not None:
+                inst = stratoweave_rfs__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -3618,11 +4038,34 @@ class stratoweave_rfs__device_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
 _breaker61: None = None
+proc def stratoweave_rfs__rfs__base_config__dynstate_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__base_config__dynstate, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str) = None
+    inst: ?stratoweave_rfs__rfs__base_config__dynstate = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            c2 = _at(e1, ygdata.Id(NS_mini_rfs, 'base-config'))
+            c3 = _at(c2, ygdata.Id(NS_mini_rfs, 'dynstate'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__base_config__dynstate.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__base_config__dynstate_subs(SubscriptionNode):
     current_datetime: SubscriptionNode
 
@@ -3634,7 +4077,30 @@ class stratoweave_rfs__rfs__base_config__dynstate_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.current_datetime]
         return direct
 
+    def dst(self, cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__base_config__dynstate, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__base_config__dynstate_deliver(cb, n, err), root=self.filt())
+
 _breaker62: None = None
+proc def stratoweave_rfs__rfs__base_config__state_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__base_config__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str) = None
+    inst: ?stratoweave_rfs__rfs__base_config__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            c2 = _at(e1, ygdata.Id(NS_mini_rfs, 'base-config'))
+            c3 = _at(c2, ygdata.Id(NS_mini_rfs, 'state'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__base_config__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__base_config__state_subs(SubscriptionNode):
     current_datetime: SubscriptionNode
 
@@ -3646,7 +4112,29 @@ class stratoweave_rfs__rfs__base_config__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.current_datetime]
         return direct
 
+    def dst(self, cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__base_config__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__base_config__state_deliver(cb, n, err), root=self.filt())
+
 _breaker63: None = None
+proc def stratoweave_rfs__rfs__base_config_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__base_config, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str) = None
+    inst: ?stratoweave_rfs__rfs__base_config = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            c2 = _at(e1, ygdata.Id(NS_mini_rfs, 'base-config'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__base_config.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__base_config_subs(SubscriptionNode):
     name: SubscriptionNode
     ipv4_address: SubscriptionNode
@@ -3663,6 +4151,12 @@ class stratoweave_rfs__rfs__base_config_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.ipv4_address, self.dynstate, self.state]
         return direct
+
+    def dst(self, cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__base_config, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__base_config_deliver(cb, n, err), root=self.filt())
 
 _breaker64: None = None
 class stratoweave_rfs__rfs__l3vpn_endpoint_entry_subs(SubscriptionNode):
@@ -3701,6 +4195,22 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry_subs(SubscriptionNode):
         return direct
 
 _breaker65: None = None
+proc def stratoweave_rfs__rfs__l3vpn_endpoint_deliver(cb: action(?(rfs_name: str, l3vpn_endpoint_interface_name: str), ?stratoweave_rfs__rfs__l3vpn_endpoint_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, l3vpn_endpoint_interface_name: str) = None
+    inst: ?stratoweave_rfs__rfs__l3vpn_endpoint_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_mini_rfs, 'l3vpn-endpoint')), 'l3vpn-endpoint')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), l3vpn_endpoint_interface_name=e2.get_str(ygdata.Id(NS_mini_rfs, 'interface-name')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__l3vpn_endpoint_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__l3vpn_endpoint_subs(SubscriptionNode):
     interface_name: SubscriptionNode
     vpn_name: SubscriptionNode
@@ -3738,6 +4248,12 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry_subs(SubscriptionPath(ygdata.Id(NS_mini_rfs, 'l3vpn-endpoint'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str, l3vpn_endpoint_interface_name: str), ?stratoweave_rfs__rfs__l3vpn_endpoint_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__l3vpn_endpoint_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.interface_name, self.vpn_name, self.customer_name, self.route_distinguisher, self.import_rt, self.export_rt, self.ipv4_address, self.prefix_length, self.mtu, self.vlan_id, self.enabled, self.site_code, self.description]
         return direct
@@ -3759,6 +4275,21 @@ class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
         return direct
 
 _breaker67: None = None
+proc def stratoweave_rfs__rfs_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str) = None
+    inst: ?stratoweave_rfs__rfs_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e1)
+            if here is not None:
+                inst = stratoweave_rfs__rfs_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs_subs(SubscriptionNode):
     name: SubscriptionNode
     base_config: stratoweave_rfs__rfs__base_config_subs
@@ -3775,6 +4306,12 @@ class stratoweave_rfs__rfs_subs(SubscriptionNode):
         ]
         base_path = self._path!.parent
         return stratoweave_rfs__rfs_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'rfs'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.base_config, self.l3vpn_endpoint]
@@ -3796,17 +4333,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/minisys/src/mini/layers/y_2_oper.act
+++ b/minisys/src/mini/layers/y_2_oper.act
@@ -241,6 +241,26 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
 _breaker5: None = None
 class stratoweave_device__devices__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
@@ -256,6 +276,22 @@ class stratoweave_device__devices__device_entry_subs(SubscriptionNode):
         return direct
 
 _breaker6: None = None
+proc def stratoweave_device__devices__device_deliver(cb: action(?(device_name: str), ?stratoweave_device__devices__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_device__devices__device_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_stratoweave_device, 'devices'))
+            e2 = _one(_at(c1, ygdata.Id(NS_stratoweave_device, 'device')), 'device')
+            keys = (device_name=e2.get_str(ygdata.Id(NS_stratoweave_device, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_device__devices__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_device__devices__device_subs(SubscriptionNode):
     name: SubscriptionNode
     modset_id: SubscriptionNode
@@ -271,11 +307,30 @@ class stratoweave_device__devices__device_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_device__devices__device_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_device, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_device__devices__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_device__devices__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.modset_id]
         return direct
 
 _breaker7: None = None
+proc def stratoweave_device__devices_deliver(cb: action(?stratoweave_device__devices, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?stratoweave_device__devices = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_stratoweave_device, 'devices'))
+            here = _present(c1)
+            if here is not None:
+                inst = stratoweave_device__devices.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class stratoweave_device__devices_subs(SubscriptionNode):
     device: stratoweave_device__devices__device_subs
 
@@ -286,6 +341,12 @@ class stratoweave_device__devices_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.device]
         return direct
+
+    def dst(self, cb: action(?stratoweave_device__devices, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_device__devices_deliver(cb, n, err), root=self.filt())
 
 _breaker8: None = None
 class root_subs(SubscriptionNode):
@@ -301,17 +362,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -192,16 +192,22 @@ class SharedSubscription(object):
 
 
 class SubscriptionOwner(object):
-    """One logical subscriber and its merged delivery state."""
+    """One logical subscriber and its merged delivery state. `synced` is
+    called with the owner id after its first delivery, once."""
     @property
-    cb: action(?ygdata.Node, ?Exception) -> None
+    cb: proc(?ygdata.Node, ?Exception) -> None
+    @property
+    synced: ?action(str) -> None
     want: set[ygdata.SubscriptionSpec]
     last_merged: ?ygdata.Node
+    synced_done: bool
 
-    def __init__(self, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec], last_merged: ?ygdata.Node=None):
+    def __init__(self, cb: proc(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec], last_merged: ?ygdata.Node=None, synced: ?action(str) -> None=None, synced_done: bool=False):
         self.cb = cb
+        self.synced = synced
         self.want = set(want)
         self.last_merged = last_merged
+        self.synced_done = synced_done
 
 
 # subscription_method() / SubscriptionStatus.method values: the transport used to
@@ -306,7 +312,7 @@ class DeviceAdapter(object):
     ## subscription is the better choice for anything watched continuously.
     get: proc(cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode) -> None
 
-    declare_subscriptions: proc(str, action(?ygdata.Node, ?Exception) -> None, set[ygdata.SubscriptionSpec]) -> None
+    declare_subscriptions: proc(str, proc(?ygdata.Node, ?Exception) -> None, set[ygdata.SubscriptionSpec], ?action(str) -> None) -> None
     remove_subscriptions: proc(str) -> None
 
 
@@ -348,8 +354,11 @@ class NoAdapter(DeviceAdapter):
     def get(self, cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
         cb(None, NotConnectedError())
 
-    def declare_subscriptions(self, owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
+    def declare_subscriptions(self, owner_id: str, cb: proc(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec], synced: ?action(str) -> None):
         cb(None, NotConnectedError())
+        s = synced
+        if s is not None:
+            s(owner_id)
 
     def remove_subscriptions(self, owner_id: str):
         pass
@@ -397,9 +406,12 @@ class MockAdapter(DeviceAdapter):
     def get(self, cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
         return self._driver.get(cb, filt)
 
-    def declare_subscriptions(self, owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
+    def declare_subscriptions(self, owner_id: str, cb: proc(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec], synced: ?action(str) -> None):
         # TODO: can / should subscriptions do something on a MockAdapter ?
         cb(None, NotConnectedError())
+        s = synced
+        if s is not None:
+            s(owner_id)
 
     def remove_subscriptions(self, owner_id: str):
         pass

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -1666,6 +1666,11 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             owner.last_merged = merged
             sub_owners[owner_id] = owner
             owner.cb(merged, err)
+            if not owner.synced_done:
+                owner.synced_done = True            # the first delivery is the first pass
+                s = owner.synced
+                if s is not None:
+                    s(owner_id)
 
     def _apply_push_change(spec: ygdata.SubscriptionSpec, sid: int, pcu: yp.PushChangeUpdate):
         # Replay the push-change-update's yang-patch onto the subscription's latest
@@ -1885,19 +1890,21 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         else:
             subs[spec] = st
 
-    def declare_subscriptions(owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
+    def declare_subscriptions(owner_id: str, cb: proc(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec], synced: ?action(str) -> None):
         old_want = set()
         last_merged = None
+        synced_done = False
         if owner_id in sub_owners:
             owner = sub_owners[owner_id]
             old_want = owner.want
             last_merged = owner.last_merged
+            synced_done = owner.synced_done
 
         for spec in old_want:
             if spec not in want:
                 _remove_owner_spec(owner_id, spec)
 
-        sub_owners[owner_id] = SubscriptionOwner(cb, want, last_merged)
+        sub_owners[owner_id] = SubscriptionOwner(cb, want, last_merged, synced, synced_done)
 
         for spec in want:
             if spec not in old_want:
@@ -1964,8 +1971,8 @@ class NetconfAdapter(DeviceAdapter):
     def get(self, cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
         self._driver.get(cb, filt)
 
-    def declare_subscriptions(self, owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
-        self._driver.declare_subscriptions(owner_id, cb, want)
+    def declare_subscriptions(self, owner_id: str, cb: proc(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec], synced: ?action(str) -> None):
+        self._driver.declare_subscriptions(owner_id, cb, want, synced)
 
     def remove_subscriptions(self, owner_id: str):
         self._driver.remove_subscriptions(owner_id)

--- a/src/adapters/software_iosxe_oper.act
+++ b/src/adapters/software_iosxe_oper.act
@@ -448,7 +448,42 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
 _breaker14: None = None
+proc def Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data_deliver(cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware-data'))
+            c2 = _at(c1, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware'))
+            c3 = _at(c2, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-system-data'))
+            here = _present(c3)
+            if here is not None:
+                inst = Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data_subs(SubscriptionNode):
     software_version: SubscriptionNode
 
@@ -460,7 +495,27 @@ class Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__
         direct: list[SubscriptionNode] = [self.software_version]
         return direct
 
+    def dst(self, cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data_deliver(cb, n, err), root=self.filt())
+
 _breaker15: None = None
+proc def Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_deliver(cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware-data'))
+            c2 = _at(c1, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware'))
+            here = _present(c2)
+            if here is not None:
+                inst = Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_subs(SubscriptionNode):
     device_system_data: Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data_subs
 
@@ -472,7 +527,26 @@ class Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_s
         direct: list[SubscriptionNode] = [self.device_system_data]
         return direct
 
+    def dst(self, cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_deliver(cb, n, err), root=self.filt())
+
 _breaker16: None = None
+proc def Cisco_IOS_XE_device_hardware_oper__device_hardware_data_deliver(cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?Cisco_IOS_XE_device_hardware_oper__device_hardware_data = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware-data'))
+            here = _present(c1)
+            if here is not None:
+                inst = Cisco_IOS_XE_device_hardware_oper__device_hardware_data.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class Cisco_IOS_XE_device_hardware_oper__device_hardware_data_subs(SubscriptionNode):
     device_hardware: Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_subs
 
@@ -483,6 +557,12 @@ class Cisco_IOS_XE_device_hardware_oper__device_hardware_data_subs(SubscriptionN
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.device_hardware]
         return direct
+
+    def dst(self, cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: Cisco_IOS_XE_device_hardware_oper__device_hardware_data_deliver(cb, n, err), root=self.filt())
 
 _breaker17: None = None
 class Cisco_IOS_XE_install_oper__install_oper_data__install_oper__install_txn_summary_op_subs(SubscriptionNode):
@@ -549,6 +629,19 @@ class Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist_subs(Subsc
         return direct
 
 _breaker21: None = None
+proc def Cisco_IOS_XE_install_oper__install_oper_data_deliver(cb: action(?Cisco_IOS_XE_install_oper__install_oper_data, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?Cisco_IOS_XE_install_oper__install_oper_data = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_Cisco_IOS_XE_install_oper, 'install-oper-data'))
+            here = _present(c1)
+            if here is not None:
+                inst = Cisco_IOS_XE_install_oper__install_oper_data.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class Cisco_IOS_XE_install_oper__install_oper_data_subs(SubscriptionNode):
     install_oper: Cisco_IOS_XE_install_oper__install_oper_data__install_oper_subs
     install_oper_hist: Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist_subs
@@ -561,6 +654,12 @@ class Cisco_IOS_XE_install_oper__install_oper_data_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.install_oper, self.install_oper_hist]
         return direct
+
+    def dst(self, cb: action(?Cisco_IOS_XE_install_oper__install_oper_data, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: Cisco_IOS_XE_install_oper__install_oper_data_deliver(cb, n, err), root=self.filt())
 
 _breaker22: None = None
 class root_subs(SubscriptionNode):
@@ -578,17 +677,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/src/device.act
+++ b/src/device.act
@@ -543,8 +543,12 @@ class DeviceTreeProvider(ygdata.TreeProvider):
     proc def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node):
         self.dev.rpc(cb, gdata_rpc)
 
-    proc def declare_subscriptions(self, owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
-        self.dev.declare_subscriptions(owner_id, cb, want)
+    proc def declare_subscriptions(self, owner_id: str, cb: proc(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec], synced: ?action(str) -> None):
+        for spec in want:
+            if spec.root is not None:
+                cb(None, ValueError("a destination rooted at a node is served by a TTT layer, not by a device"))
+                return
+        self.dev.declare_subscriptions(owner_id, cb, want, synced)
 
     proc def remove_subscriptions(self, owner_id: str):
         self.dev.remove_subscriptions(owner_id)
@@ -1188,8 +1192,8 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
         value is watched continuously."""
         adapter.get(cb, filt)
 
-    def declare_subscriptions(owner_id: str, cb: action(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec]):
-        adapter.declare_subscriptions(owner_id, cb, want)
+    def declare_subscriptions(owner_id: str, cb: proc(?ygdata.Node, ?Exception) -> None, want: set[ygdata.SubscriptionSpec], synced: ?action(str) -> None=None):
+        adapter.declare_subscriptions(owner_id, cb, want, synced)
 
     def remove_subscriptions(owner_id: str):
         adapter.remove_subscriptions(owner_id)

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -1157,3 +1157,85 @@ actor _test_subscription_manager_idempotent(t: testing.EnvT):
     start()
 
     after 2.0: fail("Timed out waiting for idempotent subscription manager test")
+
+
+actor _test_device_refuses_rooted_destination_and_syncs_once(t: testing.EnvT):
+    """A device provider serves no rooted destination: the callback hears one
+    error and no data. Its synced fires after the first read, and an equal
+    redeclaration does not repeat it."""
+    var done = False
+    var errors = 0
+    var updates = 0
+    var synced = 0
+    var subs: ?ygdata.SubscriptionManager = None
+    var rooted_subs: ?ygdata.SubscriptionManager = None
+
+    def noop_on_reconf(name: str):
+        pass
+    dev = new_netconf_mock_device_mgr(t, "dev-rooted-refused", noop_on_reconf)
+
+    def close_subs():
+        if subs is not None:
+            subs.close()
+        if rooted_subs is not None:
+            rooted_subs.close()
+
+    def fail(msg: str):
+        if done:
+            return
+        done = True
+        close_subs()
+        t.failure(ValueError(msg))
+
+    def finish():
+        if done:
+            return
+        done = True
+        close_subs()
+        if errors == 1 and synced == 1 and updates > 0:
+            t.success()
+        else:
+            t.failure(ValueError("errors={errors} synced={synced} updates={updates}"))
+
+    def on_rooted(n: ?ygdata.Node, err: ?Exception):
+        if err is not None:
+            errors += 1
+        else:
+            fail("data delivered to a rooted destination on a device")
+
+    def on_update(n: ?ygdata.Node, err: ?Exception):
+        if err is not None:
+            fail("subscription error: {err}")
+            return
+        updates += 1
+        if updates == 1:
+            declare_clock()                         # the same set again
+            after 0.3: finish()
+
+    def on_synced():
+        synced += 1
+
+    def declare_clock():
+        subs!.declare({ygdata.Dst(on_update).deliver({
+            ygdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)
+        })}, synced=on_synced)
+
+    def start():
+        adapter = dev.get_adapter()
+        if isinstance(adapter, swna.NetconfAdapter):
+            ms0 = adapter.get_mock_server()
+            if ms0 is None:
+                fail("Expected NetconfMockServer from NetconfAdapter")
+                return
+            ms0!.set_oper_ds(_mock_oper_ds("2026-02-21T10:11:12Z", "2025-12-31T00:00:00Z"))
+            rooted_subs = ygdata.SubscriptionManager(dev.tree_provider(), "rooted-refused")
+            root = ygdata.FNode(ygdata.Id("urn:ietf:params:xml:ns:yang:ietf-system", "system-state"))
+            rooted_subs!.declare({ygdata.Dst(on_rooted, root=root).deliver({ygdata.SubscriptionSpec(None, period=0.05)})})
+            subs = ygdata.SubscriptionManager(dev.tree_provider(), "synced-once")
+            declare_clock()
+        else:
+            fail("Expected NetconfAdapter from DeviceMgr")
+
+    start()
+
+    after 2.0: fail("Timed out (errors={errors} synced={synced} updates={updates})")

--- a/src/test_ttt_subscriptions.act
+++ b/src/test_ttt_subscriptions.act
@@ -1,0 +1,452 @@
+"""Subscriptions on a TTT layer, served by a Subscription actor per spec.
+
+A consumer's filters fold into one read per period, each read delivers
+the merged view when it differs from the last, and synced follows the
+first run of every read of a declaration. These tests push oper into
+transforms through a Hub and watch what the consumer receives.
+"""
+
+import testing
+
+import ttt as ttt
+import yang.gdata as gdata
+
+TEST_NS = "urn:test-subscriptions"
+
+def q(n: str) -> gdata.Id:
+    return gdata.Id(TEST_NS, n)
+
+
+class Noop(ttt.TransformFunction):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
+        return gdata.Container(), None
+
+
+actor Hub():
+    """Lets a test push oper into a transform by the name of its entry."""
+    var pushers: dict[str, action(?gdata.Node) -> None] = {}
+
+    def register(name: str, push: action(?gdata.Node) -> None):
+        pushers[name] = push
+
+    def push(name: str, oper: ?gdata.Node):
+        if name in pushers:
+            pushers[name](oper)
+        else:
+            after 0.01: push(name, oper)
+
+
+def entry_name(p: ttt.Path) -> str:
+    """The key of the list entry a path sits in, or the name of a node right
+    below the root."""
+    if isinstance(p, ttt.PathKey):
+        return p.name
+    elif isinstance(p, ttt.PathElem):
+        if isinstance(p.parent, ttt.PathRoot):
+            return p.name
+        return entry_name(p.parent)
+    return p.name
+
+
+actor Pusher(hub: Hub, path: ttt.Path, update_oper: action(?gdata.Node) -> None):
+    def on_conf(conf: gdata.Node, memory: ?gdata.Node):
+        hub.register(entry_name(path), update_oper)
+
+
+def pusher_ctor(hub: Hub) -> proc(ttt.TransformActorParams) -> proc(gdata.Node, ?gdata.Node) -> None:
+    def ctor(params: ttt.TransformActorParams) -> proc(gdata.Node, ?gdata.Node) -> None:
+        return Pusher(hub, params.path, params.update_oper).on_conf
+    return ctor
+
+
+def service_layer(hub: Hub) -> ttt.Layer:
+    return ttt.Layer("top", ttt.Container({
+        q("service"): ttt.List(ttt.Transform(Noop, pusher_ctor(hub)), [q("name")], ns=TEST_NS, module="test-subscriptions"),
+    }), None)
+
+def services(names: list[str]) -> gdata.Node:
+    return gdata.Container({
+        q("service"): gdata.List([q("name")], [
+            gdata.Container({q("name"): gdata.Leaf(n), q("enabled"): gdata.Leaf(True)}) for n in names
+        ]),
+    })
+
+def status(s: str) -> gdata.Node:
+    return gdata.Container({q("status"): gdata.Leaf(s)})
+
+def entry(name: str, s: str) -> gdata.Node:
+    """An entry as an unfiltered read delivers it: config and oper together."""
+    return gdata.Container({q("name"): gdata.Leaf(name), q("enabled"): gdata.Leaf(True), q("status"): gdata.Leaf(s)})
+
+def selected(name: str, s: str) -> gdata.Node:
+    """An entry as entry_spec delivers it: its key and the status it names."""
+    return gdata.Container({q("name"): gdata.Leaf(name), q("status"): gdata.Leaf(s)})
+
+def tree(entries: list[gdata.Node]) -> gdata.Node:
+    return gdata.Container({
+        q("service"): gdata.List([q("name")], entries, ns=TEST_NS, module="test-subscriptions"),
+    })
+
+def entry_spec(name: str, period: float=0.02) -> gdata.SubscriptionSpec:
+    return gdata.SubscriptionSpec(gdata.FNode(q("service"), children=[
+        gdata.FNode(q("name"), value_match=name),
+        gdata.FNode(q("status")),
+    ]), period=period)
+
+def whole(period: float=0.02) -> gdata.SubscriptionSpec:
+    return gdata.SubscriptionSpec(None, period=period)
+
+def prs(data: ?gdata.Node) -> str:
+    return data.prsrc(deterministic=True) if data is not None else "None"
+
+def rendered(trees: list[?gdata.Node]) -> list[str]:
+    return sorted([prs(d) for d in trees])
+
+
+actor every_read_that_differs_is_delivered(t: testing.AsyncT):
+    """The first read is delivered, then every read that differs from the
+    last, as the whole subscribed tree."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        n = len(got)
+        if n == 1:
+            if data == tree([entry("svc-a", "first")]):
+                hub.push("svc-a", status("second"))
+            else:
+                fail(ValueError("expected first, got {prs(data)}"))
+        elif n == 2:
+            if data == tree([entry("svc-a", "second")]):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected second, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("first"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {whole()})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor on_change_spec_is_refused(t: testing.AsyncT):
+    """A layer serves periodic specs; one without a period is an error."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if not done:
+            done = True
+            if err is not None:
+                t.success()
+            else:
+                t.failure(ValueError("expected an error, got {prs(data)}"))
+
+    layer.declare_subscriptions("test", on_update, {gdata.SubscriptionSpec(None)})
+    after 2: on_update(None, None)
+
+
+actor filters_with_one_period_fold_into_one_read(t: testing.AsyncT):
+    """Two filters with the same period are read together: the first
+    delivery already holds both."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if not done:
+            done = True
+            if err is not None:
+                t.failure(err)
+            elif data == tree([selected("svc-a", "a"), selected("svc-b", "b")]):
+                t.success()
+            else:
+                t.failure(ValueError("expected both entries at once, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {entry_spec("svc-a"), entry_spec("svc-b")})
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: on_update(None, ValueError("timed out"))
+
+
+actor filters_with_two_periods_are_merged(t: testing.AsyncT):
+    """Filters with different periods are read apart and delivered as one
+    view; a change under one of them keeps the other's part."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var pushed = False
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif not pushed and data == tree([selected("svc-a", "a"), selected("svc-b", "b")]):
+            pushed = True
+            hub.push("svc-a", status("a2"))
+        elif pushed and data == tree([selected("svc-a", "a2"), selected("svc-b", "b")]):
+            done = True
+            t.success()
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {entry_spec("svc-a", 0.02), entry_spec("svc-b", 0.05)})
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out (pushed={pushed})"))
+
+
+actor synced_follows_every_read(t: testing.AsyncT):
+    """A consumer with reads at two periods hears synced once, after both
+    have run, with the view holding both."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var latest: ?gdata.Node = None
+    var synced = 0
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        else:
+            latest = data
+
+    def on_synced(owner: str):
+        synced += 1
+        if latest == tree([selected("svc-a", "a"), selected("svc-b", "b")]):
+            after 0.2: finish()
+        else:
+            fail(ValueError("synced with {prs(latest)}"))
+
+    def finish():
+        if not done:
+            done = True
+            if synced == 1:
+                t.success()
+            else:
+                t.failure(ValueError("synced {synced} times"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("two", on_update, {entry_spec("svc-a", 0.02), entry_spec("svc-b", 0.05)}, on_synced)
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out (synced={synced})"))
+
+
+actor synced_waits_for_a_read_added_by_a_redeclaration(t: testing.AsyncT):
+    """A redeclaration that adds a read at a new period hears its synced
+    only once that read has run."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var latest: ?gdata.Node = None
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        else:
+            latest = data
+
+    def first_synced(owner: str):
+        layer.declare_subscriptions("one", on_update, {entry_spec("svc-a", 0.02), entry_spec("svc-b", 0.05)}, second_synced)
+
+    def second_synced(owner: str):
+        if not done:
+            done = True
+            if latest == tree([selected("svc-a", "a"), selected("svc-b", "b")]):
+                t.success()
+            else:
+                t.failure(ValueError("synced with {prs(latest)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("one", on_update, {entry_spec("svc-a", 0.02)}, first_synced)
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out"))
+
+
+actor redeclaring_the_same_set_installs_the_callbacks_only(t: testing.AsyncT):
+    """A redeclaration of the same set delivers nothing again, hears its
+    synced at once, and hands later deliveries to the new callback."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var second: list[?gdata.Node] = []
+    var synced = 0
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_first(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif data == tree([entry("svc-a", "second")]):
+            fail(ValueError("the replaced callback was called"))
+
+    def first_synced(owner: str):
+        layer.declare_subscriptions("owner", on_second, {whole()}, second_synced)
+
+    def on_second(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        else:
+            second.append(data)
+
+    def second_synced(owner: str):
+        synced += 1
+        if len(second) == 0:
+            hub.push("svc-a", status("second"))
+            after 0.3: finish()
+        else:
+            fail(ValueError("delivered again before synced: {rendered(second)}"))
+
+    def finish():
+        if not done:
+            done = True
+            if synced == 1 and len(second) == 1 and second[0] == tree([entry("svc-a", "second")]):
+                t.success()
+            else:
+                t.failure(ValueError("synced {synced} times, the new callback got {rendered(second)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("first"))
+        after 0.05: layer.declare_subscriptions("owner", on_first, {whole()}, first_synced)
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out"))
+
+
+actor dropping_a_filter_delivers_the_narrowed_view(t: testing.AsyncT):
+    """A redeclaration that drops a filter delivers the view without it."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var narrowed = False
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif not narrowed and data == tree([selected("svc-a", "a"), selected("svc-b", "b")]):
+            narrowed = True
+            layer.declare_subscriptions("test", on_update, {entry_spec("svc-a")})
+        elif narrowed and data == tree([selected("svc-a", "a")]):
+            done = True
+            t.success()
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {entry_spec("svc-a"), entry_spec("svc-b")})
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out (narrowed={narrowed})"))
+
+
+def detail_spec() -> gdata.SubscriptionSpec:
+    """Selects below detail, which raises when detail is a leaf."""
+    return gdata.SubscriptionSpec(gdata.FNode(q("service"), children=[
+        gdata.FNode(q("name"), value_match="svc-a"), gdata.FNode(q("detail"), children=[gdata.FNode(q("x"))]),
+    ]), period=0.02)
+
+
+actor failed_first_read_still_ends_with_synced(t: testing.AsyncT):
+    """A first read that fails reports the error, then synced."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var failed = False
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            failed = True
+        elif not done:
+            done = True
+            t.failure(ValueError("expected an error, got {prs(data)}"))
+
+    def on_synced(owner: str):
+        if not done:
+            done = True
+            if failed:
+                t.success()
+            else:
+                t.failure(ValueError("synced before the error"))
+
+    def declare(_r: value):
+        hub.push("svc-a", gdata.Container({q("detail"): gdata.Leaf("a leaf")}))
+        after 0.05: layer.declare_subscriptions("test", on_update, {detail_spec()}, on_synced)
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: on_update(None, None)
+
+
+actor read_error_keeps_the_last_good_view(t: testing.AsyncT):
+    """A read that fails reports the error with the last good view."""
+    hub = Hub()
+    layer = service_layer(hub)
+    good = tree([gdata.Container({q("name"): gdata.Leaf("svc-a"), q("detail"): gdata.Container({q("x"): gdata.Leaf("1")})})])
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if done:
+            return
+        if err is not None:
+            done = True
+            if data == good:
+                t.success()
+            else:
+                t.failure(ValueError("expected the last good view with the error, got {prs(data)}"))
+        elif data == good:
+            hub.push("svc-a", gdata.Container({q("detail"): gdata.Leaf("now a leaf")}))     # the filter no longer applies
+        else:
+            done = True
+            t.failure(ValueError("unexpected delivery {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", gdata.Container({q("detail"): gdata.Container({q("x"): gdata.Leaf("1")})}))
+        after 0.05: layer.declare_subscriptions("first", on_update, {detail_spec()})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: on_update(None, ValueError("timed out"))

--- a/src/test_ttt_subscriptions.act
+++ b/src/test_ttt_subscriptions.act
@@ -2,8 +2,10 @@
 
 A consumer's filters fold into one read per period, each read delivers
 the merged view when it differs from the last, and synced follows the
-first run of every read of a declaration. These tests push oper into
-transforms through a Hub and watch what the consumer receives.
+first run of every read of a declaration. A consumer rooted at a node
+gets the instances of that node instead, each as a tree from the top
+down to it. These tests push oper into transforms through a Hub and
+watch what the consumer receives.
 """
 
 import testing
@@ -64,12 +66,23 @@ def service_layer(hub: Hub) -> ttt.Layer:
         q("service"): ttt.List(ttt.Transform(Noop, pusher_ctor(hub)), [q("name")], ns=TEST_NS, module="test-subscriptions"),
     }), None)
 
+def probe_layer(hub: Hub) -> ttt.Layer:
+    """One container transform right below the root."""
+    return ttt.Layer("top", ttt.Container({
+        q("probe"): ttt.Transform(Noop, pusher_ctor(hub)),
+    }), None)
+
 def services(names: list[str]) -> gdata.Node:
     return gdata.Container({
         q("service"): gdata.List([q("name")], [
             gdata.Container({q("name"): gdata.Leaf(n), q("enabled"): gdata.Leaf(True)}) for n in names
         ]),
     })
+
+def probe(enabled: bool) -> gdata.Node:
+    if enabled:
+        return gdata.Container({q("probe"): gdata.Container({q("enabled"): gdata.Leaf(True)})})
+    return gdata.Container({q("probe"): gdata.Absent()})
 
 def status(s: str) -> gdata.Node:
     return gdata.Container({q("status"): gdata.Leaf(s)})
@@ -87,14 +100,23 @@ def tree(entries: list[gdata.Node]) -> gdata.Node:
         q("service"): gdata.List([q("name")], entries, ns=TEST_NS, module="test-subscriptions"),
     })
 
+def gone(name: str) -> gdata.Node:
+    """The spine of a service entry reported gone."""
+    return tree([gdata.Absent({q("name"): gdata.Leaf(name)})])
+
+def probe_spine(c: gdata.Node) -> gdata.Node:
+    return gdata.Container({q("probe"): c})
+
 def entry_spec(name: str, period: float=0.02) -> gdata.SubscriptionSpec:
     return gdata.SubscriptionSpec(gdata.FNode(q("service"), children=[
         gdata.FNode(q("name"), value_match=name),
         gdata.FNode(q("status")),
     ]), period=period)
 
-def whole(period: float=0.02) -> gdata.SubscriptionSpec:
-    return gdata.SubscriptionSpec(None, period=period)
+def whole(period: float=0.02, root: ?gdata.FNode=None) -> gdata.SubscriptionSpec:
+    return gdata.SubscriptionSpec(None, period=period, root=root)
+
+ROOTED_AT_SERVICE = gdata.FNode(q("service"))
 
 def prs(data: ?gdata.Node) -> str:
     return data.prsrc(deterministic=True) if data is not None else "None"
@@ -450,3 +472,218 @@ actor read_error_keeps_the_last_good_view(t: testing.AsyncT):
 
     layer.edit_config(services(["svc-a"]), None, declare)
     after 2: on_update(None, ValueError("timed out"))
+
+
+actor rooted_at_a_list(t: testing.AsyncT):
+    """Rooted at the service list: the first read is one delivery per entry
+    then synced; a change delivers its entry alone; a deletion delivers an
+    Absent with the entry's key. Each delivery is a tree from the top."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var synced = False
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_synced(owner: str):
+        if synced or rendered(got) != rendered([tree([entry("svc-a", "a")]), tree([entry("svc-b", "b")])]):
+            fail(ValueError("synced after {len(got)} deliveries: {rendered(got)}"))
+            return
+        synced = True
+        hub.push("svc-a", status("a2"))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        n = len(got)
+        if n == 3:
+            if data == tree([entry("svc-a", "a2")]):
+                layer.edit_config(gdata.Container({
+                    q("service"): gdata.List([q("name")], [gdata.Absent({q("name"): gdata.Leaf("svc-b")})]),
+                }))
+            else:
+                fail(ValueError("expected svc-a alone, got {prs(data)}"))
+        elif n == 4:
+            if data == gone("svc-b"):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected svc-b gone, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("rooted", on_update, {whole(root=ROOTED_AT_SERVICE)}, on_synced)
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries, synced={synced}"))
+
+
+actor rooted_at_a_container(t: testing.AsyncT):
+    """Rooted at a container: the container as it is; once its config, and
+    with it its oper, is gone, a read finds it empty."""
+    hub = Hub()
+    layer = probe_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_synced(owner: str):
+        if len(got) == 1 and got[0] == probe_spine(gdata.Container({q("enabled"): gdata.Leaf(True), q("status"): gdata.Leaf("up")})):
+            layer.edit_config(probe(False))
+        else:
+            fail(ValueError("synced after {rendered(got)}"))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if len(got) == 2:
+            if data == probe_spine(gdata.Container()):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected the probe empty, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("probe", status("up"))
+        after 0.05: layer.declare_subscriptions("rooted", on_update, {whole(root=gdata.FNode(q("probe")))}, on_synced)
+
+    layer.edit_config(probe(True), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor two_consumers_rooted_alike_each_get_every_entry(t: testing.AsyncT):
+    """A second consumer with the same rooted filter is served on its own:
+    every entry, then synced."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var second: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_first(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+
+    def first_synced(owner: str):
+        layer.declare_subscriptions("two", on_second, {whole(root=ROOTED_AT_SERVICE)}, second_synced)
+
+    def on_second(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        else:
+            second.append(data)
+
+    def second_synced(owner: str):
+        if not done:
+            done = True
+            if rendered(second) == rendered([tree([entry("svc-a", "a")]), tree([entry("svc-b", "b")])]):
+                t.success()
+            else:
+                t.failure(ValueError("the second consumer got {rendered(second)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("one", on_first, {whole(root=ROOTED_AT_SERVICE)}, first_synced)
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(second)} deliveries to the second consumer"))
+
+
+actor rooted_destination_reads_on_one_period(t: testing.AsyncT):
+    """A rooted consumer's filters fold into one read; a second period is
+    refused."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if not done:
+            done = True
+            if err is not None:
+                t.success()
+            else:
+                t.failure(ValueError("expected an error, got {prs(data)}"))
+
+    layer.declare_subscriptions("rooted", on_update, {
+        whole(root=ROOTED_AT_SERVICE),
+        gdata.SubscriptionSpec(entry_spec("svc-a").filt, period=0.05, root=ROOTED_AT_SERVICE),
+    })
+    after 2: on_update(None, None)
+
+
+def item(id: str, v: str) -> gdata.Node:
+    return gdata.Container({q("id"): gdata.Leaf(id), q("v"): gdata.Leaf(v)})
+
+def items(entries: list[gdata.Node]) -> gdata.Node:
+    return gdata.Container({q("items"): gdata.List([q("id")], entries)})
+
+def item_spine(i: gdata.Node) -> gdata.Node:
+    return probe_spine(items([i]))
+
+
+actor change_above_the_root_delivers_the_instances_that_differ(t: testing.AsyncT):
+    """A producer that holds several instances of the root's node delivers,
+    on a read, the instances that differ and those gone."""
+    hub = Hub()
+    layer = probe_layer(hub)
+    var got: list[?gdata.Node] = []
+    var stage = 0
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_synced(owner: str):
+        if rendered(got) == rendered([item_spine(item("one", "x")), item_spine(item("two", "y"))]):
+            stage = 1
+            got = []
+            hub.push("probe", items([item("one", "x2"), item("two", "y")]))
+        else:
+            fail(ValueError("synced after {rendered(got)}"))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if stage == 1 and len(got) == 1:
+            if data == item_spine(item("one", "x2")):
+                stage = 2
+                got = []
+                hub.push("probe", items([item("one", "x2")]))
+            else:
+                fail(ValueError("expected item one changed alone, got {prs(data)}"))
+        elif stage == 2 and len(got) == 1:
+            if data == item_spine(gdata.Absent({q("id"): gdata.Leaf("two")})):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected item two gone, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("probe", items([item("one", "x"), item("two", "y")]))
+        root = gdata.FNode(q("probe"), children=[gdata.FNode(q("items"))])
+        after 0.05: layer.declare_subscriptions("rooted", on_update, {whole(root=root)}, on_synced)
+
+    layer.edit_config(probe(True), None, declare)
+    after 2: fail(ValueError("timed out at stage {stage} with {rendered(got)}"))

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -476,27 +476,38 @@ def fold(want: set[gdata.SubscriptionSpec]) -> dict[u64, ?gdata.FNode]:
 
 class Read(object):
     """One read of a consumer's actor: a folded filter, read on its period,
-    and the latest tree it gave."""
+    and what it gave last: the tree, or rooted, the instances by key, each
+    with its spine."""
     filt: ?gdata.FNode
     latest: ?gdata.Node
+    held: dict[str, (gdata.Node, gdata.Node)]
     done: bool                  # has run at least once
     active: bool                # False once replaced or dropped, so its timer ends
 
     def __init__(self, filt: ?gdata.FNode):
         self.filt = filt
         self.latest = None
+        self.held = {}
         self.done = False
         self.active = True
 
 
-actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) -> None):
+actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) -> None, point: list[gdata.Id]):
     """One consumer's subscriptions, served outside the Layer actor.
 
     The consumer's filters fold into one read per period. Each read runs
     on its period, and every delivery is the reads' latest trees merged
     into one view, sent straight to the consumer. synced is called once per
-    declaration, when every read has run once. The reads and the waiting
-    happen here, never in the Layer actor that runs transactions.
+    declaration, when every read has run once.
+
+    Rooted at a point, a path of node names from the top, the consumer
+    gets the instances of that node instead of one view: after each read,
+    every instance that differs from the last read, as a tree from the top
+    down to that one instance, and every instance gone, as that tree with
+    an Absent holding its keys where the entry was.
+
+    The reads and the waiting happen here, never in the Layer actor that
+    runs transactions.
     """
     var reads: dict[u64, Read] = {}
     var cb = cb0
@@ -526,9 +537,11 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
                     old.active = False
             if replace:
                 fresh = Read(filt)
+                if old is not None:
+                    fresh.held = old.held       # so the next read reports only what changed
                 reads[period] = fresh
                 _read(fresh, period)
-        if dropped:
+        if dropped and len(point) == 0:
             _deliver(None)                      # the narrowed view
         owed = True
         _synced_if_done()
@@ -537,14 +550,31 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
         if active and r.active:
             try:
                 tree = node.get_data(r.filt)
-                if tree != r.latest:
+                if len(point) > 0:
+                    _read_rooted(r, tree)
+                elif tree != r.latest:
                     r.latest = tree
                     _deliver(None)
             except Exception as e:
-                _deliver(e)
+                if len(point) > 0:
+                    cb(None, e)
+                else:
+                    _deliver(e)
             r.done = True
             _synced_if_done()
             after _delay(period): _read(r, period)
+
+    def _read_rooted(r: Read, tree: ?gdata.Node):
+        """Deliver the instances that differ from the last read, and those gone."""
+        now: dict[str, (gdata.Node, gdata.Node)] = {}
+        for i in gdata.instances(tree, point):
+            now[i.0] = (i.1, i.2)
+            if i.0 not in r.held or r.held[i.0].1 != i.2:
+                cb(i.1, None)
+        for k, h in r.held.items():
+            if k not in now:
+                cb(gdata.gone(h.0, point), None)
+        r.held = now
 
     def _deliver(err: ?Exception):
         """The reads' latest trees as one view, by reference for one read."""
@@ -827,6 +857,7 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
     root = rootgen(PathRoot(name), lower)
     root.bind_db(db_arg)
     var subscribers: dict[str, Subscription] = {}
+    var roots: dict[str, ?gdata.FNode] = {}
 
     def load_from_db(done: action(?Exception) -> None, top_only=False) -> None:
         db = db_arg
@@ -857,21 +888,35 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
         """Replace one consumer's want set. A Subscription actor of the
         consumer's own serves it and calls `synced` with the owner id once
         every read of the declaration has run. A layer serves periodic
-        specs; a spec rooted at a node is not served yet."""
-        for spec in want:
-            if spec.period is None:
-                cb(None, ValueError("TTT layer TreeProvider only supports periodic subscriptions"))
-                return
-            if spec.root is not None:
-                cb(None, ValueError("a destination rooted at a node is not served by a TTT layer yet"))
-                return
+        specs. Specs rooted at a node share one root, and one period."""
+        point: list[gdata.Id] = []
+        root_of: ?gdata.FNode = None
+        first = True
+        try:
+            for spec in want:
+                if spec.period is None:
+                    raise ValueError("TTT layer TreeProvider only supports periodic subscriptions")
+                if first:
+                    root_of = spec.root
+                    first = False
+                elif root_of != spec.root:
+                    raise ValueError("a consumer's filters share one root")
+            point = gdata.root_names(root_of)
+            if len(point) > 0 and len(fold(want)) > 1:
+                raise ValueError("a rooted destination is read on one period")
+        except Exception as e:
+            cb(None, e)
+            return
         sub = subscribers.get(owner_id)
         if sub is not None:
-            sub.declare(want, cb, synced)
-        else:
-            fresh = Subscription(owner_id, root, cb)
-            subscribers[owner_id] = fresh
-            fresh.declare(want, cb, synced)
+            if roots[owner_id] == root_of:
+                sub.declare(want, cb, synced)
+                return
+            sub.stop()                              # a new root is a new actor
+        fresh = Subscription(owner_id, root, cb, point)
+        subscribers[owner_id] = fresh
+        roots[owner_id] = root_of
+        fresh.declare(want, cb, synced)
 
     def remove_subscriptions(owner_id: str):
         """Drop a consumer and stop its reads."""
@@ -879,6 +924,7 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
         if sub is not None:
             sub.stop()
             del subscribers[owner_id]
+            del roots[owner_id]
 
 
 actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?swdb.Store, dbuf_arg: ?swdb.Buffer=None):

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -465,17 +465,23 @@ class LayerSharedSubscription(object):
 
 
 class LayerSubscriptionOwner(object):
-    """One logical subscriber and its merged delivery state."""
+    """One logical subscriber and its merged delivery state. `synced` is
+    called with the owner id after its first delivery, once."""
     @property
-    cb: action(?gdata.Node, ?Exception) -> None
+    cb: proc(?gdata.Node, ?Exception) -> None
+    @property
+    synced: ?action(str) -> None
     want: set[gdata.SubscriptionSpec]
     last_merged: ?gdata.Node
+    synced_done: bool
 
-    def __init__(self, cb: action(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec], last_merged: ?gdata.Node=None):
+    def __init__(self, cb: proc(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec], last_merged: ?gdata.Node=None, synced: ?action(str) -> None=None, synced_done: bool=False):
         """Track the callback, desired specs, and last delivered tree."""
         self.cb = cb
+        self.synced = synced
         self.want = set(want)
         self.last_merged = last_merged
+        self.synced_done = synced_done
 
 def layer_subscription_delay(spec: gdata.SubscriptionSpec) -> float:
     """Return the actor delay, in seconds, for a normalized spec period."""
@@ -786,6 +792,11 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
             owner.last_merged = merged
             sub_owners[owner_id] = owner
             owner.cb(merged, err)
+            if not owner.synced_done:
+                owner.synced_done = True            # the first delivery is the first pass
+                s = owner.synced
+                if s is not None:
+                    s(owner_id)
 
     def _sub_cancel(spec: gdata.SubscriptionSpec):
         """Stop tracking a shared spec and invalidate already scheduled ticks."""
@@ -848,26 +859,33 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
         else:
             subs[spec] = st
 
-    def declare_subscriptions(owner_id: str, cb: action(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec]):
+    def declare_subscriptions(owner_id: str, cb: proc(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec], synced: ?action(str) -> None=None):
         """Replace one owner's desired subscription set.
 
         SubscriptionManager declarations are full-state declarations, not
         incremental updates. Specs removed from the desired set release this
         owner from the shared sampler; new specs attach the owner and start
-        sampling as needed.
+        sampling as needed. `synced` is called with the owner id after the
+        owner's first delivery. A spec rooted at a node is not served yet.
         """
+        for spec in want:
+            if spec.root is not None:
+                cb(None, ValueError("a destination rooted at a node is not served by a TTT layer yet"))
+                return
         old_want = set()
         last_merged = None
+        synced_done = False
         if owner_id in sub_owners:
             owner = sub_owners[owner_id]
             old_want = owner.want
             last_merged = owner.last_merged
+            synced_done = owner.synced_done
 
         for spec in old_want:
             if spec not in want:
                 _remove_owner_spec(owner_id, spec)
 
-        sub_owners[owner_id] = LayerSubscriptionOwner(cb, want, last_merged)
+        sub_owners[owner_id] = LayerSubscriptionOwner(cb, want, last_merged, synced, synced_done)
 
         for spec in want:
             if spec not in old_want:
@@ -1055,8 +1073,8 @@ class LayerTreeProvider(gdata.TreeProvider):
     proc def rpc(self, cb: action(?gdata.Node, ?Exception) -> None, gdata_rpc: gdata.Node):
         cb(None, ValueError("TTT layer TreeProvider does not support RPC"))
 
-    proc def declare_subscriptions(self, owner_id: str, cb: action(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec]):
-        self.layer.declare_subscriptions(owner_id, cb, want)
+    proc def declare_subscriptions(self, owner_id: str, cb: proc(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec], synced: ?action(str) -> None):
+        self.layer.declare_subscriptions(owner_id, cb, want, synced)
 
     proc def remove_subscriptions(self, owner_id: str):
         self.layer.remove_subscriptions(owner_id)

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -444,62 +444,134 @@ def exact_list_filter_branches(filters: list[gdata.FNode], key_names: list[gdata
             return None
     return branches
 
-class LayerSharedSubscription(object):
-    """Runtime state for one periodic layer subscription spec.
+##################### Subscriptions #####################
 
-    The same SubscriptionSpec can be declared by multiple owners. The layer
-    reads it once per period, stores the latest filtered tree here, and lets
-    each owner merge that result with any other specs it declared.
-    """
-    spec: gdata.SubscriptionSpec
+def _delay(period: u64) -> float:
+    return float(period) / 1000000000.0
+
+def fold(want: set[gdata.SubscriptionSpec]) -> dict[u64, ?gdata.FNode]:
+    """One filter per period: the union of the filters a consumer declared
+    with that period, so one read serves them all. A filter that names
+    nothing, or no filter, is everything."""
+    branches: dict[u64, list[gdata.FNode]] = {}
+    whole: set[u64] = set()
+    for spec in gdata.hack_sorted(iter(want)):           # a canonical union, whatever the set order
+        period = spec.period
+        if period is not None:
+            if period not in branches:
+                branches[period] = []
+            f = root_filter(spec.filt)
+            if f is not None and len(f.children) > 0:
+                branches[period].extend(f.children)
+            else:
+                whole.add(period)
+    folded: dict[u64, ?gdata.FNode] = {}
+    for period, bs in branches.items():
+        if period in whole:
+            folded[period] = None
+        else:
+            folded[period] = gdata.FNode(children=gdata.filter_merge_list(bs))
+    return folded
+
+
+class Read(object):
+    """One read of a consumer's actor: a folded filter, read on its period,
+    and the latest tree it gave."""
+    filt: ?gdata.FNode
     latest: ?gdata.Node
-    owners: set[str]
-    active: bool
+    done: bool                  # has run at least once
+    active: bool                # False once replaced or dropped, so its timer ends
 
-    def __init__(self, spec: gdata.SubscriptionSpec):
-        """Copy the public spec into provider-owned mutable state."""
-        self.spec = gdata.SubscriptionSpec(spec.filt, period=spec.period)
+    def __init__(self, filt: ?gdata.FNode):
+        self.filt = filt
         self.latest = None
-        self.owners = set()
+        self.done = False
         self.active = True
 
 
-class LayerSubscriptionOwner(object):
-    """One logical subscriber and its merged delivery state. `synced` is
-    called with the owner id after its first delivery, once."""
-    @property
-    cb: proc(?gdata.Node, ?Exception) -> None
-    @property
-    synced: ?action(str) -> None
-    want: set[gdata.SubscriptionSpec]
-    last_merged: ?gdata.Node
-    synced_done: bool
+actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) -> None):
+    """One consumer's subscriptions, served outside the Layer actor.
 
-    def __init__(self, cb: proc(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec], last_merged: ?gdata.Node=None, synced: ?action(str) -> None=None, synced_done: bool=False):
-        """Track the callback, desired specs, and last delivered tree."""
-        self.cb = cb
-        self.synced = synced
-        self.want = set(want)
-        self.last_merged = last_merged
-        self.synced_done = synced_done
+    The consumer's filters fold into one read per period. Each read runs
+    on its period, and every delivery is the reads' latest trees merged
+    into one view, sent straight to the consumer. synced is called once per
+    declaration, when every read has run once. The reads and the waiting
+    happen here, never in the Layer actor that runs transactions.
+    """
+    var reads: dict[u64, Read] = {}
+    var cb = cb0
+    var synced: ?action(str) -> None = None
+    var owed = False                            # a synced for the current declaration
+    var active = True
 
-def layer_subscription_delay(spec: gdata.SubscriptionSpec) -> float:
-    """Return the actor delay, in seconds, for a normalized spec period."""
-    pn = spec.period
-    if pn is not None:
-        return float(pn) / 1000000000.0
-    return float(1)
+    def declare(want: set[gdata.SubscriptionSpec], cb1: proc(?gdata.Node, ?Exception) -> None, synced1: ?action(str) -> None):
+        """Replace the want set: reads no longer wanted stop, changed ones
+        start over, unchanged ones keep their latest tree."""
+        cb = cb1
+        synced = synced1
+        folded = fold(want)
+        dropped = False
+        for period in list(reads.keys()):
+            if period not in folded:
+                reads[period].active = False
+                del reads[period]
+                dropped = True
+        for period, filt in folded.items():
+            replace = True
+            old = reads.get(period)
+            if old is not None:
+                if old.filt == filt:
+                    replace = False
+                else:
+                    old.active = False
+            if replace:
+                fresh = Read(filt)
+                reads[period] = fresh
+                _read(fresh, period)
+        if dropped:
+            _deliver(None)                      # the narrowed view
+        owed = True
+        _synced_if_done()
 
-def merge_subscription_tree(want: set[gdata.SubscriptionSpec], subs: dict[gdata.SubscriptionSpec, LayerSharedSubscription]) -> ?gdata.Node:
-    """Merge latest samples for all specs owned by one subscriber."""
-    merged = None
-    for spec in gdata.hack_sorted(iter(want)):
-        if spec in subs:
-            sub = subs[spec]
-            if sub.latest is not None:
-                base = merged if merged is not None else gdata.Container({})
-                merged = gdata.patch(base, sub.latest)
-    return merged
+    def _read(r: Read, period: u64):
+        if active and r.active:
+            try:
+                tree = node.get_data(r.filt)
+                if tree != r.latest:
+                    r.latest = tree
+                    _deliver(None)
+            except Exception as e:
+                _deliver(e)
+            r.done = True
+            _synced_if_done()
+            after _delay(period): _read(r, period)
+
+    def _deliver(err: ?Exception):
+        """The reads' latest trees as one view, by reference for one read."""
+        merged: ?gdata.Node = None
+        for period in sorted(reads.keys()):
+            t = reads[period].latest
+            if t is not None:
+                m = merged
+                if m is not None:
+                    merged = gdata.patch(m, t)
+                else:
+                    merged = t
+        cb(merged, err)
+
+    def _synced_if_done():
+        if owed:
+            for r in reads.values():
+                if not r.done:
+                    return
+            owed = False
+            s = synced
+            if s is not None:
+                s(owner)
+
+    def stop():
+        active = False
+
 
 def _db_path(path: Path) -> list[value]:
     if isinstance(path, PathElem):
@@ -754,8 +826,7 @@ actor LayerRestore(
 actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg: ?swdb.Store=None):
     root = rootgen(PathRoot(name), lower)
     root.bind_db(db_arg)
-    var subs: dict[gdata.SubscriptionSpec, LayerSharedSubscription] = {}
-    var sub_owners: dict[str, LayerSubscriptionOwner] = {}
+    var subscribers: dict[str, Subscription] = {}
 
     def load_from_db(done: action(?Exception) -> None, top_only=False) -> None:
         db = db_arg
@@ -782,125 +853,32 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
     def tree_provider() -> gdata.TreeProvider:
         return LayerTreeProvider(self)
 
-    def _owner_publish(owner_id: str, err: ?Exception=None):
-        """Deliver an owner's merged tree when it changed or an error occurred."""
-        if owner_id not in sub_owners:
-            return
-        owner = sub_owners[owner_id]
-        merged = merge_subscription_tree(owner.want, subs)
-        if err is not None or merged != owner.last_merged:
-            owner.last_merged = merged
-            sub_owners[owner_id] = owner
-            owner.cb(merged, err)
-            if not owner.synced_done:
-                owner.synced_done = True            # the first delivery is the first pass
-                s = owner.synced
-                if s is not None:
-                    s(owner_id)
-
-    def _sub_cancel(spec: gdata.SubscriptionSpec):
-        """Stop tracking a shared spec and invalidate already scheduled ticks."""
-        if spec in subs:
-            subs[spec].active = False
-            del subs[spec]
-
-    def _sub_schedule_next(spec: gdata.SubscriptionSpec):
-        """Schedule the next sample for an active shared subscription."""
-        if spec not in subs:
-            return
-        st = subs[spec]
-        if not st.active:
-            return
-        after layer_subscription_delay(st.spec): _sub_tick(spec)
-
-    def _sub_tick(spec: gdata.SubscriptionSpec):
-        """Sample one shared spec and publish the result to interested owners."""
-        if spec not in subs:
-            return
-        st = subs[spec]
-        if not st.active:
-            return
-        if st.spec.period is None:
-            err = ValueError("TTT layer TreeProvider only supports periodic subscriptions")
-            for owner_id in st.owners:
-                _owner_publish(owner_id, err)
-            _sub_cancel(spec)
-            return
-
-        try:
-            st.latest = get_data(st.spec.filt)
-            subs[spec] = st
-            for owner_id in st.owners:
-                _owner_publish(owner_id)
-        except Exception as e:
-            for owner_id in st.owners:
-                _owner_publish(owner_id, e)
-        _sub_schedule_next(spec)
-
-    def _add_owner_spec(owner_id: str, spec: gdata.SubscriptionSpec):
-        """Attach an owner to a shared spec, creating and starting it if needed."""
-        if spec in subs:
-            st = subs[spec]
-        else:
-            st = LayerSharedSubscription(spec)
-        st.owners.add(owner_id)
-        subs[spec] = st
-        if st.latest is None and len(st.owners) == 1:
-            _sub_tick(spec)
-
-    def _remove_owner_spec(owner_id: str, spec: gdata.SubscriptionSpec):
-        """Detach an owner from a shared spec and cancel unused sampling."""
-        if spec not in subs:
-            return
-        st = subs[spec]
-        st.owners.discard(owner_id)
-        if len(st.owners) == 0:
-            _sub_cancel(spec)
-        else:
-            subs[spec] = st
-
     def declare_subscriptions(owner_id: str, cb: proc(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec], synced: ?action(str) -> None=None):
-        """Replace one owner's desired subscription set.
-
-        SubscriptionManager declarations are full-state declarations, not
-        incremental updates. Specs removed from the desired set release this
-        owner from the shared sampler; new specs attach the owner and start
-        sampling as needed. `synced` is called with the owner id after the
-        owner's first delivery. A spec rooted at a node is not served yet.
-        """
+        """Replace one consumer's want set. A Subscription actor of the
+        consumer's own serves it and calls `synced` with the owner id once
+        every read of the declaration has run. A layer serves periodic
+        specs; a spec rooted at a node is not served yet."""
         for spec in want:
+            if spec.period is None:
+                cb(None, ValueError("TTT layer TreeProvider only supports periodic subscriptions"))
+                return
             if spec.root is not None:
                 cb(None, ValueError("a destination rooted at a node is not served by a TTT layer yet"))
                 return
-        old_want = set()
-        last_merged = None
-        synced_done = False
-        if owner_id in sub_owners:
-            owner = sub_owners[owner_id]
-            old_want = owner.want
-            last_merged = owner.last_merged
-            synced_done = owner.synced_done
-
-        for spec in old_want:
-            if spec not in want:
-                _remove_owner_spec(owner_id, spec)
-
-        sub_owners[owner_id] = LayerSubscriptionOwner(cb, want, last_merged, synced, synced_done)
-
-        for spec in want:
-            if spec not in old_want:
-                _add_owner_spec(owner_id, spec)
-
-        _owner_publish(owner_id)
+        sub = subscribers.get(owner_id)
+        if sub is not None:
+            sub.declare(want, cb, synced)
+        else:
+            fresh = Subscription(owner_id, root, cb)
+            subscribers[owner_id] = fresh
+            fresh.declare(want, cb, synced)
 
     def remove_subscriptions(owner_id: str):
-        """Remove an owner and release every shared spec it referenced."""
-        if owner_id not in sub_owners:
-            return
-        old_want = sub_owners[owner_id].want
-        del sub_owners[owner_id]
-        for spec in old_want:
-            _remove_owner_spec(owner_id, spec)
+        """Drop a consumer and stop its reads."""
+        sub = subscribers.get(owner_id)
+        if sub is not None:
+            sub.stop()
+            del subscribers[owner_id]
 
 
 actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?swdb.Store, dbuf_arg: ?swdb.Buffer=None):


### PR DESCRIPTION
Until now a subscriber always got the whole tree it subscribed to, rooted at the top. This adds instance delivery: a subscription rooted at a node, where the subscriber gets one instance of that node per call. When one device out of a hundred thousand changes, the subscriber is called with that one device, not the whole tree. acton-yang PR #496 added the API for this. This PR takes it in and makes the TTT layer serve it.

The layer now serves every subscriber from an actor of its own, outside the Layer actor. That actor reads the subscribed data on the subscriber's period, keeps the latest result, and hands it straight to the subscriber. A top-rooted subscription gets the merged tree as before. An instance-rooted subscription gets one instance at a time. When the first round of reads is done, the actor tells the subscriber it is in sync. A device answers an instance-rooted subscription with an error; only a layer serves them.

The minisys router uses an instance-rooted subscription for its device state.
