### PR TITLE
Share SSH options across device models

### DIFF
--- a/docs/developer/system-spec.md
+++ b/docs/developer/system-spec.md
@@ -50,7 +50,8 @@ cfs_layer.models.extend([
 inter_layer = stratoweave.build.Layer.from_dir(fc, "yang/inter")
 inter_layer.models.extend([swyang.stratoweave, swyang.ietf_inet_types])
 rfs_layer = stratoweave.build.Layer.from_dir(fc, "yang/rfs")
-rfs_layer.models.extend([swyang.stratoweave, swyang.rfs, swyang.ietf_inet_types])
+rfs_layer.models.extend([swyang.stratoweave, swyang.rfs, swyang.ssh,
+                         swyang.ietf_inet_types, swyang.ietf_yang_types])
 ```
 
 Each of these layers is built from a directory of YANG models, which define
@@ -62,6 +63,9 @@ modules that are shipped with StratoWeave:
 * `swyang.ietf_inet_types` includes common IETF-defined types.
 * `swyang.rfs` includes the StratoWeave-specific RFS schema, that is used in
  the RFS layer.
+* `swyang.ssh` provides reusable SSH client types and the `ssh-client-config`
+ grouping used by the RFS device model and application inventory models.
+* `swyang.ietf_yang_types` supplies the date and time types used by RFS.
 * `tmf.yang.ietf_yang_tmf_map` includes the TMF mapping schema, which is used
  to annotate YANG with TMF Service/Resource mapping instructions.
 * `tmf.yang.swtmf` and `tmf.yang.swtmf640` include the TMF640 store transform

--- a/docs/operations/devices.md
+++ b/docs/operations/devices.md
@@ -139,6 +139,22 @@ its transport settings from the device's `ssh` container. Leave it out and the
 SSH library's defaults apply; set it to deal with devices that need something
 narrower or older.
 
+To expose these settings in another model, import `stratoweave-ssh` and use
+its `ssh-client-config` grouping inside an `ssh` container:
+
+```yang
+import stratoweave-ssh {
+  prefix sw-ssh;
+}
+
+container ssh {
+  uses sw-ssh:ssh-client-config;
+}
+```
+
+Include `swyang.ssh` in the layer's models when generating the application,
+and copy the settings to `dev.ssh` in its transform.
+
 ```acton title="src/sorespo/cfs.act"
 dev.ssh.cipher = ["aes128-ctr"]
 dev.ssh.key_exchange = ["diffie-hellman-group14-sha256"]

--- a/fleetmgr/Build.act
+++ b/fleetmgr/Build.act
@@ -11,8 +11,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/c00115cd07db0ee062c85090d4c85f32ef805baa.zip",
-        hash="N-V-__8AACP5JgBjkphmkpC0_Doep_M_Ji8P-z3_5_exsKvl"
+        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
+        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
     )
 }
 zig_dependencies = {}

--- a/fleetmgr/README.md
+++ b/fleetmgr/README.md
@@ -19,8 +19,8 @@ an IOS XE device.
         -> fleetmgr CFS /software/upgrade-campaign/state
 
 There is no range expansion. A flotilla assigned 500 devices receives 500
-complete `/device` entries, including addresses, credentials, policy, mock and
-debug settings, feature flags, and software intent.
+complete `/device` entries, including addresses, credentials, SSH options, policy,
+mock and debug settings, feature flags, and software intent.
 
 ## Build and regenerate
 
@@ -86,6 +86,12 @@ The `fleetmgr` CFS has two inventory lists:
 - `/fleet/device`: complete device configuration plus a string `shard` and an
   explicit device `type`. Its
   transform writes the entry under `/rfs{shard}/device`.
+
+Both lists expose an `ssh` container using the shared
+`stratoweave-ssh:ssh-client-config` grouping. Set SSH client options under
+`/fleet/device/ssh` to pass them through to the device's owning flotilla, or
+under `/fleet/node/ssh` to configure the top's connection to that flotilla.
+Algorithm preference order is preserved through both transforms.
 
 The generic `software` model remains separate from inventory. Each campaign
 device list entry links its name to the referenced `/fleet/device` entry,

--- a/fleetmgr/spec/Build.act
+++ b/fleetmgr/spec/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/c00115cd07db0ee062c85090d4c85f32ef805baa.zip",
-        hash="N-V-__8AACP5JgBjkphmkpC0_Doep_M_Ji8P-z3_5_exsKvl"
+        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
+        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
     )
 }
 zig_dependencies = {}

--- a/fleetmgr/spec/src/gen.act
+++ b/fleetmgr/spec/src/gen.act
@@ -11,19 +11,19 @@ actor main(env):
     common = file.ReadFile(rfc, "yang/common/fleetmgr-types.yang").read().decode()
 
     cfs_layer = swbuild.Layer.from_dir(fc, "yang/cfs")
-    cfs_layer.models.extend([common, swyang.stratoweave, swyang.ietf_inet_types])
+    cfs_layer.models.extend([common, swyang.stratoweave, swyang.ssh, swyang.ietf_inet_types])
     rfs_layer = swbuild.Layer.from_dir(fc, "yang/rfs")
-    rfs_layer.models.extend([common, swyang.stratoweave, swyang.rfs, swyang.ietf_inet_types, swyang.ietf_yang_types])
+    rfs_layer.models.extend([common, swyang.stratoweave, swyang.rfs, swyang.ssh, swyang.ietf_inet_types, swyang.ietf_yang_types])
 
     fleetmgr = swbuild.SysSpec("fleetmgr", [
         cfs_layer,
         rfs_layer,
     ], [
-        swbuild.DeviceType("flotilla", models=[swyang.stratoweave, swyang.rfs, swyang.ietf_inet_types, swyang.ietf_yang_types])
+        swbuild.DeviceType("flotilla", models=[swyang.stratoweave, swyang.rfs, swyang.ssh, swyang.ietf_inet_types, swyang.ietf_yang_types])
     ])
 
     flotilla_rfs = swbuild.Layer([])
-    flotilla_rfs.models.extend([swyang.stratoweave, swyang.rfs, swyang.ietf_inet_types, swyang.ietf_yang_types])
+    flotilla_rfs.models.extend([swyang.stratoweave, swyang.rfs, swyang.ssh, swyang.ietf_inet_types, swyang.ietf_yang_types])
     iosxe = swbuild.DeviceType.from_dir(fc, "iosxe", "yang/dev-cpe")
     iosxe.models.extend(swxe_yang.models)
 

--- a/fleetmgr/spec/yang/common/fleetmgr-types.yang
+++ b/fleetmgr/spec/yang/common/fleetmgr-types.yang
@@ -6,6 +6,9 @@ module fleetmgr-types {
   import ietf-inet-types {
     prefix inet;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
 
   grouping device-options {
     leaf description {
@@ -69,6 +72,13 @@ module fleetmgr-types {
       leaf key {
         type string;
       }
+    }
+
+    container ssh {
+      description
+        "SSH transport parameters used when connecting to this device. Applies
+         to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {

--- a/fleetmgr/src/fleetmgr/cfs.act
+++ b/fleetmgr/src/fleetmgr/cfs.act
@@ -43,6 +43,17 @@ class Node(base.Node):
                 key=credentials.key,
             ))
 
+        dev.ssh.cipher = i.ssh.cipher
+        dev.ssh.mac = i.ssh.mac
+        dev.ssh.key_exchange = i.ssh.key_exchange
+        dev.ssh.host_key_algorithm = i.ssh.host_key_algorithm
+        dev.ssh.public_key_algorithm = i.ssh.public_key_algorithm
+        dev.ssh.compression_algorithm = i.ssh.compression_algorithm
+        dev.ssh.compression_level = i.ssh.compression_level
+        dev.ssh.rekey_after_bytes = i.ssh.rekey_after_bytes
+        dev.ssh.rekey_after_seconds = i.ssh.rekey_after_seconds
+        dev.ssh.minimum_rsa_bits = i.ssh.minimum_rsa_bits
+
         dev.mock.enabled = i.mock.enabled
         for module in i.mock.module:
             out_module = dev.mock.module.create(
@@ -94,6 +105,17 @@ class Device(base.Device):
                 password=credentials.password,
                 key=credentials.key,
             ))
+
+        dev.ssh.cipher = i.ssh.cipher
+        dev.ssh.mac = i.ssh.mac
+        dev.ssh.key_exchange = i.ssh.key_exchange
+        dev.ssh.host_key_algorithm = i.ssh.host_key_algorithm
+        dev.ssh.public_key_algorithm = i.ssh.public_key_algorithm
+        dev.ssh.compression_algorithm = i.ssh.compression_algorithm
+        dev.ssh.compression_level = i.ssh.compression_level
+        dev.ssh.rekey_after_bytes = i.ssh.rekey_after_bytes
+        dev.ssh.rekey_after_seconds = i.ssh.rekey_after_seconds
+        dev.ssh.minimum_rsa_bits = i.ssh.minimum_rsa_bits
 
         dev.mock.enabled = i.mock.enabled
         for module in i.mock.module:

--- a/fleetmgr/src/fleetmgr/devices/flotilla.act
+++ b/fleetmgr/src/fleetmgr/devices/flotilla.act
@@ -24,6 +24,7 @@ pure def src_yang() -> list[str]:
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 
@@ -53,7 +54,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -61,7 +62,7 @@ class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -108,7 +109,7 @@ class stratoweave_rfs__device__address_entry(yadata.MNode):
 _breaker4: None = None
 class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         e = self.get(key)
@@ -120,7 +121,7 @@ class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__d
             return e
         name = key
         res = stratoweave_rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -163,7 +164,7 @@ class stratoweave_rfs__device__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -173,7 +174,7 @@ class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratowea
             return e
         key = key_
         res = stratoweave_rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -243,7 +244,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -251,7 +252,7 @@ class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -337,7 +338,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
 _breaker12: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         e = self.get(key)
@@ -349,7 +350,7 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -457,7 +458,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
 _breaker17: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__device__software__veto_entry:
         e = self.get(key)
@@ -467,7 +468,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
             return e
         holder = key
         res = stratoweave_rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -559,7 +560,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
 _breaker20: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         e = self.get(key)
@@ -573,7 +574,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
             return e
         name = key
         res = stratoweave_rfs__device_entry(name=name, description=description, type=type, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -614,7 +615,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
 _breaker22: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> stratoweave_rfs__rfs_entry:
         e = self.get(key)
@@ -622,7 +623,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
             return e
         name = key
         res = stratoweave_rfs__rfs_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/fleetmgr/devices/flotilla_oper.act
+++ b/fleetmgr/src/fleetmgr/devices/flotilla_oper.act
@@ -60,12 +60,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -144,7 +144,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_20],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module stratoweave {
@@ -218,6 +218,9 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -226,211 +229,6 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -524,7 +322,7 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -719,7 +517,220 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_2: str = r"""module ietf-inet-types {
+SRC_YANG_2: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_3: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1179,7 +1190,7 @@ SRC_YANG_2: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-yang-types {
+SRC_YANG_4: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -1951,11 +1962,13 @@ pure def src_yang() -> list[str]:
         SRC_YANG_1,
         SRC_YANG_2,
         SRC_YANG_3,
+        SRC_YANG_4,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 
@@ -1985,7 +1998,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1993,7 +2006,7 @@ class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2040,7 +2053,7 @@ class stratoweave_rfs__device__address_entry(yadata.MNode):
 _breaker4: None = None
 class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         e = self.get(key)
@@ -2052,7 +2065,7 @@ class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__d
             return e
         name = key
         res = stratoweave_rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2095,7 +2108,7 @@ class stratoweave_rfs__device__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -2105,7 +2118,7 @@ class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratowea
             return e
         key = key_
         res = stratoweave_rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2175,7 +2188,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -2183,7 +2196,7 @@ class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2269,7 +2282,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
 _breaker12: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         e = self.get(key)
@@ -2281,7 +2294,7 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2389,7 +2402,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
 _breaker17: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__device__software__veto_entry:
         e = self.get(key)
@@ -2399,7 +2412,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
             return e
         holder = key
         res = stratoweave_rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2450,7 +2463,7 @@ class stratoweave_rfs__device__software__state__job_entry(yadata.MNode):
 _breaker19: None = None
 class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, stratoweave_rfs__device__software__state__job_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__state__job_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, state: ?str=None, started: ?str=None, ended: ?str=None, progress: ?u64=None, message: ?str=None) -> stratoweave_rfs__device__software__state__job_entry:
         e = self.get(key)
@@ -2468,7 +2481,7 @@ class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, strat
             return e
         name = key
         res = stratoweave_rfs__device__software__state__job_entry(name=name, state=state, started=started, ended=ended, progress=progress, message=message)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2663,7 +2676,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
 _breaker26: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         e = self.get(key)
@@ -2677,7 +2690,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
             return e
         name = key
         res = stratoweave_rfs__device_entry(name=name, description=description, type=type, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2718,7 +2731,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
 _breaker28: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> stratoweave_rfs__rfs_entry:
         e = self.get(key)
@@ -2726,7 +2739,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
             return e
         name = key
         res = stratoweave_rfs__rfs_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/fleetmgr/devices/flotilla_schema.act
+++ b/fleetmgr/src/fleetmgr/devices/flotilla_schema.act
@@ -52,12 +52,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -107,7 +107,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_13],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module stratoweave {
@@ -181,6 +181,9 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -189,211 +192,6 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -487,7 +285,7 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -682,7 +480,220 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_2: str = r"""module ietf-inet-types {
+SRC_YANG_2: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_3: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1142,7 +1153,7 @@ SRC_YANG_2: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-yang-types {
+SRC_YANG_4: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -1914,5 +1925,6 @@ pure def src_yang() -> list[str]:
         SRC_YANG_1,
         SRC_YANG_2,
         SRC_YANG_3,
+        SRC_YANG_4,
     ]
 

--- a/fleetmgr/src/fleetmgr/layers/y_0.act
+++ b/fleetmgr/src/fleetmgr/layers/y_0.act
@@ -56,9 +56,22 @@ SRC_DNODE_CHILD_6: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:flee
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_7: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_7: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='minimum-rsa-bits', config=True, description='Reject RSA host and public keys shorter than this.', default='1024', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1024, 2147483647)])))
+])
 
-SRC_DNODE_CHILD_8: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
+SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_9: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -68,27 +81,27 @@ SRC_DNODE_CHILD_8: DContainer = DContainer(module='fleetmgr', namespace='urn:fle
     ])
 ])
 
-SRC_DNODE_CHILD_9: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
+SRC_DNODE_CHILD_10: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='connection', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_10: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
+SRC_DNODE_CHILD_11: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='runtime-schema-fetch', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
 SRC_DNODE_CHILD_1: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='node', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
         DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='transform', arg='fleetmgr.cfs.Node', exts=[])
-    ], children=[SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10])
+    ], children=[SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10, SRC_DNODE_CHILD_11])
 
-SRC_DNODE_CHILD_12: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_13: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_13: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='type', config=True, description='Device platform type understood by the owning flotilla.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_14: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='type', config=True, description='Device platform type understood by the owning flotilla.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_14: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='shard', config=True, description='Name of the flotilla node that owns this device.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_15: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='shard', config=True, description='Name of the flotilla node that owns this device.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_15: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='description', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_16: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='description', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_16: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='address', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
+SRC_DNODE_CHILD_17: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='address', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, description="Name of address, e.g. 'loopback' or 'OOB'", mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='address', config=True, mandatory=True, type=DTypeUnion(name='inet:host', description='The host type represents either an IP address or a DNS\ndomain name.', reference=None, exts=[], builtin_type='union', default=None, types=[DTypeString(name='inet:ipv4-address', description='The ipv4-address type represents an IPv4 address in\ndotted-quad notation.  The IPv4 address may include a zone\nindex, separated by a % sign.\n\nThe zone index is used to disambiguate identical address\nvalues.  For link-local addresses, the zone index will\ntypically be the interface index number or the name of an\ninterface.  If the zone index is not present, the default\nzone of the device will be used.\n\nThe canonical format for the zone index is the numerical\nformat', reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False)]), DTypeString(name='inet:ipv6-address', description='The ipv6-address type represents an IPv6 address in full,\nmixed, shortened, and shortened-mixed notation.  The IPv6\naddress may include a zone index, separated by a % sign.\n\nThe zone index is used to disambiguate identical address\nvalues.  For link-local addresses, the zone index will\ntypically be the interface index number or the name of an\ninterface.  If the zone index is not present, the default\nzone of the device will be used.\n\nThe canonical format of IPv6 addresses uses the textual\nrepresentation defined in Section 4 of RFC 5952.  The\ncanonical format for the zone index is the numerical\nformat as described in Section 11.2 of RFC 4007.', reference='RFC 4291: IP Version 6 Addressing Architecture\nRFC 4007: IPv6 Scoped Address Architecture\nRFC 5952: A Recommendation for IPv6 Address Text\n          Representation', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?', pcre='^(((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='(([^:]+:){{6}}(([^:]+:[^:]+)|(.*\\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?', pcre='^((([^\\:]+:){{6}}(([^\\:]+:[^\\:]+)|(.*\\..*)))|((([^\\:]+:)*[^\\:]+)?::(([^\\:]+:)*[^\\:]+)?)(%.+)?)$', invert=False)]), DTypeString(name='inet:domain-name', description='The domain-name type represents a DNS domain name.  The\nname SHOULD be fully qualified whenever possible.\n\nInternet domain names are only loosely specified.  Section\n3.5 of RFC 1034 recommends a syntax (modified in Section\n2.1 of RFC 1123).  The pattern above is intended to allow\nfor current practice in domain name use, and some possible\nfuture expansion.  It is designed to hold various types of\ndomain names, including names used for A or AAAA records\n(host names) and other records, such as SRV records.  Note\nthat Internet host names have a stricter syntax (described\nin RFC 952) than the DNS recommendations in RFCs 1034 and\n1123, and that systems that want to store host names in\nschema nodes using the domain-name type are recommended to\nadhere to this stricter standard to ensure interoperability.\n\nThe encoding of DNS names in the DNS protocol is limited\nto 255 characters.  Since the encoding consists of labels\nprefixed by a length bytes and there is a trailing NULL\nbyte, only 253 characters can appear in the textual dotted\nnotation.\n\nThe description clause of schema nodes using the domain-name\ntype MUST describe when and how these names are resolved to\nIP addresses.  Note that the resolution of a domain-name value\nmay require to query multiple DNS records (e.g., A for IPv4\nand AAAA for IPv6).  The order of the resolution process and\nwhich DNS record takes precedence can either be defined\nexplicitly or may depend on the configuration of the\nresolver.\n\nDomain-name values use the US-ASCII encoding.  Their canonical\nformat uses lowercase US-ASCII characters.  Internationalized\ndomain names MUST be A-labels as per RFC 5890.', reference='RFC  952: DoD Internet Host Table Specification\nRFC 1034: Domain Names - Concepts and Facilities\nRFC 1123: Requirements for Internet Hosts -- Application\n          and Support\nRFC 2782: A DNS RR for specifying the location of services\n          (DNS SRV)\nRFC 5890: Internationalized Domain Names in Applications\n          (IDNA): Definitions and Document Framework', exts=[], builtin_type='string', default=None, length=Ranges([(1, 253)]), patterns=[YangPattern(yang_regex='((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.', pcre='^(((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.)$', invert=False)])])),
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='port', config=True, mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)]))),
@@ -103,7 +116,7 @@ SRC_DNODE_CHILD_16: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fle
     ])
 ])
 
-SRC_DNODE_CHILD_17: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='credentials', config=True, presence=False, children=[
+SRC_DNODE_CHILD_18: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='credentials', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='username', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='password', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key', key=['key'], config=True, min_elements=0, ordered_by='system', children=[
@@ -112,7 +125,7 @@ SRC_DNODE_CHILD_17: DContainer = DContainer(module='fleetmgr', namespace='urn:fl
     ])
 ])
 
-SRC_DNODE_CHILD_18: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='initial-credentials', key=[
+SRC_DNODE_CHILD_19: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='initial-credentials', key=[
 'username',
 'password',
 'key'
@@ -122,9 +135,22 @@ SRC_DNODE_CHILD_18: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fle
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_19: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_20: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='minimum-rsa-bits', config=True, description='Reject RSA host and public keys shorter than this.', default='1024', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1024, 2147483647)])))
+])
 
-SRC_DNODE_CHILD_20: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
+SRC_DNODE_CHILD_21: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_22: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -134,21 +160,21 @@ SRC_DNODE_CHILD_20: DContainer = DContainer(module='fleetmgr', namespace='urn:fl
     ])
 ])
 
-SRC_DNODE_CHILD_21: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
+SRC_DNODE_CHILD_23: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='connection', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_22: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
+SRC_DNODE_CHILD_24: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='runtime-schema-fetch', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_11: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
+SRC_DNODE_CHILD_12: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
         DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='transform', arg='fleetmgr.cfs.Device', exts=[])
-    ], children=[SRC_DNODE_CHILD_12, SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16, SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22])
+    ], children=[SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16, SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24])
 
-SRC_DNODE_CHILD_0: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='fleet', config=True, presence=False, children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_11])
+SRC_DNODE_CHILD_0: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='fleet', config=True, presence=False, children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_12])
 
-SRC_DNODE_CHILD_23: DContainer = DContainer(module='software', namespace='urn:fleetmgr:software', prefix='sw-cfs', name='software', config=True, presence=False, children=[
+SRC_DNODE_CHILD_25: DContainer = DContainer(module='software', namespace='urn:fleetmgr:software', prefix='sw-cfs', name='software', config=True, presence=False, children=[
     DList(module='software', namespace='urn:fleetmgr:software', prefix='sw-cfs', name='upgrade-campaign', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
             DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='transform', arg='fleetmgr.cfs.UpgradeCampaign', exts=[])
         ], children=[
@@ -166,10 +192,10 @@ SRC_DNODE_CHILD_23: DContainer = DContainer(module='software', namespace='urn:fl
 ])
 
 SRC_DNODE: DRoot = DRoot(
-    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_23],
+    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_25],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:fleetmgr':('fleetmgr', None), 'urn:fleetmgr:software':('software', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:fleetmgr':('fleetmgr', None), 'urn:fleetmgr:software':('software', None)},
 )
 
 SRC_YANG_0: str = r"""module fleetmgr {
@@ -319,6 +345,9 @@ SRC_YANG_2: str = r"""module fleetmgr-types {
   import ietf-inet-types {
     prefix inet;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
 
   grouping device-options {
     leaf description {
@@ -382,6 +411,13 @@ SRC_YANG_2: str = r"""module fleetmgr-types {
       leaf key {
         type string;
       }
+    }
+
+    container ssh {
+      description
+        "SSH transport parameters used when connecting to this device. Applies
+         to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -520,7 +556,220 @@ SRC_YANG_3: str = r"""module stratoweave {
   }
 }"""
 
-SRC_YANG_4: str = r"""module ietf-inet-types {
+SRC_YANG_4: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_5: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -987,10 +1236,12 @@ pure def src_yang() -> list[str]:
         SRC_YANG_2,
         SRC_YANG_3,
         SRC_YANG_4,
+        SRC_YANG_5,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_fleetmgr: str = 'urn:fleetmgr:fleetmgr'
 NS_software: str = 'urn:fleetmgr:software'
 NS_fleetmgr_types: str = 'urn:fleetmgr:types'
@@ -1022,7 +1273,7 @@ class fleetmgr__fleet__node__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class fleetmgr__fleet__node__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__node__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__node__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1030,7 +1281,7 @@ class fleetmgr__fleet__node__address__initial_credentials(yadata.MKeyedList[(use
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__node__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1077,7 +1328,7 @@ class fleetmgr__fleet__node__address_entry(yadata.MNode):
 _breaker4: None = None
 class fleetmgr__fleet__node__address(yadata.MKeyedList[str, fleetmgr__fleet__node__address_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: str, port: ?u64=None) -> fleetmgr__fleet__node__address_entry:
         e = self.get(key)
@@ -1088,7 +1339,7 @@ class fleetmgr__fleet__node__address(yadata.MKeyedList[str, fleetmgr__fleet__nod
             return e
         name = key
         res = fleetmgr__fleet__node__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1131,7 +1382,7 @@ class fleetmgr__fleet__node__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class fleetmgr__fleet__node__credentials__key(yadata.MKeyedList[str, fleetmgr__fleet__node__credentials__key_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> fleetmgr__fleet__node__credentials__key_entry:
         e = self.get(key_)
@@ -1141,7 +1392,7 @@ class fleetmgr__fleet__node__credentials__key(yadata.MKeyedList[str, fleetmgr__f
             return e
         key = key_
         res = fleetmgr__fleet__node__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1211,7 +1462,7 @@ class fleetmgr__fleet__node__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class fleetmgr__fleet__node__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__node__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__node__initial_credentials_entry:
         e = self.get(key_)
@@ -1219,7 +1470,7 @@ class fleetmgr__fleet__node__initial_credentials(yadata.MKeyedList[(username: st
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__node__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1240,6 +1491,45 @@ class fleetmgr__fleet__node__initial_credentials(yadata.MKeyedList[(username: st
 
 
 _breaker10: None = None
+class fleetmgr__fleet__node__ssh(yadata.MNode):
+    cipher: list[str]
+    mac: list[str]
+    key_exchange: list[str]
+    host_key_algorithm: list[str]
+    public_key_algorithm: list[str]
+    compression_algorithm: list[str]
+    compression_level: u64
+    rekey_after_bytes: ?u64
+    rekey_after_seconds: ?u64
+    minimum_rsa_bits: u64
+
+    mut def __init__(self, cipher: ?list[str]=None, mac: ?list[str]=None, key_exchange: ?list[str]=None, host_key_algorithm: ?list[str]=None, public_key_algorithm: ?list[str]=None, compression_algorithm: ?list[str]=None, compression_level: ?u64=None, rekey_after_bytes: ?u64, rekey_after_seconds: ?u64, minimum_rsa_bits: ?u64=None) -> None:
+        self.cipher = cipher if cipher is not None else []
+        self.mac = mac if mac is not None else []
+        self.key_exchange = key_exchange if key_exchange is not None else []
+        self.host_key_algorithm = host_key_algorithm if host_key_algorithm is not None else []
+        self.public_key_algorithm = public_key_algorithm if public_key_algorithm is not None else []
+        self.compression_algorithm = compression_algorithm if compression_algorithm is not None else []
+        self.compression_level = compression_level if compression_level is not None else u64(7)
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits if minimum_rsa_bits is not None else u64(1024)
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['fleetmgr:fleet', 'node', 'ssh'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__node__ssh:
+        if n is not None:
+            return fleetmgr__fleet__node__ssh(cipher=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'cipher')), mac=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'mac')), key_exchange=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'key-exchange')), host_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'host-key-algorithm')), public_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'public-key-algorithm')), compression_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'compression-algorithm')), compression_level=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'compression-level')), rekey_after_bytes=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-bytes')), rekey_after_seconds=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-seconds')), minimum_rsa_bits=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'minimum-rsa-bits')))
+        return fleetmgr__fleet__node__ssh()
+
+    mut def copy(self) -> fleetmgr__fleet__node__ssh:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__node__ssh.from_gdata(self.to_gdata())
+
+
+_breaker11: None = None
 class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
     name: str
     namespace: str
@@ -1263,10 +1553,10 @@ class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker11: None = None
+_breaker12: None = None
 class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__node__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: str, revision: ?str=None) -> fleetmgr__fleet__node__mock__module_entry:
         e = self.get(key)
@@ -1277,7 +1567,7 @@ class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet
             return e
         name = key
         res = fleetmgr__fleet__node__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1297,7 +1587,7 @@ class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet
         return fleetmgr__fleet__node__mock__module(elements=copied_elements)
 
 
-_breaker12: None = None
+_breaker13: None = None
 class fleetmgr__fleet__node__mock(yadata.MNode):
     enabled: bool
     module: fleetmgr__fleet__node__mock__module
@@ -1320,7 +1610,7 @@ class fleetmgr__fleet__node__mock(yadata.MNode):
         return fleetmgr__fleet__node__mock.from_gdata(self.to_gdata())
 
 
-_breaker13: None = None
+_breaker14: None = None
 class fleetmgr__fleet__node__debug(yadata.MNode):
     connection: bool
 
@@ -1341,7 +1631,7 @@ class fleetmgr__fleet__node__debug(yadata.MNode):
         return fleetmgr__fleet__node__debug.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class fleetmgr__fleet__node__feature_flags(yadata.MNode):
     runtime_schema_fetch: bool
 
@@ -1362,24 +1652,26 @@ class fleetmgr__fleet__node__feature_flags(yadata.MNode):
         return fleetmgr__fleet__node__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class fleetmgr__fleet__node_entry(yadata.MNode):
     name: str
     description: ?str
     address: fleetmgr__fleet__node__address
     credentials: fleetmgr__fleet__node__credentials
     initial_credentials: fleetmgr__fleet__node__initial_credentials
+    ssh: fleetmgr__fleet__node__ssh
     approval_required: bool
     mock: fleetmgr__fleet__node__mock
     debug: fleetmgr__fleet__node__debug
     feature_flags: fleetmgr__fleet__node__feature_flags
 
-    mut def __init__(self, name: str, credentials: fleetmgr__fleet__node__credentials, description: ?str, address: list[fleetmgr__fleet__node__address_entry]=[], initial_credentials: list[fleetmgr__fleet__node__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?fleetmgr__fleet__node__mock=None, debug: ?fleetmgr__fleet__node__debug=None, feature_flags: ?fleetmgr__fleet__node__feature_flags=None) -> None:
+    mut def __init__(self, name: str, credentials: fleetmgr__fleet__node__credentials, description: ?str, address: list[fleetmgr__fleet__node__address_entry]=[], initial_credentials: list[fleetmgr__fleet__node__initial_credentials_entry]=[], ssh: ?fleetmgr__fleet__node__ssh=None, approval_required: ?bool=None, mock: ?fleetmgr__fleet__node__mock=None, debug: ?fleetmgr__fleet__node__debug=None, feature_flags: ?fleetmgr__fleet__node__feature_flags=None) -> None:
         self.name = name
         self.description = description
         self.address = fleetmgr__fleet__node__address(elements=address)
         self.credentials = credentials
         self.initial_credentials = fleetmgr__fleet__node__initial_credentials(elements=initial_credentials)
+        self.ssh = ssh if ssh is not None else fleetmgr__fleet__node__ssh()
         self.approval_required = approval_required if approval_required is not None else False
         self.mock = mock if mock is not None else fleetmgr__fleet__node__mock()
         self.debug = debug if debug is not None else fleetmgr__fleet__node__debug()
@@ -1390,16 +1682,16 @@ class fleetmgr__fleet__node_entry(yadata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ygdata.Node) -> fleetmgr__fleet__node_entry:
-        return fleetmgr__fleet__node_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__node__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__node__credentials.from_gdata(n.get_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__node__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__node__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__node__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__node__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
+        return fleetmgr__fleet__node_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__node__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__node__credentials.from_gdata(n.get_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__node__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), ssh=fleetmgr__fleet__node__ssh.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'ssh'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__node__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__node__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__node__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
 
     mut def copy(self) -> fleetmgr__fleet__node_entry:
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node_entry.from_gdata(self.to_gdata())
 
-_breaker16: None = None
+_breaker17: None = None
 class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, credentials: fleetmgr__fleet__node__credentials, description: ?str=None, approval_required: ?bool=None) -> fleetmgr__fleet__node_entry:
         e = self.get(key)
@@ -1412,7 +1704,7 @@ class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry])
             return e
         name = key
         res = fleetmgr__fleet__node_entry(name=name, credentials=credentials, description=description, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1432,7 +1724,7 @@ class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry])
         return fleetmgr__fleet__node(elements=copied_elements)
 
 
-_breaker17: None = None
+_breaker18: None = None
 class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1454,10 +1746,10 @@ class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker18: None = None
+_breaker19: None = None
 class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1465,7 +1757,7 @@ class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1485,7 +1777,7 @@ class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(u
         return fleetmgr__fleet__device__address__initial_credentials(elements=copied_elements)
 
 
-_breaker19: None = None
+_breaker20: None = None
 class fleetmgr__fleet__device__address_entry(yadata.MNode):
     name: str
     address: str
@@ -1509,10 +1801,10 @@ class fleetmgr__fleet__device__address_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker20: None = None
+_breaker21: None = None
 class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__device__address_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: str, port: ?u64=None) -> fleetmgr__fleet__device__address_entry:
         e = self.get(key)
@@ -1523,7 +1815,7 @@ class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__d
             return e
         name = key
         res = fleetmgr__fleet__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1543,7 +1835,7 @@ class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__d
         return fleetmgr__fleet__device__address(elements=copied_elements)
 
 
-_breaker21: None = None
+_breaker22: None = None
 class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
     key: str
     private_key: ?str
@@ -1563,10 +1855,10 @@ class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker22: None = None
+_breaker23: None = None
 class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr__fleet__device__credentials__key_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> fleetmgr__fleet__device__credentials__key_entry:
         e = self.get(key_)
@@ -1576,7 +1868,7 @@ class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr_
             return e
         key = key_
         res = fleetmgr__fleet__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1596,7 +1888,7 @@ class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr_
         return fleetmgr__fleet__device__credentials__key(elements=copied_elements)
 
 
-_breaker23: None = None
+_breaker24: None = None
 class fleetmgr__fleet__device__credentials(yadata.MNode):
     username: str
     password: ?str
@@ -1621,7 +1913,7 @@ class fleetmgr__fleet__device__credentials(yadata.MNode):
         return fleetmgr__fleet__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker24: None = None
+_breaker25: None = None
 class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1643,10 +1935,10 @@ class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker25: None = None
+_breaker26: None = None
 class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__device__initial_credentials_entry:
         e = self.get(key_)
@@ -1654,7 +1946,7 @@ class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1674,7 +1966,46 @@ class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: 
         return fleetmgr__fleet__device__initial_credentials(elements=copied_elements)
 
 
-_breaker26: None = None
+_breaker27: None = None
+class fleetmgr__fleet__device__ssh(yadata.MNode):
+    cipher: list[str]
+    mac: list[str]
+    key_exchange: list[str]
+    host_key_algorithm: list[str]
+    public_key_algorithm: list[str]
+    compression_algorithm: list[str]
+    compression_level: u64
+    rekey_after_bytes: ?u64
+    rekey_after_seconds: ?u64
+    minimum_rsa_bits: u64
+
+    mut def __init__(self, cipher: ?list[str]=None, mac: ?list[str]=None, key_exchange: ?list[str]=None, host_key_algorithm: ?list[str]=None, public_key_algorithm: ?list[str]=None, compression_algorithm: ?list[str]=None, compression_level: ?u64=None, rekey_after_bytes: ?u64, rekey_after_seconds: ?u64, minimum_rsa_bits: ?u64=None) -> None:
+        self.cipher = cipher if cipher is not None else []
+        self.mac = mac if mac is not None else []
+        self.key_exchange = key_exchange if key_exchange is not None else []
+        self.host_key_algorithm = host_key_algorithm if host_key_algorithm is not None else []
+        self.public_key_algorithm = public_key_algorithm if public_key_algorithm is not None else []
+        self.compression_algorithm = compression_algorithm if compression_algorithm is not None else []
+        self.compression_level = compression_level if compression_level is not None else u64(7)
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits if minimum_rsa_bits is not None else u64(1024)
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['fleetmgr:fleet', 'device', 'ssh'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__device__ssh:
+        if n is not None:
+            return fleetmgr__fleet__device__ssh(cipher=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'cipher')), mac=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'mac')), key_exchange=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'key-exchange')), host_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'host-key-algorithm')), public_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'public-key-algorithm')), compression_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'compression-algorithm')), compression_level=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'compression-level')), rekey_after_bytes=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-bytes')), rekey_after_seconds=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-seconds')), minimum_rsa_bits=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'minimum-rsa-bits')))
+        return fleetmgr__fleet__device__ssh()
+
+    mut def copy(self) -> fleetmgr__fleet__device__ssh:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__device__ssh.from_gdata(self.to_gdata())
+
+
+_breaker28: None = None
 class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: str
@@ -1698,10 +2029,10 @@ class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker27: None = None
+_breaker29: None = None
 class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__device__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: str, revision: ?str=None) -> fleetmgr__fleet__device__mock__module_entry:
         e = self.get(key)
@@ -1712,7 +2043,7 @@ class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fle
             return e
         name = key
         res = fleetmgr__fleet__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1732,7 +2063,7 @@ class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fle
         return fleetmgr__fleet__device__mock__module(elements=copied_elements)
 
 
-_breaker28: None = None
+_breaker30: None = None
 class fleetmgr__fleet__device__mock(yadata.MNode):
     enabled: bool
     module: fleetmgr__fleet__device__mock__module
@@ -1755,7 +2086,7 @@ class fleetmgr__fleet__device__mock(yadata.MNode):
         return fleetmgr__fleet__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker29: None = None
+_breaker31: None = None
 class fleetmgr__fleet__device__debug(yadata.MNode):
     connection: bool
 
@@ -1776,7 +2107,7 @@ class fleetmgr__fleet__device__debug(yadata.MNode):
         return fleetmgr__fleet__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker30: None = None
+_breaker32: None = None
 class fleetmgr__fleet__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: bool
 
@@ -1797,7 +2128,7 @@ class fleetmgr__fleet__device__feature_flags(yadata.MNode):
         return fleetmgr__fleet__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker31: None = None
+_breaker33: None = None
 class fleetmgr__fleet__device_entry(yadata.MNode):
     name: str
     type: str
@@ -1806,12 +2137,13 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
     address: fleetmgr__fleet__device__address
     credentials: fleetmgr__fleet__device__credentials
     initial_credentials: fleetmgr__fleet__device__initial_credentials
+    ssh: fleetmgr__fleet__device__ssh
     approval_required: bool
     mock: fleetmgr__fleet__device__mock
     debug: fleetmgr__fleet__device__debug
     feature_flags: fleetmgr__fleet__device__feature_flags
 
-    mut def __init__(self, name: str, type: str, shard: str, credentials: fleetmgr__fleet__device__credentials, description: ?str, address: list[fleetmgr__fleet__device__address_entry]=[], initial_credentials: list[fleetmgr__fleet__device__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?fleetmgr__fleet__device__mock=None, debug: ?fleetmgr__fleet__device__debug=None, feature_flags: ?fleetmgr__fleet__device__feature_flags=None) -> None:
+    mut def __init__(self, name: str, type: str, shard: str, credentials: fleetmgr__fleet__device__credentials, description: ?str, address: list[fleetmgr__fleet__device__address_entry]=[], initial_credentials: list[fleetmgr__fleet__device__initial_credentials_entry]=[], ssh: ?fleetmgr__fleet__device__ssh=None, approval_required: ?bool=None, mock: ?fleetmgr__fleet__device__mock=None, debug: ?fleetmgr__fleet__device__debug=None, feature_flags: ?fleetmgr__fleet__device__feature_flags=None) -> None:
         self.name = name
         self.type = type
         self.shard = shard
@@ -1819,6 +2151,7 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
         self.address = fleetmgr__fleet__device__address(elements=address)
         self.credentials = credentials
         self.initial_credentials = fleetmgr__fleet__device__initial_credentials(elements=initial_credentials)
+        self.ssh = ssh if ssh is not None else fleetmgr__fleet__device__ssh()
         self.approval_required = approval_required if approval_required is not None else False
         self.mock = mock if mock is not None else fleetmgr__fleet__device__mock()
         self.debug = debug if debug is not None else fleetmgr__fleet__device__debug()
@@ -1829,16 +2162,16 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ygdata.Node) -> fleetmgr__fleet__device_entry:
-        return fleetmgr__fleet__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), type=n.get_str(ygdata.Id(NS_fleetmgr, 'type')), shard=n.get_str(ygdata.Id(NS_fleetmgr, 'shard')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__device__credentials.from_gdata(n.get_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
+        return fleetmgr__fleet__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), type=n.get_str(ygdata.Id(NS_fleetmgr, 'type')), shard=n.get_str(ygdata.Id(NS_fleetmgr, 'shard')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__device__credentials.from_gdata(n.get_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), ssh=fleetmgr__fleet__device__ssh.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'ssh'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
 
     mut def copy(self) -> fleetmgr__fleet__device_entry:
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device_entry.from_gdata(self.to_gdata())
 
-_breaker32: None = None
+_breaker34: None = None
 class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, type: str, shard: str, credentials: fleetmgr__fleet__device__credentials, description: ?str=None, approval_required: ?bool=None) -> fleetmgr__fleet__device_entry:
         e = self.get(key)
@@ -1853,7 +2186,7 @@ class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_ent
             return e
         name = key
         res = fleetmgr__fleet__device_entry(name=name, type=type, shard=shard, credentials=credentials, description=description, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1873,7 +2206,7 @@ class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_ent
         return fleetmgr__fleet__device(elements=copied_elements)
 
 
-_breaker33: None = None
+_breaker35: None = None
 class fleetmgr__fleet(yadata.MNode):
     node: fleetmgr__fleet__node
     device: fleetmgr__fleet__device
@@ -1896,7 +2229,7 @@ class fleetmgr__fleet(yadata.MNode):
         return fleetmgr__fleet.from_gdata(self.to_gdata())
 
 
-_breaker34: None = None
+_breaker36: None = None
 class software__software__upgrade_campaign__device_entry(yadata.MNode):
     name: str
 
@@ -1914,10 +2247,10 @@ class software__software__upgrade_campaign__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign__device_entry.from_gdata(self.to_gdata())
 
-_breaker35: None = None
+_breaker37: None = None
 class software__software__upgrade_campaign__device(yadata.MKeyedList[str, software__software__upgrade_campaign__device_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> software__software__upgrade_campaign__device_entry:
         e = self.get(key)
@@ -1925,7 +2258,7 @@ class software__software__upgrade_campaign__device(yadata.MKeyedList[str, softwa
             return e
         name = key
         res = software__software__upgrade_campaign__device_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1945,7 +2278,7 @@ class software__software__upgrade_campaign__device(yadata.MKeyedList[str, softwa
         return software__software__upgrade_campaign__device(elements=copied_elements)
 
 
-_breaker36: None = None
+_breaker38: None = None
 class software__software__upgrade_campaign_entry(yadata.MNode):
     name: str
     target_release: str
@@ -1973,10 +2306,10 @@ class software__software__upgrade_campaign_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign_entry.from_gdata(self.to_gdata())
 
-_breaker37: None = None
+_breaker39: None = None
 class software__software__upgrade_campaign(yadata.MKeyedList[str, software__software__upgrade_campaign_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, target_release: str, image_url: ?str=None, allow_staging: ?bool=None, admin_state: ?str=None) -> software__software__upgrade_campaign_entry:
         e = self.get(key)
@@ -1991,7 +2324,7 @@ class software__software__upgrade_campaign(yadata.MKeyedList[str, software__soft
             return e
         name = key
         res = software__software__upgrade_campaign_entry(name=name, target_release=target_release, image_url=image_url, allow_staging=allow_staging, admin_state=admin_state)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2011,7 +2344,7 @@ class software__software__upgrade_campaign(yadata.MKeyedList[str, software__soft
         return software__software__upgrade_campaign(elements=copied_elements)
 
 
-_breaker38: None = None
+_breaker40: None = None
 class software__software(yadata.MNode):
     upgrade_campaign: software__software__upgrade_campaign
 
@@ -2032,7 +2365,7 @@ class software__software(yadata.MNode):
         return software__software.from_gdata(self.to_gdata())
 
 
-_breaker39: None = None
+_breaker41: None = None
 class root(yadata.MNode):
     fleet: fleetmgr__fleet
     software: software__software

--- a/fleetmgr/src/fleetmgr/layers/y_0_loose.act
+++ b/fleetmgr/src/fleetmgr/layers/y_0_loose.act
@@ -56,9 +56,22 @@ SRC_DNODE_CHILD_6: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:flee
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_7: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_7: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='minimum-rsa-bits', config=True, description='Reject RSA host and public keys shorter than this.', default='1024', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1024, 2147483647)])))
+])
 
-SRC_DNODE_CHILD_8: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
+SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_9: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -68,27 +81,27 @@ SRC_DNODE_CHILD_8: DContainer = DContainer(module='fleetmgr', namespace='urn:fle
     ])
 ])
 
-SRC_DNODE_CHILD_9: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
+SRC_DNODE_CHILD_10: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='connection', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_10: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
+SRC_DNODE_CHILD_11: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='runtime-schema-fetch', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
 SRC_DNODE_CHILD_1: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='node', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
         DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='transform', arg='fleetmgr.cfs.Node', exts=[])
-    ], children=[SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10])
+    ], children=[SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10, SRC_DNODE_CHILD_11])
 
-SRC_DNODE_CHILD_12: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_13: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_13: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='type', config=True, description='Device platform type understood by the owning flotilla.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_14: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='type', config=True, description='Device platform type understood by the owning flotilla.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_14: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='shard', config=True, description='Name of the flotilla node that owns this device.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_15: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='shard', config=True, description='Name of the flotilla node that owns this device.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_15: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='description', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_16: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='description', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_16: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='address', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
+SRC_DNODE_CHILD_17: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='address', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, description="Name of address, e.g. 'loopback' or 'OOB'", mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='address', config=True, mandatory=True, type=DTypeUnion(name='inet:host', description='The host type represents either an IP address or a DNS\ndomain name.', reference=None, exts=[], builtin_type='union', default=None, types=[DTypeString(name='inet:ipv4-address', description='The ipv4-address type represents an IPv4 address in\ndotted-quad notation.  The IPv4 address may include a zone\nindex, separated by a % sign.\n\nThe zone index is used to disambiguate identical address\nvalues.  For link-local addresses, the zone index will\ntypically be the interface index number or the name of an\ninterface.  If the zone index is not present, the default\nzone of the device will be used.\n\nThe canonical format for the zone index is the numerical\nformat', reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False)]), DTypeString(name='inet:ipv6-address', description='The ipv6-address type represents an IPv6 address in full,\nmixed, shortened, and shortened-mixed notation.  The IPv6\naddress may include a zone index, separated by a % sign.\n\nThe zone index is used to disambiguate identical address\nvalues.  For link-local addresses, the zone index will\ntypically be the interface index number or the name of an\ninterface.  If the zone index is not present, the default\nzone of the device will be used.\n\nThe canonical format of IPv6 addresses uses the textual\nrepresentation defined in Section 4 of RFC 5952.  The\ncanonical format for the zone index is the numerical\nformat as described in Section 11.2 of RFC 4007.', reference='RFC 4291: IP Version 6 Addressing Architecture\nRFC 4007: IPv6 Scoped Address Architecture\nRFC 5952: A Recommendation for IPv6 Address Text\n          Representation', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?', pcre='^(((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='(([^:]+:){{6}}(([^:]+:[^:]+)|(.*\\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?', pcre='^((([^\\:]+:){{6}}(([^\\:]+:[^\\:]+)|(.*\\..*)))|((([^\\:]+:)*[^\\:]+)?::(([^\\:]+:)*[^\\:]+)?)(%.+)?)$', invert=False)]), DTypeString(name='inet:domain-name', description='The domain-name type represents a DNS domain name.  The\nname SHOULD be fully qualified whenever possible.\n\nInternet domain names are only loosely specified.  Section\n3.5 of RFC 1034 recommends a syntax (modified in Section\n2.1 of RFC 1123).  The pattern above is intended to allow\nfor current practice in domain name use, and some possible\nfuture expansion.  It is designed to hold various types of\ndomain names, including names used for A or AAAA records\n(host names) and other records, such as SRV records.  Note\nthat Internet host names have a stricter syntax (described\nin RFC 952) than the DNS recommendations in RFCs 1034 and\n1123, and that systems that want to store host names in\nschema nodes using the domain-name type are recommended to\nadhere to this stricter standard to ensure interoperability.\n\nThe encoding of DNS names in the DNS protocol is limited\nto 255 characters.  Since the encoding consists of labels\nprefixed by a length bytes and there is a trailing NULL\nbyte, only 253 characters can appear in the textual dotted\nnotation.\n\nThe description clause of schema nodes using the domain-name\ntype MUST describe when and how these names are resolved to\nIP addresses.  Note that the resolution of a domain-name value\nmay require to query multiple DNS records (e.g., A for IPv4\nand AAAA for IPv6).  The order of the resolution process and\nwhich DNS record takes precedence can either be defined\nexplicitly or may depend on the configuration of the\nresolver.\n\nDomain-name values use the US-ASCII encoding.  Their canonical\nformat uses lowercase US-ASCII characters.  Internationalized\ndomain names MUST be A-labels as per RFC 5890.', reference='RFC  952: DoD Internet Host Table Specification\nRFC 1034: Domain Names - Concepts and Facilities\nRFC 1123: Requirements for Internet Hosts -- Application\n          and Support\nRFC 2782: A DNS RR for specifying the location of services\n          (DNS SRV)\nRFC 5890: Internationalized Domain Names in Applications\n          (IDNA): Definitions and Document Framework', exts=[], builtin_type='string', default=None, length=Ranges([(1, 253)]), patterns=[YangPattern(yang_regex='((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.', pcre='^(((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.)$', invert=False)])])),
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='port', config=True, mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)]))),
@@ -103,7 +116,7 @@ SRC_DNODE_CHILD_16: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fle
     ])
 ])
 
-SRC_DNODE_CHILD_17: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='credentials', config=True, presence=False, children=[
+SRC_DNODE_CHILD_18: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='credentials', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='username', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='password', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key', key=['key'], config=True, min_elements=0, ordered_by='system', children=[
@@ -112,7 +125,7 @@ SRC_DNODE_CHILD_17: DContainer = DContainer(module='fleetmgr', namespace='urn:fl
     ])
 ])
 
-SRC_DNODE_CHILD_18: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='initial-credentials', key=[
+SRC_DNODE_CHILD_19: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='initial-credentials', key=[
 'username',
 'password',
 'key'
@@ -122,9 +135,22 @@ SRC_DNODE_CHILD_18: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fle
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_19: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_20: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='minimum-rsa-bits', config=True, description='Reject RSA host and public keys shorter than this.', default='1024', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1024, 2147483647)])))
+])
 
-SRC_DNODE_CHILD_20: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
+SRC_DNODE_CHILD_21: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_22: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -134,21 +160,21 @@ SRC_DNODE_CHILD_20: DContainer = DContainer(module='fleetmgr', namespace='urn:fl
     ])
 ])
 
-SRC_DNODE_CHILD_21: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
+SRC_DNODE_CHILD_23: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='connection', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_22: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
+SRC_DNODE_CHILD_24: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='runtime-schema-fetch', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_11: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
+SRC_DNODE_CHILD_12: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
         DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='transform', arg='fleetmgr.cfs.Device', exts=[])
-    ], children=[SRC_DNODE_CHILD_12, SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16, SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22])
+    ], children=[SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16, SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24])
 
-SRC_DNODE_CHILD_0: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='fleet', config=True, presence=False, children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_11])
+SRC_DNODE_CHILD_0: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='fleet', config=True, presence=False, children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_12])
 
-SRC_DNODE_CHILD_23: DContainer = DContainer(module='software', namespace='urn:fleetmgr:software', prefix='sw-cfs', name='software', config=True, presence=False, children=[
+SRC_DNODE_CHILD_25: DContainer = DContainer(module='software', namespace='urn:fleetmgr:software', prefix='sw-cfs', name='software', config=True, presence=False, children=[
     DList(module='software', namespace='urn:fleetmgr:software', prefix='sw-cfs', name='upgrade-campaign', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
             DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='transform', arg='fleetmgr.cfs.UpgradeCampaign', exts=[])
         ], children=[
@@ -166,10 +192,10 @@ SRC_DNODE_CHILD_23: DContainer = DContainer(module='software', namespace='urn:fl
 ])
 
 SRC_DNODE: DRoot = DRoot(
-    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_23],
+    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_25],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:fleetmgr':('fleetmgr', None), 'urn:fleetmgr:software':('software', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:fleetmgr':('fleetmgr', None), 'urn:fleetmgr:software':('software', None)},
 )
 
 SRC_YANG_0: str = r"""module fleetmgr {
@@ -319,6 +345,9 @@ SRC_YANG_2: str = r"""module fleetmgr-types {
   import ietf-inet-types {
     prefix inet;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
 
   grouping device-options {
     leaf description {
@@ -382,6 +411,13 @@ SRC_YANG_2: str = r"""module fleetmgr-types {
       leaf key {
         type string;
       }
+    }
+
+    container ssh {
+      description
+        "SSH transport parameters used when connecting to this device. Applies
+         to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -520,7 +556,220 @@ SRC_YANG_3: str = r"""module stratoweave {
   }
 }"""
 
-SRC_YANG_4: str = r"""module ietf-inet-types {
+SRC_YANG_4: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_5: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -987,10 +1236,12 @@ pure def src_yang() -> list[str]:
         SRC_YANG_2,
         SRC_YANG_3,
         SRC_YANG_4,
+        SRC_YANG_5,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_fleetmgr: str = 'urn:fleetmgr:fleetmgr'
 NS_software: str = 'urn:fleetmgr:software'
 NS_fleetmgr_types: str = 'urn:fleetmgr:types'
@@ -1022,7 +1273,7 @@ class fleetmgr__fleet__node__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class fleetmgr__fleet__node__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__node__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__node__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1030,7 +1281,7 @@ class fleetmgr__fleet__node__address__initial_credentials(yadata.MKeyedList[(use
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__node__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1077,7 +1328,7 @@ class fleetmgr__fleet__node__address_entry(yadata.MNode):
 _breaker4: None = None
 class fleetmgr__fleet__node__address(yadata.MKeyedList[str, fleetmgr__fleet__node__address_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> fleetmgr__fleet__node__address_entry:
         e = self.get(key)
@@ -1089,7 +1340,7 @@ class fleetmgr__fleet__node__address(yadata.MKeyedList[str, fleetmgr__fleet__nod
             return e
         name = key
         res = fleetmgr__fleet__node__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1132,7 +1383,7 @@ class fleetmgr__fleet__node__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class fleetmgr__fleet__node__credentials__key(yadata.MKeyedList[str, fleetmgr__fleet__node__credentials__key_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> fleetmgr__fleet__node__credentials__key_entry:
         e = self.get(key_)
@@ -1142,7 +1393,7 @@ class fleetmgr__fleet__node__credentials__key(yadata.MKeyedList[str, fleetmgr__f
             return e
         key = key_
         res = fleetmgr__fleet__node__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1212,7 +1463,7 @@ class fleetmgr__fleet__node__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class fleetmgr__fleet__node__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__node__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__node__initial_credentials_entry:
         e = self.get(key_)
@@ -1220,7 +1471,7 @@ class fleetmgr__fleet__node__initial_credentials(yadata.MKeyedList[(username: st
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__node__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1241,6 +1492,45 @@ class fleetmgr__fleet__node__initial_credentials(yadata.MKeyedList[(username: st
 
 
 _breaker10: None = None
+class fleetmgr__fleet__node__ssh(yadata.MNode):
+    cipher: list[str]
+    mac: list[str]
+    key_exchange: list[str]
+    host_key_algorithm: list[str]
+    public_key_algorithm: list[str]
+    compression_algorithm: list[str]
+    compression_level: ?u64
+    rekey_after_bytes: ?u64
+    rekey_after_seconds: ?u64
+    minimum_rsa_bits: ?u64
+
+    mut def __init__(self, cipher: ?list[str]=None, mac: ?list[str]=None, key_exchange: ?list[str]=None, host_key_algorithm: ?list[str]=None, public_key_algorithm: ?list[str]=None, compression_algorithm: ?list[str]=None, compression_level: ?u64, rekey_after_bytes: ?u64, rekey_after_seconds: ?u64, minimum_rsa_bits: ?u64) -> None:
+        self.cipher = cipher if cipher is not None else []
+        self.mac = mac if mac is not None else []
+        self.key_exchange = key_exchange if key_exchange is not None else []
+        self.host_key_algorithm = host_key_algorithm if host_key_algorithm is not None else []
+        self.public_key_algorithm = public_key_algorithm if public_key_algorithm is not None else []
+        self.compression_algorithm = compression_algorithm if compression_algorithm is not None else []
+        self.compression_level = compression_level
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['fleetmgr:fleet', 'node', 'ssh'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__node__ssh:
+        if n is not None:
+            return fleetmgr__fleet__node__ssh(cipher=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'cipher')), mac=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'mac')), key_exchange=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'key-exchange')), host_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'host-key-algorithm')), public_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'public-key-algorithm')), compression_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'compression-algorithm')), compression_level=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'compression-level')), rekey_after_bytes=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-bytes')), rekey_after_seconds=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-seconds')), minimum_rsa_bits=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'minimum-rsa-bits')))
+        return fleetmgr__fleet__node__ssh()
+
+    mut def copy(self) -> fleetmgr__fleet__node__ssh:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__node__ssh.from_gdata(self.to_gdata())
+
+
+_breaker11: None = None
 class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -1264,10 +1554,10 @@ class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker11: None = None
+_breaker12: None = None
 class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__node__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> fleetmgr__fleet__node__mock__module_entry:
         e = self.get(key)
@@ -1279,7 +1569,7 @@ class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet
             return e
         name = key
         res = fleetmgr__fleet__node__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1299,7 +1589,7 @@ class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet
         return fleetmgr__fleet__node__mock__module(elements=copied_elements)
 
 
-_breaker12: None = None
+_breaker13: None = None
 class fleetmgr__fleet__node__mock(yadata.MNode):
     enabled: ?bool
     module: fleetmgr__fleet__node__mock__module
@@ -1322,7 +1612,7 @@ class fleetmgr__fleet__node__mock(yadata.MNode):
         return fleetmgr__fleet__node__mock.from_gdata(self.to_gdata())
 
 
-_breaker13: None = None
+_breaker14: None = None
 class fleetmgr__fleet__node__debug(yadata.MNode):
     connection: ?bool
 
@@ -1343,7 +1633,7 @@ class fleetmgr__fleet__node__debug(yadata.MNode):
         return fleetmgr__fleet__node__debug.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class fleetmgr__fleet__node__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -1364,24 +1654,26 @@ class fleetmgr__fleet__node__feature_flags(yadata.MNode):
         return fleetmgr__fleet__node__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class fleetmgr__fleet__node_entry(yadata.MNode):
     name: str
     description: ?str
     address: fleetmgr__fleet__node__address
     credentials: fleetmgr__fleet__node__credentials
     initial_credentials: fleetmgr__fleet__node__initial_credentials
+    ssh: fleetmgr__fleet__node__ssh
     approval_required: ?bool
     mock: fleetmgr__fleet__node__mock
     debug: fleetmgr__fleet__node__debug
     feature_flags: fleetmgr__fleet__node__feature_flags
 
-    mut def __init__(self, name: str, description: ?str, address: list[fleetmgr__fleet__node__address_entry]=[], credentials: ?fleetmgr__fleet__node__credentials=None, initial_credentials: list[fleetmgr__fleet__node__initial_credentials_entry]=[], approval_required: ?bool, mock: ?fleetmgr__fleet__node__mock=None, debug: ?fleetmgr__fleet__node__debug=None, feature_flags: ?fleetmgr__fleet__node__feature_flags=None) -> None:
+    mut def __init__(self, name: str, description: ?str, address: list[fleetmgr__fleet__node__address_entry]=[], credentials: ?fleetmgr__fleet__node__credentials=None, initial_credentials: list[fleetmgr__fleet__node__initial_credentials_entry]=[], ssh: ?fleetmgr__fleet__node__ssh=None, approval_required: ?bool, mock: ?fleetmgr__fleet__node__mock=None, debug: ?fleetmgr__fleet__node__debug=None, feature_flags: ?fleetmgr__fleet__node__feature_flags=None) -> None:
         self.name = name
         self.description = description
         self.address = fleetmgr__fleet__node__address(elements=address)
         self.credentials = credentials if credentials is not None else fleetmgr__fleet__node__credentials()
         self.initial_credentials = fleetmgr__fleet__node__initial_credentials(elements=initial_credentials)
+        self.ssh = ssh if ssh is not None else fleetmgr__fleet__node__ssh()
         self.approval_required = approval_required
         self.mock = mock if mock is not None else fleetmgr__fleet__node__mock()
         self.debug = debug if debug is not None else fleetmgr__fleet__node__debug()
@@ -1392,16 +1684,16 @@ class fleetmgr__fleet__node_entry(yadata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ygdata.Node) -> fleetmgr__fleet__node_entry:
-        return fleetmgr__fleet__node_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__node__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__node__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__node__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__node__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__node__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__node__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
+        return fleetmgr__fleet__node_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__node__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__node__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__node__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), ssh=fleetmgr__fleet__node__ssh.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'ssh'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__node__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__node__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__node__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
 
     mut def copy(self) -> fleetmgr__fleet__node_entry:
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node_entry.from_gdata(self.to_gdata())
 
-_breaker16: None = None
+_breaker17: None = None
 class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, description: ?str=None, approval_required: ?bool=None) -> fleetmgr__fleet__node_entry:
         e = self.get(key)
@@ -1413,7 +1705,7 @@ class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry])
             return e
         name = key
         res = fleetmgr__fleet__node_entry(name=name, description=description, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1433,7 +1725,7 @@ class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry])
         return fleetmgr__fleet__node(elements=copied_elements)
 
 
-_breaker17: None = None
+_breaker18: None = None
 class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1455,10 +1747,10 @@ class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker18: None = None
+_breaker19: None = None
 class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1466,7 +1758,7 @@ class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1486,7 +1778,7 @@ class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(u
         return fleetmgr__fleet__device__address__initial_credentials(elements=copied_elements)
 
 
-_breaker19: None = None
+_breaker20: None = None
 class fleetmgr__fleet__device__address_entry(yadata.MNode):
     name: str
     address: ?str
@@ -1510,10 +1802,10 @@ class fleetmgr__fleet__device__address_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker20: None = None
+_breaker21: None = None
 class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__device__address_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> fleetmgr__fleet__device__address_entry:
         e = self.get(key)
@@ -1525,7 +1817,7 @@ class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__d
             return e
         name = key
         res = fleetmgr__fleet__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1545,7 +1837,7 @@ class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__d
         return fleetmgr__fleet__device__address(elements=copied_elements)
 
 
-_breaker21: None = None
+_breaker22: None = None
 class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
     key: str
     private_key: ?str
@@ -1565,10 +1857,10 @@ class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker22: None = None
+_breaker23: None = None
 class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr__fleet__device__credentials__key_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> fleetmgr__fleet__device__credentials__key_entry:
         e = self.get(key_)
@@ -1578,7 +1870,7 @@ class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr_
             return e
         key = key_
         res = fleetmgr__fleet__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1598,7 +1890,7 @@ class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr_
         return fleetmgr__fleet__device__credentials__key(elements=copied_elements)
 
 
-_breaker23: None = None
+_breaker24: None = None
 class fleetmgr__fleet__device__credentials(yadata.MNode):
     username: ?str
     password: ?str
@@ -1623,7 +1915,7 @@ class fleetmgr__fleet__device__credentials(yadata.MNode):
         return fleetmgr__fleet__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker24: None = None
+_breaker25: None = None
 class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1645,10 +1937,10 @@ class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker25: None = None
+_breaker26: None = None
 class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__device__initial_credentials_entry:
         e = self.get(key_)
@@ -1656,7 +1948,7 @@ class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1676,7 +1968,46 @@ class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: 
         return fleetmgr__fleet__device__initial_credentials(elements=copied_elements)
 
 
-_breaker26: None = None
+_breaker27: None = None
+class fleetmgr__fleet__device__ssh(yadata.MNode):
+    cipher: list[str]
+    mac: list[str]
+    key_exchange: list[str]
+    host_key_algorithm: list[str]
+    public_key_algorithm: list[str]
+    compression_algorithm: list[str]
+    compression_level: ?u64
+    rekey_after_bytes: ?u64
+    rekey_after_seconds: ?u64
+    minimum_rsa_bits: ?u64
+
+    mut def __init__(self, cipher: ?list[str]=None, mac: ?list[str]=None, key_exchange: ?list[str]=None, host_key_algorithm: ?list[str]=None, public_key_algorithm: ?list[str]=None, compression_algorithm: ?list[str]=None, compression_level: ?u64, rekey_after_bytes: ?u64, rekey_after_seconds: ?u64, minimum_rsa_bits: ?u64) -> None:
+        self.cipher = cipher if cipher is not None else []
+        self.mac = mac if mac is not None else []
+        self.key_exchange = key_exchange if key_exchange is not None else []
+        self.host_key_algorithm = host_key_algorithm if host_key_algorithm is not None else []
+        self.public_key_algorithm = public_key_algorithm if public_key_algorithm is not None else []
+        self.compression_algorithm = compression_algorithm if compression_algorithm is not None else []
+        self.compression_level = compression_level
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['fleetmgr:fleet', 'device', 'ssh'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__device__ssh:
+        if n is not None:
+            return fleetmgr__fleet__device__ssh(cipher=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'cipher')), mac=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'mac')), key_exchange=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'key-exchange')), host_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'host-key-algorithm')), public_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'public-key-algorithm')), compression_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'compression-algorithm')), compression_level=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'compression-level')), rekey_after_bytes=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-bytes')), rekey_after_seconds=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-seconds')), minimum_rsa_bits=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'minimum-rsa-bits')))
+        return fleetmgr__fleet__device__ssh()
+
+    mut def copy(self) -> fleetmgr__fleet__device__ssh:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__device__ssh.from_gdata(self.to_gdata())
+
+
+_breaker28: None = None
 class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -1700,10 +2031,10 @@ class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker27: None = None
+_breaker29: None = None
 class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__device__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> fleetmgr__fleet__device__mock__module_entry:
         e = self.get(key)
@@ -1715,7 +2046,7 @@ class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fle
             return e
         name = key
         res = fleetmgr__fleet__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1735,7 +2066,7 @@ class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fle
         return fleetmgr__fleet__device__mock__module(elements=copied_elements)
 
 
-_breaker28: None = None
+_breaker30: None = None
 class fleetmgr__fleet__device__mock(yadata.MNode):
     enabled: ?bool
     module: fleetmgr__fleet__device__mock__module
@@ -1758,7 +2089,7 @@ class fleetmgr__fleet__device__mock(yadata.MNode):
         return fleetmgr__fleet__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker29: None = None
+_breaker31: None = None
 class fleetmgr__fleet__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -1779,7 +2110,7 @@ class fleetmgr__fleet__device__debug(yadata.MNode):
         return fleetmgr__fleet__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker30: None = None
+_breaker32: None = None
 class fleetmgr__fleet__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -1800,7 +2131,7 @@ class fleetmgr__fleet__device__feature_flags(yadata.MNode):
         return fleetmgr__fleet__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker31: None = None
+_breaker33: None = None
 class fleetmgr__fleet__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -1809,12 +2140,13 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
     address: fleetmgr__fleet__device__address
     credentials: fleetmgr__fleet__device__credentials
     initial_credentials: fleetmgr__fleet__device__initial_credentials
+    ssh: fleetmgr__fleet__device__ssh
     approval_required: ?bool
     mock: fleetmgr__fleet__device__mock
     debug: fleetmgr__fleet__device__debug
     feature_flags: fleetmgr__fleet__device__feature_flags
 
-    mut def __init__(self, name: str, type: ?str, shard: ?str, description: ?str, address: list[fleetmgr__fleet__device__address_entry]=[], credentials: ?fleetmgr__fleet__device__credentials=None, initial_credentials: list[fleetmgr__fleet__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?fleetmgr__fleet__device__mock=None, debug: ?fleetmgr__fleet__device__debug=None, feature_flags: ?fleetmgr__fleet__device__feature_flags=None) -> None:
+    mut def __init__(self, name: str, type: ?str, shard: ?str, description: ?str, address: list[fleetmgr__fleet__device__address_entry]=[], credentials: ?fleetmgr__fleet__device__credentials=None, initial_credentials: list[fleetmgr__fleet__device__initial_credentials_entry]=[], ssh: ?fleetmgr__fleet__device__ssh=None, approval_required: ?bool, mock: ?fleetmgr__fleet__device__mock=None, debug: ?fleetmgr__fleet__device__debug=None, feature_flags: ?fleetmgr__fleet__device__feature_flags=None) -> None:
         self.name = name
         self.type = type
         self.shard = shard
@@ -1822,6 +2154,7 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
         self.address = fleetmgr__fleet__device__address(elements=address)
         self.credentials = credentials if credentials is not None else fleetmgr__fleet__device__credentials()
         self.initial_credentials = fleetmgr__fleet__device__initial_credentials(elements=initial_credentials)
+        self.ssh = ssh if ssh is not None else fleetmgr__fleet__device__ssh()
         self.approval_required = approval_required
         self.mock = mock if mock is not None else fleetmgr__fleet__device__mock()
         self.debug = debug if debug is not None else fleetmgr__fleet__device__debug()
@@ -1832,16 +2165,16 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ygdata.Node) -> fleetmgr__fleet__device_entry:
-        return fleetmgr__fleet__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), type=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'type')), shard=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'shard')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__device__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
+        return fleetmgr__fleet__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), type=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'type')), shard=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'shard')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__device__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), ssh=fleetmgr__fleet__device__ssh.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'ssh'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
 
     mut def copy(self) -> fleetmgr__fleet__device_entry:
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device_entry.from_gdata(self.to_gdata())
 
-_breaker32: None = None
+_breaker34: None = None
 class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, type: ?str=None, shard: ?str=None, description: ?str=None, approval_required: ?bool=None) -> fleetmgr__fleet__device_entry:
         e = self.get(key)
@@ -1857,7 +2190,7 @@ class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_ent
             return e
         name = key
         res = fleetmgr__fleet__device_entry(name=name, type=type, shard=shard, description=description, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1877,7 +2210,7 @@ class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_ent
         return fleetmgr__fleet__device(elements=copied_elements)
 
 
-_breaker33: None = None
+_breaker35: None = None
 class fleetmgr__fleet(yadata.MNode):
     node: fleetmgr__fleet__node
     device: fleetmgr__fleet__device
@@ -1900,7 +2233,7 @@ class fleetmgr__fleet(yadata.MNode):
         return fleetmgr__fleet.from_gdata(self.to_gdata())
 
 
-_breaker34: None = None
+_breaker36: None = None
 class software__software__upgrade_campaign__device_entry(yadata.MNode):
     name: str
 
@@ -1918,10 +2251,10 @@ class software__software__upgrade_campaign__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign__device_entry.from_gdata(self.to_gdata())
 
-_breaker35: None = None
+_breaker37: None = None
 class software__software__upgrade_campaign__device(yadata.MKeyedList[str, software__software__upgrade_campaign__device_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> software__software__upgrade_campaign__device_entry:
         e = self.get(key)
@@ -1929,7 +2262,7 @@ class software__software__upgrade_campaign__device(yadata.MKeyedList[str, softwa
             return e
         name = key
         res = software__software__upgrade_campaign__device_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1949,7 +2282,7 @@ class software__software__upgrade_campaign__device(yadata.MKeyedList[str, softwa
         return software__software__upgrade_campaign__device(elements=copied_elements)
 
 
-_breaker36: None = None
+_breaker38: None = None
 class software__software__upgrade_campaign_entry(yadata.MNode):
     name: str
     target_release: ?str
@@ -1977,10 +2310,10 @@ class software__software__upgrade_campaign_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign_entry.from_gdata(self.to_gdata())
 
-_breaker37: None = None
+_breaker39: None = None
 class software__software__upgrade_campaign(yadata.MKeyedList[str, software__software__upgrade_campaign_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, target_release: ?str=None, image_url: ?str=None, allow_staging: ?bool=None, admin_state: ?str=None) -> software__software__upgrade_campaign_entry:
         e = self.get(key)
@@ -1996,7 +2329,7 @@ class software__software__upgrade_campaign(yadata.MKeyedList[str, software__soft
             return e
         name = key
         res = software__software__upgrade_campaign_entry(name=name, target_release=target_release, image_url=image_url, allow_staging=allow_staging, admin_state=admin_state)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2016,7 +2349,7 @@ class software__software__upgrade_campaign(yadata.MKeyedList[str, software__soft
         return software__software__upgrade_campaign(elements=copied_elements)
 
 
-_breaker38: None = None
+_breaker40: None = None
 class software__software(yadata.MNode):
     upgrade_campaign: software__software__upgrade_campaign
 
@@ -2037,7 +2370,7 @@ class software__software(yadata.MNode):
         return software__software.from_gdata(self.to_gdata())
 
 
-_breaker39: None = None
+_breaker41: None = None
 class root(yadata.MNode):
     fleet: fleetmgr__fleet
     software: software__software

--- a/fleetmgr/src/fleetmgr/layers/y_0_oper.act
+++ b/fleetmgr/src/fleetmgr/layers/y_0_oper.act
@@ -57,9 +57,22 @@ SRC_DNODE_CHILD_6: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:flee
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_7: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_7: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='minimum-rsa-bits', config=True, description='Reject RSA host and public keys shorter than this.', default='1024', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1024, 2147483647)])))
+])
 
-SRC_DNODE_CHILD_8: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
+SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_9: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -69,27 +82,27 @@ SRC_DNODE_CHILD_8: DContainer = DContainer(module='fleetmgr', namespace='urn:fle
     ])
 ])
 
-SRC_DNODE_CHILD_9: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
+SRC_DNODE_CHILD_10: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='connection', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_10: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
+SRC_DNODE_CHILD_11: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='runtime-schema-fetch', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
 SRC_DNODE_CHILD_1: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='node', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
         DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='transform', arg='fleetmgr.cfs.Node', exts=[])
-    ], children=[SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10])
+    ], children=[SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10, SRC_DNODE_CHILD_11])
 
-SRC_DNODE_CHILD_12: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_13: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_13: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='type', config=True, description='Device platform type understood by the owning flotilla.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_14: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='type', config=True, description='Device platform type understood by the owning flotilla.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_14: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='shard', config=True, description='Name of the flotilla node that owns this device.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_15: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='shard', config=True, description='Name of the flotilla node that owns this device.', mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_15: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='description', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_16: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='description', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_16: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='address', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
+SRC_DNODE_CHILD_17: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='address', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, description="Name of address, e.g. 'loopback' or 'OOB'", mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='address', config=True, mandatory=True, type=DTypeUnion(name='inet:host', description='The host type represents either an IP address or a DNS\ndomain name.', reference=None, exts=[], builtin_type='union', default=None, types=[DTypeString(name='inet:ipv4-address', description='The ipv4-address type represents an IPv4 address in\ndotted-quad notation.  The IPv4 address may include a zone\nindex, separated by a % sign.\n\nThe zone index is used to disambiguate identical address\nvalues.  For link-local addresses, the zone index will\ntypically be the interface index number or the name of an\ninterface.  If the zone index is not present, the default\nzone of the device will be used.\n\nThe canonical format for the zone index is the numerical\nformat', reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False)]), DTypeString(name='inet:ipv6-address', description='The ipv6-address type represents an IPv6 address in full,\nmixed, shortened, and shortened-mixed notation.  The IPv6\naddress may include a zone index, separated by a % sign.\n\nThe zone index is used to disambiguate identical address\nvalues.  For link-local addresses, the zone index will\ntypically be the interface index number or the name of an\ninterface.  If the zone index is not present, the default\nzone of the device will be used.\n\nThe canonical format of IPv6 addresses uses the textual\nrepresentation defined in Section 4 of RFC 5952.  The\ncanonical format for the zone index is the numerical\nformat as described in Section 11.2 of RFC 4007.', reference='RFC 4291: IP Version 6 Addressing Architecture\nRFC 4007: IPv6 Scoped Address Architecture\nRFC 5952: A Recommendation for IPv6 Address Text\n          Representation', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?', pcre='^(((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='(([^:]+:){{6}}(([^:]+:[^:]+)|(.*\\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?', pcre='^((([^\\:]+:){{6}}(([^\\:]+:[^\\:]+)|(.*\\..*)))|((([^\\:]+:)*[^\\:]+)?::(([^\\:]+:)*[^\\:]+)?)(%.+)?)$', invert=False)]), DTypeString(name='inet:domain-name', description='The domain-name type represents a DNS domain name.  The\nname SHOULD be fully qualified whenever possible.\n\nInternet domain names are only loosely specified.  Section\n3.5 of RFC 1034 recommends a syntax (modified in Section\n2.1 of RFC 1123).  The pattern above is intended to allow\nfor current practice in domain name use, and some possible\nfuture expansion.  It is designed to hold various types of\ndomain names, including names used for A or AAAA records\n(host names) and other records, such as SRV records.  Note\nthat Internet host names have a stricter syntax (described\nin RFC 952) than the DNS recommendations in RFCs 1034 and\n1123, and that systems that want to store host names in\nschema nodes using the domain-name type are recommended to\nadhere to this stricter standard to ensure interoperability.\n\nThe encoding of DNS names in the DNS protocol is limited\nto 255 characters.  Since the encoding consists of labels\nprefixed by a length bytes and there is a trailing NULL\nbyte, only 253 characters can appear in the textual dotted\nnotation.\n\nThe description clause of schema nodes using the domain-name\ntype MUST describe when and how these names are resolved to\nIP addresses.  Note that the resolution of a domain-name value\nmay require to query multiple DNS records (e.g., A for IPv4\nand AAAA for IPv6).  The order of the resolution process and\nwhich DNS record takes precedence can either be defined\nexplicitly or may depend on the configuration of the\nresolver.\n\nDomain-name values use the US-ASCII encoding.  Their canonical\nformat uses lowercase US-ASCII characters.  Internationalized\ndomain names MUST be A-labels as per RFC 5890.', reference='RFC  952: DoD Internet Host Table Specification\nRFC 1034: Domain Names - Concepts and Facilities\nRFC 1123: Requirements for Internet Hosts -- Application\n          and Support\nRFC 2782: A DNS RR for specifying the location of services\n          (DNS SRV)\nRFC 5890: Internationalized Domain Names in Applications\n          (IDNA): Definitions and Document Framework', exts=[], builtin_type='string', default=None, length=Ranges([(1, 253)]), patterns=[YangPattern(yang_regex='((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.', pcre='^(((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.)$', invert=False)])])),
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='port', config=True, mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)]))),
@@ -104,7 +117,7 @@ SRC_DNODE_CHILD_16: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fle
     ])
 ])
 
-SRC_DNODE_CHILD_17: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='credentials', config=True, presence=False, children=[
+SRC_DNODE_CHILD_18: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='credentials', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='username', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='password', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key', key=['key'], config=True, min_elements=0, ordered_by='system', children=[
@@ -113,7 +126,7 @@ SRC_DNODE_CHILD_17: DContainer = DContainer(module='fleetmgr', namespace='urn:fl
     ])
 ])
 
-SRC_DNODE_CHILD_18: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='initial-credentials', key=[
+SRC_DNODE_CHILD_19: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='initial-credentials', key=[
 'username',
 'password',
 'key'
@@ -123,9 +136,22 @@ SRC_DNODE_CHILD_18: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fle
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_19: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_20: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
+    DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='minimum-rsa-bits', config=True, description='Reject RSA host and public keys shorter than this.', default='1024', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1024, 2147483647)])))
+])
 
-SRC_DNODE_CHILD_20: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
+SRC_DNODE_CHILD_21: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_22: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -135,21 +161,21 @@ SRC_DNODE_CHILD_20: DContainer = DContainer(module='fleetmgr', namespace='urn:fl
     ])
 ])
 
-SRC_DNODE_CHILD_21: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
+SRC_DNODE_CHILD_23: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='debug', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='connection', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_22: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
+SRC_DNODE_CHILD_24: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='feature-flags', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='runtime-schema-fetch', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_11: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
+SRC_DNODE_CHILD_12: DList = DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
         DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='transform', arg='fleetmgr.cfs.Device', exts=[])
-    ], children=[SRC_DNODE_CHILD_12, SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16, SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22])
+    ], children=[SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16, SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24])
 
-SRC_DNODE_CHILD_0: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='fleet', config=True, presence=False, children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_11])
+SRC_DNODE_CHILD_0: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='fleet', config=True, presence=False, children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_12])
 
-SRC_DNODE_CHILD_23: DContainer = DContainer(module='software', namespace='urn:fleetmgr:software', prefix='sw-cfs', name='software', config=True, presence=False, children=[
+SRC_DNODE_CHILD_25: DContainer = DContainer(module='software', namespace='urn:fleetmgr:software', prefix='sw-cfs', name='software', config=True, presence=False, children=[
     DList(module='software', namespace='urn:fleetmgr:software', prefix='sw-cfs', name='upgrade-campaign', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
             DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='transform', arg='fleetmgr.cfs.UpgradeCampaign', exts=[])
         ], children=[
@@ -178,10 +204,10 @@ SRC_DNODE_CHILD_23: DContainer = DContainer(module='software', namespace='urn:fl
 ])
 
 SRC_DNODE: DRoot = DRoot(
-    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_23],
+    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_25],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:fleetmgr':('fleetmgr', None), 'urn:fleetmgr:software':('software', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:fleetmgr':('fleetmgr', None), 'urn:fleetmgr:software':('software', None)},
 )
 
 SRC_YANG_0: str = r"""module fleetmgr {
@@ -331,6 +357,9 @@ SRC_YANG_2: str = r"""module fleetmgr-types {
   import ietf-inet-types {
     prefix inet;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
 
   grouping device-options {
     leaf description {
@@ -394,6 +423,13 @@ SRC_YANG_2: str = r"""module fleetmgr-types {
       leaf key {
         type string;
       }
+    }
+
+    container ssh {
+      description
+        "SSH transport parameters used when connecting to this device. Applies
+         to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -532,7 +568,220 @@ SRC_YANG_3: str = r"""module stratoweave {
   }
 }"""
 
-SRC_YANG_4: str = r"""module ietf-inet-types {
+SRC_YANG_4: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_5: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -999,10 +1248,12 @@ pure def src_yang() -> list[str]:
         SRC_YANG_2,
         SRC_YANG_3,
         SRC_YANG_4,
+        SRC_YANG_5,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_fleetmgr: str = 'urn:fleetmgr:fleetmgr'
 NS_software: str = 'urn:fleetmgr:software'
 NS_fleetmgr_types: str = 'urn:fleetmgr:types'
@@ -1034,7 +1285,7 @@ class fleetmgr__fleet__node__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class fleetmgr__fleet__node__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__node__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__node__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1042,7 +1293,7 @@ class fleetmgr__fleet__node__address__initial_credentials(yadata.MKeyedList[(use
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__node__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1089,7 +1340,7 @@ class fleetmgr__fleet__node__address_entry(yadata.MNode):
 _breaker4: None = None
 class fleetmgr__fleet__node__address(yadata.MKeyedList[str, fleetmgr__fleet__node__address_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> fleetmgr__fleet__node__address_entry:
         e = self.get(key)
@@ -1101,7 +1352,7 @@ class fleetmgr__fleet__node__address(yadata.MKeyedList[str, fleetmgr__fleet__nod
             return e
         name = key
         res = fleetmgr__fleet__node__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1144,7 +1395,7 @@ class fleetmgr__fleet__node__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class fleetmgr__fleet__node__credentials__key(yadata.MKeyedList[str, fleetmgr__fleet__node__credentials__key_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> fleetmgr__fleet__node__credentials__key_entry:
         e = self.get(key_)
@@ -1154,7 +1405,7 @@ class fleetmgr__fleet__node__credentials__key(yadata.MKeyedList[str, fleetmgr__f
             return e
         key = key_
         res = fleetmgr__fleet__node__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1224,7 +1475,7 @@ class fleetmgr__fleet__node__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class fleetmgr__fleet__node__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__node__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__node__initial_credentials_entry:
         e = self.get(key_)
@@ -1232,7 +1483,7 @@ class fleetmgr__fleet__node__initial_credentials(yadata.MKeyedList[(username: st
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__node__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1253,6 +1504,45 @@ class fleetmgr__fleet__node__initial_credentials(yadata.MKeyedList[(username: st
 
 
 _breaker10: None = None
+class fleetmgr__fleet__node__ssh(yadata.MNode):
+    cipher: list[str]
+    mac: list[str]
+    key_exchange: list[str]
+    host_key_algorithm: list[str]
+    public_key_algorithm: list[str]
+    compression_algorithm: list[str]
+    compression_level: ?u64
+    rekey_after_bytes: ?u64
+    rekey_after_seconds: ?u64
+    minimum_rsa_bits: ?u64
+
+    mut def __init__(self, cipher: ?list[str]=None, mac: ?list[str]=None, key_exchange: ?list[str]=None, host_key_algorithm: ?list[str]=None, public_key_algorithm: ?list[str]=None, compression_algorithm: ?list[str]=None, compression_level: ?u64, rekey_after_bytes: ?u64, rekey_after_seconds: ?u64, minimum_rsa_bits: ?u64) -> None:
+        self.cipher = cipher if cipher is not None else []
+        self.mac = mac if mac is not None else []
+        self.key_exchange = key_exchange if key_exchange is not None else []
+        self.host_key_algorithm = host_key_algorithm if host_key_algorithm is not None else []
+        self.public_key_algorithm = public_key_algorithm if public_key_algorithm is not None else []
+        self.compression_algorithm = compression_algorithm if compression_algorithm is not None else []
+        self.compression_level = compression_level
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['fleetmgr:fleet', 'node', 'ssh'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__node__ssh:
+        if n is not None:
+            return fleetmgr__fleet__node__ssh(cipher=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'cipher')), mac=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'mac')), key_exchange=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'key-exchange')), host_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'host-key-algorithm')), public_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'public-key-algorithm')), compression_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'compression-algorithm')), compression_level=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'compression-level')), rekey_after_bytes=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-bytes')), rekey_after_seconds=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-seconds')), minimum_rsa_bits=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'minimum-rsa-bits')))
+        return fleetmgr__fleet__node__ssh()
+
+    mut def copy(self) -> fleetmgr__fleet__node__ssh:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__node__ssh.from_gdata(self.to_gdata())
+
+
+_breaker11: None = None
 class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -1276,10 +1566,10 @@ class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker11: None = None
+_breaker12: None = None
 class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__node__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> fleetmgr__fleet__node__mock__module_entry:
         e = self.get(key)
@@ -1291,7 +1581,7 @@ class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet
             return e
         name = key
         res = fleetmgr__fleet__node__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1311,7 +1601,7 @@ class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet
         return fleetmgr__fleet__node__mock__module(elements=copied_elements)
 
 
-_breaker12: None = None
+_breaker13: None = None
 class fleetmgr__fleet__node__mock(yadata.MNode):
     enabled: ?bool
     module: fleetmgr__fleet__node__mock__module
@@ -1334,7 +1624,7 @@ class fleetmgr__fleet__node__mock(yadata.MNode):
         return fleetmgr__fleet__node__mock.from_gdata(self.to_gdata())
 
 
-_breaker13: None = None
+_breaker14: None = None
 class fleetmgr__fleet__node__debug(yadata.MNode):
     connection: ?bool
 
@@ -1355,7 +1645,7 @@ class fleetmgr__fleet__node__debug(yadata.MNode):
         return fleetmgr__fleet__node__debug.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class fleetmgr__fleet__node__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -1376,24 +1666,26 @@ class fleetmgr__fleet__node__feature_flags(yadata.MNode):
         return fleetmgr__fleet__node__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class fleetmgr__fleet__node_entry(yadata.MNode):
     name: str
     description: ?str
     address: fleetmgr__fleet__node__address
     credentials: fleetmgr__fleet__node__credentials
     initial_credentials: fleetmgr__fleet__node__initial_credentials
+    ssh: fleetmgr__fleet__node__ssh
     approval_required: ?bool
     mock: fleetmgr__fleet__node__mock
     debug: fleetmgr__fleet__node__debug
     feature_flags: fleetmgr__fleet__node__feature_flags
 
-    mut def __init__(self, name: str, description: ?str, address: list[fleetmgr__fleet__node__address_entry]=[], credentials: ?fleetmgr__fleet__node__credentials=None, initial_credentials: list[fleetmgr__fleet__node__initial_credentials_entry]=[], approval_required: ?bool, mock: ?fleetmgr__fleet__node__mock=None, debug: ?fleetmgr__fleet__node__debug=None, feature_flags: ?fleetmgr__fleet__node__feature_flags=None) -> None:
+    mut def __init__(self, name: str, description: ?str, address: list[fleetmgr__fleet__node__address_entry]=[], credentials: ?fleetmgr__fleet__node__credentials=None, initial_credentials: list[fleetmgr__fleet__node__initial_credentials_entry]=[], ssh: ?fleetmgr__fleet__node__ssh=None, approval_required: ?bool, mock: ?fleetmgr__fleet__node__mock=None, debug: ?fleetmgr__fleet__node__debug=None, feature_flags: ?fleetmgr__fleet__node__feature_flags=None) -> None:
         self.name = name
         self.description = description
         self.address = fleetmgr__fleet__node__address(elements=address)
         self.credentials = credentials if credentials is not None else fleetmgr__fleet__node__credentials()
         self.initial_credentials = fleetmgr__fleet__node__initial_credentials(elements=initial_credentials)
+        self.ssh = ssh if ssh is not None else fleetmgr__fleet__node__ssh()
         self.approval_required = approval_required
         self.mock = mock if mock is not None else fleetmgr__fleet__node__mock()
         self.debug = debug if debug is not None else fleetmgr__fleet__node__debug()
@@ -1404,16 +1696,16 @@ class fleetmgr__fleet__node_entry(yadata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ygdata.Node) -> fleetmgr__fleet__node_entry:
-        return fleetmgr__fleet__node_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__node__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__node__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__node__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__node__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__node__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__node__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
+        return fleetmgr__fleet__node_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__node__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__node__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__node__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), ssh=fleetmgr__fleet__node__ssh.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'ssh'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__node__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__node__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__node__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
 
     mut def copy(self) -> fleetmgr__fleet__node_entry:
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node_entry.from_gdata(self.to_gdata())
 
-_breaker16: None = None
+_breaker17: None = None
 class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, description: ?str=None, approval_required: ?bool=None) -> fleetmgr__fleet__node_entry:
         e = self.get(key)
@@ -1425,7 +1717,7 @@ class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry])
             return e
         name = key
         res = fleetmgr__fleet__node_entry(name=name, description=description, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1445,7 +1737,7 @@ class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry])
         return fleetmgr__fleet__node(elements=copied_elements)
 
 
-_breaker17: None = None
+_breaker18: None = None
 class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1467,10 +1759,10 @@ class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker18: None = None
+_breaker19: None = None
 class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1478,7 +1770,7 @@ class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1498,7 +1790,7 @@ class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(u
         return fleetmgr__fleet__device__address__initial_credentials(elements=copied_elements)
 
 
-_breaker19: None = None
+_breaker20: None = None
 class fleetmgr__fleet__device__address_entry(yadata.MNode):
     name: str
     address: ?str
@@ -1522,10 +1814,10 @@ class fleetmgr__fleet__device__address_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker20: None = None
+_breaker21: None = None
 class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__device__address_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> fleetmgr__fleet__device__address_entry:
         e = self.get(key)
@@ -1537,7 +1829,7 @@ class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__d
             return e
         name = key
         res = fleetmgr__fleet__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1557,7 +1849,7 @@ class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__d
         return fleetmgr__fleet__device__address(elements=copied_elements)
 
 
-_breaker21: None = None
+_breaker22: None = None
 class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
     key: str
     private_key: ?str
@@ -1577,10 +1869,10 @@ class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker22: None = None
+_breaker23: None = None
 class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr__fleet__device__credentials__key_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> fleetmgr__fleet__device__credentials__key_entry:
         e = self.get(key_)
@@ -1590,7 +1882,7 @@ class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr_
             return e
         key = key_
         res = fleetmgr__fleet__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1610,7 +1902,7 @@ class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr_
         return fleetmgr__fleet__device__credentials__key(elements=copied_elements)
 
 
-_breaker23: None = None
+_breaker24: None = None
 class fleetmgr__fleet__device__credentials(yadata.MNode):
     username: ?str
     password: ?str
@@ -1635,7 +1927,7 @@ class fleetmgr__fleet__device__credentials(yadata.MNode):
         return fleetmgr__fleet__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker24: None = None
+_breaker25: None = None
 class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1657,10 +1949,10 @@ class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker25: None = None
+_breaker26: None = None
 class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> fleetmgr__fleet__device__initial_credentials_entry:
         e = self.get(key_)
@@ -1668,7 +1960,7 @@ class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = fleetmgr__fleet__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1688,7 +1980,46 @@ class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: 
         return fleetmgr__fleet__device__initial_credentials(elements=copied_elements)
 
 
-_breaker26: None = None
+_breaker27: None = None
+class fleetmgr__fleet__device__ssh(yadata.MNode):
+    cipher: list[str]
+    mac: list[str]
+    key_exchange: list[str]
+    host_key_algorithm: list[str]
+    public_key_algorithm: list[str]
+    compression_algorithm: list[str]
+    compression_level: ?u64
+    rekey_after_bytes: ?u64
+    rekey_after_seconds: ?u64
+    minimum_rsa_bits: ?u64
+
+    mut def __init__(self, cipher: ?list[str]=None, mac: ?list[str]=None, key_exchange: ?list[str]=None, host_key_algorithm: ?list[str]=None, public_key_algorithm: ?list[str]=None, compression_algorithm: ?list[str]=None, compression_level: ?u64, rekey_after_bytes: ?u64, rekey_after_seconds: ?u64, minimum_rsa_bits: ?u64) -> None:
+        self.cipher = cipher if cipher is not None else []
+        self.mac = mac if mac is not None else []
+        self.key_exchange = key_exchange if key_exchange is not None else []
+        self.host_key_algorithm = host_key_algorithm if host_key_algorithm is not None else []
+        self.public_key_algorithm = public_key_algorithm if public_key_algorithm is not None else []
+        self.compression_algorithm = compression_algorithm if compression_algorithm is not None else []
+        self.compression_level = compression_level
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['fleetmgr:fleet', 'device', 'ssh'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__device__ssh:
+        if n is not None:
+            return fleetmgr__fleet__device__ssh(cipher=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'cipher')), mac=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'mac')), key_exchange=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'key-exchange')), host_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'host-key-algorithm')), public_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'public-key-algorithm')), compression_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr, 'compression-algorithm')), compression_level=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'compression-level')), rekey_after_bytes=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-bytes')), rekey_after_seconds=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'rekey-after-seconds')), minimum_rsa_bits=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'minimum-rsa-bits')))
+        return fleetmgr__fleet__device__ssh()
+
+    mut def copy(self) -> fleetmgr__fleet__device__ssh:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__device__ssh.from_gdata(self.to_gdata())
+
+
+_breaker28: None = None
 class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -1712,10 +2043,10 @@ class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker27: None = None
+_breaker29: None = None
 class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__device__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> fleetmgr__fleet__device__mock__module_entry:
         e = self.get(key)
@@ -1727,7 +2058,7 @@ class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fle
             return e
         name = key
         res = fleetmgr__fleet__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1747,7 +2078,7 @@ class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fle
         return fleetmgr__fleet__device__mock__module(elements=copied_elements)
 
 
-_breaker28: None = None
+_breaker30: None = None
 class fleetmgr__fleet__device__mock(yadata.MNode):
     enabled: ?bool
     module: fleetmgr__fleet__device__mock__module
@@ -1770,7 +2101,7 @@ class fleetmgr__fleet__device__mock(yadata.MNode):
         return fleetmgr__fleet__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker29: None = None
+_breaker31: None = None
 class fleetmgr__fleet__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -1791,7 +2122,7 @@ class fleetmgr__fleet__device__debug(yadata.MNode):
         return fleetmgr__fleet__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker30: None = None
+_breaker32: None = None
 class fleetmgr__fleet__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -1812,7 +2143,7 @@ class fleetmgr__fleet__device__feature_flags(yadata.MNode):
         return fleetmgr__fleet__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker31: None = None
+_breaker33: None = None
 class fleetmgr__fleet__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -1821,12 +2152,13 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
     address: fleetmgr__fleet__device__address
     credentials: fleetmgr__fleet__device__credentials
     initial_credentials: fleetmgr__fleet__device__initial_credentials
+    ssh: fleetmgr__fleet__device__ssh
     approval_required: ?bool
     mock: fleetmgr__fleet__device__mock
     debug: fleetmgr__fleet__device__debug
     feature_flags: fleetmgr__fleet__device__feature_flags
 
-    mut def __init__(self, name: str, type: ?str, shard: ?str, description: ?str, address: list[fleetmgr__fleet__device__address_entry]=[], credentials: ?fleetmgr__fleet__device__credentials=None, initial_credentials: list[fleetmgr__fleet__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?fleetmgr__fleet__device__mock=None, debug: ?fleetmgr__fleet__device__debug=None, feature_flags: ?fleetmgr__fleet__device__feature_flags=None) -> None:
+    mut def __init__(self, name: str, type: ?str, shard: ?str, description: ?str, address: list[fleetmgr__fleet__device__address_entry]=[], credentials: ?fleetmgr__fleet__device__credentials=None, initial_credentials: list[fleetmgr__fleet__device__initial_credentials_entry]=[], ssh: ?fleetmgr__fleet__device__ssh=None, approval_required: ?bool, mock: ?fleetmgr__fleet__device__mock=None, debug: ?fleetmgr__fleet__device__debug=None, feature_flags: ?fleetmgr__fleet__device__feature_flags=None) -> None:
         self.name = name
         self.type = type
         self.shard = shard
@@ -1834,6 +2166,7 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
         self.address = fleetmgr__fleet__device__address(elements=address)
         self.credentials = credentials if credentials is not None else fleetmgr__fleet__device__credentials()
         self.initial_credentials = fleetmgr__fleet__device__initial_credentials(elements=initial_credentials)
+        self.ssh = ssh if ssh is not None else fleetmgr__fleet__device__ssh()
         self.approval_required = approval_required
         self.mock = mock if mock is not None else fleetmgr__fleet__device__mock()
         self.debug = debug if debug is not None else fleetmgr__fleet__device__debug()
@@ -1844,16 +2177,16 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ygdata.Node) -> fleetmgr__fleet__device_entry:
-        return fleetmgr__fleet__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), type=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'type')), shard=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'shard')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__device__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
+        return fleetmgr__fleet__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr, 'name')), type=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'type')), shard=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'shard')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'description')), address=fleetmgr__fleet__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'address'))), credentials=fleetmgr__fleet__device__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'credentials'))), initial_credentials=fleetmgr__fleet__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'initial-credentials'))), ssh=fleetmgr__fleet__device__ssh.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'ssh'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'approval-required')), mock=fleetmgr__fleet__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'mock'))), debug=fleetmgr__fleet__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'debug'))), feature_flags=fleetmgr__fleet__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'feature-flags'))))
 
     mut def copy(self) -> fleetmgr__fleet__device_entry:
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device_entry.from_gdata(self.to_gdata())
 
-_breaker32: None = None
+_breaker34: None = None
 class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, type: ?str=None, shard: ?str=None, description: ?str=None, approval_required: ?bool=None) -> fleetmgr__fleet__device_entry:
         e = self.get(key)
@@ -1869,7 +2202,7 @@ class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_ent
             return e
         name = key
         res = fleetmgr__fleet__device_entry(name=name, type=type, shard=shard, description=description, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1889,7 +2222,7 @@ class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_ent
         return fleetmgr__fleet__device(elements=copied_elements)
 
 
-_breaker33: None = None
+_breaker35: None = None
 class fleetmgr__fleet(yadata.MNode):
     node: fleetmgr__fleet__node
     device: fleetmgr__fleet__device
@@ -1912,7 +2245,7 @@ class fleetmgr__fleet(yadata.MNode):
         return fleetmgr__fleet.from_gdata(self.to_gdata())
 
 
-_breaker34: None = None
+_breaker36: None = None
 class software__software__upgrade_campaign__device_entry(yadata.MNode):
     name: str
 
@@ -1930,10 +2263,10 @@ class software__software__upgrade_campaign__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign__device_entry.from_gdata(self.to_gdata())
 
-_breaker35: None = None
+_breaker37: None = None
 class software__software__upgrade_campaign__device(yadata.MKeyedList[str, software__software__upgrade_campaign__device_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> software__software__upgrade_campaign__device_entry:
         e = self.get(key)
@@ -1941,7 +2274,7 @@ class software__software__upgrade_campaign__device(yadata.MKeyedList[str, softwa
             return e
         name = key
         res = software__software__upgrade_campaign__device_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -1961,7 +2294,7 @@ class software__software__upgrade_campaign__device(yadata.MKeyedList[str, softwa
         return software__software__upgrade_campaign__device(elements=copied_elements)
 
 
-_breaker36: None = None
+_breaker38: None = None
 class software__software__upgrade_campaign__state__device_status_entry(yadata.MNode):
     device: str
     status: ?str
@@ -1983,10 +2316,10 @@ class software__software__upgrade_campaign__state__device_status_entry(yadata.MN
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign__state__device_status_entry.from_gdata(self.to_gdata())
 
-_breaker37: None = None
+_breaker39: None = None
 class software__software__upgrade_campaign__state__device_status(yadata.MKeyedList[str, software__software__upgrade_campaign__state__device_status_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign__state__device_status_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.device == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.device, elements)
 
     mut def create(self, key: str, status: ?str=None, running_release: ?str=None) -> software__software__upgrade_campaign__state__device_status_entry:
         e = self.get(key)
@@ -1998,7 +2331,7 @@ class software__software__upgrade_campaign__state__device_status(yadata.MKeyedLi
             return e
         device = key
         res = software__software__upgrade_campaign__state__device_status_entry(device=device, status=status, running_release=running_release)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2018,7 +2351,7 @@ class software__software__upgrade_campaign__state__device_status(yadata.MKeyedLi
         return software__software__upgrade_campaign__state__device_status(elements=copied_elements)
 
 
-_breaker38: None = None
+_breaker40: None = None
 class software__software__upgrade_campaign__state(yadata.MNode):
     total: ?u64
     in_progress: ?u64
@@ -2047,7 +2380,7 @@ class software__software__upgrade_campaign__state(yadata.MNode):
         return software__software__upgrade_campaign__state.from_gdata(self.to_gdata())
 
 
-_breaker39: None = None
+_breaker41: None = None
 class software__software__upgrade_campaign_entry(yadata.MNode):
     name: str
     target_release: ?str
@@ -2077,10 +2410,10 @@ class software__software__upgrade_campaign_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign_entry.from_gdata(self.to_gdata())
 
-_breaker40: None = None
+_breaker42: None = None
 class software__software__upgrade_campaign(yadata.MKeyedList[str, software__software__upgrade_campaign_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, target_release: ?str=None, image_url: ?str=None, allow_staging: ?bool=None, admin_state: ?str=None) -> software__software__upgrade_campaign_entry:
         e = self.get(key)
@@ -2096,7 +2429,7 @@ class software__software__upgrade_campaign(yadata.MKeyedList[str, software__soft
             return e
         name = key
         res = software__software__upgrade_campaign_entry(name=name, target_release=target_release, image_url=image_url, allow_staging=allow_staging, admin_state=admin_state)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2116,7 +2449,7 @@ class software__software__upgrade_campaign(yadata.MKeyedList[str, software__soft
         return software__software__upgrade_campaign(elements=copied_elements)
 
 
-_breaker41: None = None
+_breaker43: None = None
 class software__software(yadata.MNode):
     upgrade_campaign: software__software__upgrade_campaign
 
@@ -2137,7 +2470,7 @@ class software__software(yadata.MNode):
         return software__software.from_gdata(self.to_gdata())
 
 
-_breaker42: None = None
+_breaker44: None = None
 class root(yadata.MNode):
     fleet: fleetmgr__fleet
     software: software__software
@@ -2165,7 +2498,7 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
-_breaker43: None = None
+_breaker45: None = None
 class fleetmgr__fleet__node__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2181,7 +2514,7 @@ class fleetmgr__fleet__node__address__initial_credentials_entry_subs(Subscriptio
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker44: None = None
+_breaker46: None = None
 class fleetmgr__fleet__node__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2205,7 +2538,7 @@ class fleetmgr__fleet__node__address__initial_credentials_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker45: None = None
+_breaker47: None = None
 class fleetmgr__fleet__node__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2223,7 +2556,7 @@ class fleetmgr__fleet__node__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker46: None = None
+_breaker48: None = None
 class fleetmgr__fleet__node__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2247,7 +2580,7 @@ class fleetmgr__fleet__node__address_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker47: None = None
+_breaker49: None = None
 class fleetmgr__fleet__node__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2261,7 +2594,7 @@ class fleetmgr__fleet__node__credentials__key_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker48: None = None
+_breaker50: None = None
 class fleetmgr__fleet__node__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2281,7 +2614,7 @@ class fleetmgr__fleet__node__credentials__key_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker49: None = None
+_breaker51: None = None
 class fleetmgr__fleet__node__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2297,7 +2630,7 @@ class fleetmgr__fleet__node__credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker50: None = None
+_breaker52: None = None
 class fleetmgr__fleet__node__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2313,7 +2646,7 @@ class fleetmgr__fleet__node__initial_credentials_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker51: None = None
+_breaker53: None = None
 class fleetmgr__fleet__node__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2337,7 +2670,37 @@ class fleetmgr__fleet__node__initial_credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker52: None = None
+_breaker54: None = None
+class fleetmgr__fleet__node__ssh_subs(SubscriptionNode):
+    cipher: SubscriptionNode
+    mac: SubscriptionNode
+    key_exchange: SubscriptionNode
+    host_key_algorithm: SubscriptionNode
+    public_key_algorithm: SubscriptionNode
+    compression_algorithm: SubscriptionNode
+    compression_level: SubscriptionNode
+    rekey_after_bytes: SubscriptionNode
+    rekey_after_seconds: SubscriptionNode
+    minimum_rsa_bits: SubscriptionNode
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.cipher = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'cipher'), parent=path))
+        self.mac = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'mac'), parent=path))
+        self.key_exchange = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'key-exchange'), parent=path))
+        self.host_key_algorithm = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'host-key-algorithm'), parent=path))
+        self.public_key_algorithm = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'public-key-algorithm'), parent=path))
+        self.compression_algorithm = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'compression-algorithm'), parent=path))
+        self.compression_level = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'compression-level'), parent=path))
+        self.rekey_after_bytes = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'rekey-after-bytes'), parent=path))
+        self.rekey_after_seconds = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'rekey-after-seconds'), parent=path))
+        self.minimum_rsa_bits = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'minimum-rsa-bits'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
+        return direct
+
+_breaker55: None = None
 class fleetmgr__fleet__node__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -2355,7 +2718,7 @@ class fleetmgr__fleet__node__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker53: None = None
+_breaker56: None = None
 class fleetmgr__fleet__node__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -2379,7 +2742,7 @@ class fleetmgr__fleet__node__mock__module_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker54: None = None
+_breaker57: None = None
 class fleetmgr__fleet__node__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
     module: fleetmgr__fleet__node__mock__module_subs
@@ -2393,7 +2756,7 @@ class fleetmgr__fleet__node__mock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.module]
         return direct
 
-_breaker55: None = None
+_breaker58: None = None
 class fleetmgr__fleet__node__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -2405,7 +2768,7 @@ class fleetmgr__fleet__node__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
-_breaker56: None = None
+_breaker59: None = None
 class fleetmgr__fleet__node__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -2417,13 +2780,14 @@ class fleetmgr__fleet__node__feature_flags_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
 
-_breaker57: None = None
+_breaker60: None = None
 class fleetmgr__fleet__node_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
     address: fleetmgr__fleet__node__address_subs
     credentials: fleetmgr__fleet__node__credentials_subs
     initial_credentials: fleetmgr__fleet__node__initial_credentials_subs
+    ssh: fleetmgr__fleet__node__ssh_subs
     approval_required: SubscriptionNode
     mock: fleetmgr__fleet__node__mock_subs
     debug: fleetmgr__fleet__node__debug_subs
@@ -2436,22 +2800,24 @@ class fleetmgr__fleet__node_entry_subs(SubscriptionNode):
         self.address = fleetmgr__fleet__node__address_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'address'), parent=path))
         self.credentials = fleetmgr__fleet__node__credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'credentials'), parent=path))
         self.initial_credentials = fleetmgr__fleet__node__initial_credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'initial-credentials'), parent=path))
+        self.ssh = fleetmgr__fleet__node__ssh_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'ssh'), parent=path))
         self.approval_required = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'approval-required'), parent=path))
         self.mock = fleetmgr__fleet__node__mock_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'mock'), parent=path))
         self.debug = fleetmgr__fleet__node__debug_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'debug'), parent=path))
         self.feature_flags = fleetmgr__fleet__node__feature_flags_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'feature-flags'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.name, self.description, self.address, self.credentials, self.initial_credentials, self.approval_required, self.mock, self.debug, self.feature_flags]
+        direct: list[SubscriptionNode] = [self.name, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
 
-_breaker58: None = None
+_breaker61: None = None
 class fleetmgr__fleet__node_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
     address: fleetmgr__fleet__node__address_subs
     credentials: fleetmgr__fleet__node__credentials_subs
     initial_credentials: fleetmgr__fleet__node__initial_credentials_subs
+    ssh: fleetmgr__fleet__node__ssh_subs
     approval_required: SubscriptionNode
     mock: fleetmgr__fleet__node__mock_subs
     debug: fleetmgr__fleet__node__debug_subs
@@ -2463,6 +2829,7 @@ class fleetmgr__fleet__node_subs(SubscriptionNode):
         self.address = fleetmgr__fleet__node__address_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'address'), parent=path))
         self.credentials = fleetmgr__fleet__node__credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'credentials'), parent=path))
         self.initial_credentials = fleetmgr__fleet__node__initial_credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'initial-credentials'), parent=path))
+        self.ssh = fleetmgr__fleet__node__ssh_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'ssh'), parent=path))
         self.approval_required = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'approval-required'), parent=path))
         self.mock = fleetmgr__fleet__node__mock_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'mock'), parent=path))
         self.debug = fleetmgr__fleet__node__debug_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'debug'), parent=path))
@@ -2476,10 +2843,10 @@ class fleetmgr__fleet__node_subs(SubscriptionNode):
         return fleetmgr__fleet__node_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'node'), predicates=predicates, parent=base_path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.name, self.description, self.address, self.credentials, self.initial_credentials, self.approval_required, self.mock, self.debug, self.feature_flags]
+        direct: list[SubscriptionNode] = [self.name, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
 
-_breaker59: None = None
+_breaker62: None = None
 class fleetmgr__fleet__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2495,7 +2862,7 @@ class fleetmgr__fleet__device__address__initial_credentials_entry_subs(Subscript
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker60: None = None
+_breaker63: None = None
 class fleetmgr__fleet__device__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2519,7 +2886,7 @@ class fleetmgr__fleet__device__address__initial_credentials_subs(SubscriptionNod
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker61: None = None
+_breaker64: None = None
 class fleetmgr__fleet__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2537,7 +2904,7 @@ class fleetmgr__fleet__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker62: None = None
+_breaker65: None = None
 class fleetmgr__fleet__device__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2561,7 +2928,7 @@ class fleetmgr__fleet__device__address_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker63: None = None
+_breaker66: None = None
 class fleetmgr__fleet__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2575,7 +2942,7 @@ class fleetmgr__fleet__device__credentials__key_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker64: None = None
+_breaker67: None = None
 class fleetmgr__fleet__device__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2595,7 +2962,7 @@ class fleetmgr__fleet__device__credentials__key_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker65: None = None
+_breaker68: None = None
 class fleetmgr__fleet__device__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2611,7 +2978,7 @@ class fleetmgr__fleet__device__credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker66: None = None
+_breaker69: None = None
 class fleetmgr__fleet__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2627,7 +2994,7 @@ class fleetmgr__fleet__device__initial_credentials_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker67: None = None
+_breaker70: None = None
 class fleetmgr__fleet__device__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2651,7 +3018,37 @@ class fleetmgr__fleet__device__initial_credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker68: None = None
+_breaker71: None = None
+class fleetmgr__fleet__device__ssh_subs(SubscriptionNode):
+    cipher: SubscriptionNode
+    mac: SubscriptionNode
+    key_exchange: SubscriptionNode
+    host_key_algorithm: SubscriptionNode
+    public_key_algorithm: SubscriptionNode
+    compression_algorithm: SubscriptionNode
+    compression_level: SubscriptionNode
+    rekey_after_bytes: SubscriptionNode
+    rekey_after_seconds: SubscriptionNode
+    minimum_rsa_bits: SubscriptionNode
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.cipher = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'cipher'), parent=path))
+        self.mac = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'mac'), parent=path))
+        self.key_exchange = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'key-exchange'), parent=path))
+        self.host_key_algorithm = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'host-key-algorithm'), parent=path))
+        self.public_key_algorithm = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'public-key-algorithm'), parent=path))
+        self.compression_algorithm = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'compression-algorithm'), parent=path))
+        self.compression_level = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'compression-level'), parent=path))
+        self.rekey_after_bytes = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'rekey-after-bytes'), parent=path))
+        self.rekey_after_seconds = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'rekey-after-seconds'), parent=path))
+        self.minimum_rsa_bits = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'minimum-rsa-bits'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
+        return direct
+
+_breaker72: None = None
 class fleetmgr__fleet__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -2669,7 +3066,7 @@ class fleetmgr__fleet__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker69: None = None
+_breaker73: None = None
 class fleetmgr__fleet__device__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -2693,7 +3090,7 @@ class fleetmgr__fleet__device__mock__module_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker70: None = None
+_breaker74: None = None
 class fleetmgr__fleet__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
     module: fleetmgr__fleet__device__mock__module_subs
@@ -2707,7 +3104,7 @@ class fleetmgr__fleet__device__mock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.module]
         return direct
 
-_breaker71: None = None
+_breaker75: None = None
 class fleetmgr__fleet__device__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -2719,7 +3116,7 @@ class fleetmgr__fleet__device__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
-_breaker72: None = None
+_breaker76: None = None
 class fleetmgr__fleet__device__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -2731,7 +3128,7 @@ class fleetmgr__fleet__device__feature_flags_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
 
-_breaker73: None = None
+_breaker77: None = None
 class fleetmgr__fleet__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -2740,6 +3137,7 @@ class fleetmgr__fleet__device_entry_subs(SubscriptionNode):
     address: fleetmgr__fleet__device__address_subs
     credentials: fleetmgr__fleet__device__credentials_subs
     initial_credentials: fleetmgr__fleet__device__initial_credentials_subs
+    ssh: fleetmgr__fleet__device__ssh_subs
     approval_required: SubscriptionNode
     mock: fleetmgr__fleet__device__mock_subs
     debug: fleetmgr__fleet__device__debug_subs
@@ -2754,16 +3152,17 @@ class fleetmgr__fleet__device_entry_subs(SubscriptionNode):
         self.address = fleetmgr__fleet__device__address_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'address'), parent=path))
         self.credentials = fleetmgr__fleet__device__credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'credentials'), parent=path))
         self.initial_credentials = fleetmgr__fleet__device__initial_credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'initial-credentials'), parent=path))
+        self.ssh = fleetmgr__fleet__device__ssh_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'ssh'), parent=path))
         self.approval_required = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'approval-required'), parent=path))
         self.mock = fleetmgr__fleet__device__mock_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'mock'), parent=path))
         self.debug = fleetmgr__fleet__device__debug_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'debug'), parent=path))
         self.feature_flags = fleetmgr__fleet__device__feature_flags_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'feature-flags'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.name, self.type, self.shard, self.description, self.address, self.credentials, self.initial_credentials, self.approval_required, self.mock, self.debug, self.feature_flags]
+        direct: list[SubscriptionNode] = [self.name, self.type, self.shard, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
 
-_breaker74: None = None
+_breaker78: None = None
 class fleetmgr__fleet__device_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -2772,6 +3171,7 @@ class fleetmgr__fleet__device_subs(SubscriptionNode):
     address: fleetmgr__fleet__device__address_subs
     credentials: fleetmgr__fleet__device__credentials_subs
     initial_credentials: fleetmgr__fleet__device__initial_credentials_subs
+    ssh: fleetmgr__fleet__device__ssh_subs
     approval_required: SubscriptionNode
     mock: fleetmgr__fleet__device__mock_subs
     debug: fleetmgr__fleet__device__debug_subs
@@ -2785,6 +3185,7 @@ class fleetmgr__fleet__device_subs(SubscriptionNode):
         self.address = fleetmgr__fleet__device__address_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'address'), parent=path))
         self.credentials = fleetmgr__fleet__device__credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'credentials'), parent=path))
         self.initial_credentials = fleetmgr__fleet__device__initial_credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'initial-credentials'), parent=path))
+        self.ssh = fleetmgr__fleet__device__ssh_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'ssh'), parent=path))
         self.approval_required = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'approval-required'), parent=path))
         self.mock = fleetmgr__fleet__device__mock_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'mock'), parent=path))
         self.debug = fleetmgr__fleet__device__debug_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'debug'), parent=path))
@@ -2798,10 +3199,10 @@ class fleetmgr__fleet__device_subs(SubscriptionNode):
         return fleetmgr__fleet__device_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'device'), predicates=predicates, parent=base_path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.name, self.type, self.shard, self.description, self.address, self.credentials, self.initial_credentials, self.approval_required, self.mock, self.debug, self.feature_flags]
+        direct: list[SubscriptionNode] = [self.name, self.type, self.shard, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
 
-_breaker75: None = None
+_breaker79: None = None
 class fleetmgr__fleet_subs(SubscriptionNode):
     node: fleetmgr__fleet__node_subs
     device: fleetmgr__fleet__device_subs
@@ -2815,7 +3216,7 @@ class fleetmgr__fleet_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.node, self.device]
         return direct
 
-_breaker76: None = None
+_breaker80: None = None
 class software__software__upgrade_campaign__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
 
@@ -2827,7 +3228,7 @@ class software__software__upgrade_campaign__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name]
         return direct
 
-_breaker77: None = None
+_breaker81: None = None
 class software__software__upgrade_campaign__device_subs(SubscriptionNode):
     name: SubscriptionNode
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -2845,7 +3246,7 @@ class software__software__upgrade_campaign__device_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name]
         return direct
 
-_breaker78: None = None
+_breaker82: None = None
 class software__software__upgrade_campaign__state__device_status_entry_subs(SubscriptionNode):
     device: SubscriptionNode
     status: SubscriptionNode
@@ -2861,7 +3262,7 @@ class software__software__upgrade_campaign__state__device_status_entry_subs(Subs
         direct: list[SubscriptionNode] = [self.device, self.status, self.running_release]
         return direct
 
-_breaker79: None = None
+_breaker83: None = None
 class software__software__upgrade_campaign__state__device_status_subs(SubscriptionNode):
     device: SubscriptionNode
     status: SubscriptionNode
@@ -2883,7 +3284,7 @@ class software__software__upgrade_campaign__state__device_status_subs(Subscripti
         direct: list[SubscriptionNode] = [self.device, self.status, self.running_release]
         return direct
 
-_breaker80: None = None
+_breaker84: None = None
 class software__software__upgrade_campaign__state_subs(SubscriptionNode):
     total: SubscriptionNode
     in_progress: SubscriptionNode
@@ -2903,7 +3304,7 @@ class software__software__upgrade_campaign__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.total, self.in_progress, self.succeeded, self.failed, self.device_status]
         return direct
 
-_breaker81: None = None
+_breaker85: None = None
 class software__software__upgrade_campaign_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     target_release: SubscriptionNode
@@ -2927,7 +3328,7 @@ class software__software__upgrade_campaign_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.target_release, self.image_url, self.allow_staging, self.device, self.admin_state, self.state]
         return direct
 
-_breaker82: None = None
+_breaker86: None = None
 class software__software__upgrade_campaign_subs(SubscriptionNode):
     name: SubscriptionNode
     target_release: SubscriptionNode
@@ -2957,7 +3358,7 @@ class software__software__upgrade_campaign_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.target_release, self.image_url, self.allow_staging, self.device, self.admin_state, self.state]
         return direct
 
-_breaker83: None = None
+_breaker87: None = None
 class software__software_subs(SubscriptionNode):
     upgrade_campaign: software__software__upgrade_campaign_subs
 
@@ -2969,7 +3370,7 @@ class software__software_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.upgrade_campaign]
         return direct
 
-_breaker84: None = None
+_breaker88: None = None
 class root_subs(SubscriptionNode):
     fleet: fleetmgr__fleet_subs
     software: software__software_subs

--- a/fleetmgr/src/fleetmgr/layers/y_1.act
+++ b/fleetmgr/src/fleetmgr/layers/y_1.act
@@ -59,12 +59,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -154,9 +154,22 @@ SRC_DNODE_CHILD_22: DList = DList(module='fleetmgr-rfs', namespace='urn:fleetmgr
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='key', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_23: DLeaf = DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_23: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='minimum-rsa-bits', config=True, description='Reject RSA host and public keys shorter than this.', default='1024', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1024, 2147483647)])))
+])
 
-SRC_DNODE_CHILD_24: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mock', config=True, presence=False, children=[
+SRC_DNODE_CHILD_24: DLeaf = DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_25: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -166,15 +179,15 @@ SRC_DNODE_CHILD_24: DContainer = DContainer(module='fleetmgr-rfs', namespace='ur
     ])
 ])
 
-SRC_DNODE_CHILD_25: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='debug', config=True, presence=False, children=[
+SRC_DNODE_CHILD_26: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='debug', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='connection', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_26: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='feature-flags', config=True, presence=False, children=[
+SRC_DNODE_CHILD_27: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='feature-flags', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='runtime-schema-fetch', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_27: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='software', config=True, presence=False, children=[
+SRC_DNODE_CHILD_28: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='software', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='upgrade-campaign', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='target-release', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='image-url', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -187,7 +200,7 @@ SRC_DNODE_CHILD_27: DContainer = DContainer(module='fleetmgr-rfs', namespace='ur
 
 SRC_DNODE_CHILD_16: DList = DList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
         DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='rfs-transform', arg='fleetmgr.rfs.Device', exts=[])
-    ], children=[SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25, SRC_DNODE_CHILD_26, SRC_DNODE_CHILD_27])
+    ], children=[SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25, SRC_DNODE_CHILD_26, SRC_DNODE_CHILD_27, SRC_DNODE_CHILD_28])
 
 SRC_DNODE_CHILD_13: DList = DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rfs', key=['name'], config=True, min_elements=0, ordered_by='system', children=[SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16])
 
@@ -195,7 +208,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_13],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:rfs':('fleetmgr-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:rfs':('fleetmgr-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module fleetmgr-rfs {
@@ -274,6 +287,9 @@ SRC_YANG_1: str = r"""module fleetmgr-types {
   import ietf-inet-types {
     prefix inet;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
 
   grouping device-options {
     leaf description {
@@ -337,6 +353,13 @@ SRC_YANG_1: str = r"""module fleetmgr-types {
       leaf key {
         type string;
       }
+    }
+
+    container ssh {
+      description
+        "SSH transport parameters used when connecting to this device. Applies
+         to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -483,6 +506,9 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -491,211 +517,6 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -789,7 +610,7 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -984,7 +805,220 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_4: str = r"""module ietf-inet-types {
+SRC_YANG_4: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_5: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1444,7 +1478,7 @@ SRC_YANG_4: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_5: str = r"""module ietf-yang-types {
+SRC_YANG_6: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -2218,11 +2252,13 @@ pure def src_yang() -> list[str]:
         SRC_YANG_3,
         SRC_YANG_4,
         SRC_YANG_5,
+        SRC_YANG_6,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_fleetmgr_rfs: str = 'urn:fleetmgr:rfs'
 NS_fleetmgr_types: str = 'urn:fleetmgr:types'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
@@ -2254,7 +2290,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -2262,7 +2298,7 @@ class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2309,7 +2345,7 @@ class stratoweave_rfs__device__address_entry(yadata.MNode):
 _breaker4: None = None
 class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: str, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         e = self.get(key)
@@ -2320,7 +2356,7 @@ class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__d
             return e
         name = key
         res = stratoweave_rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2363,7 +2399,7 @@ class stratoweave_rfs__device__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -2373,7 +2409,7 @@ class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratowea
             return e
         key = key_
         res = stratoweave_rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2443,7 +2479,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -2451,7 +2487,7 @@ class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2537,7 +2573,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
 _breaker12: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: str, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         e = self.get(key)
@@ -2548,7 +2584,7 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2656,7 +2692,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
 _breaker17: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__device__software__veto_entry:
         e = self.get(key)
@@ -2666,7 +2702,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
             return e
         holder = key
         res = stratoweave_rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2758,7 +2794,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
 _breaker20: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, credentials: stratoweave_rfs__device__credentials, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         e = self.get(key)
@@ -2773,7 +2809,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
             return e
         name = key
         res = stratoweave_rfs__device_entry(name=name, credentials=credentials, description=description, type=type, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2839,7 +2875,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_entry(yadata.MN
 _breaker23: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -2847,7 +2883,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedLi
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2894,7 +2930,7 @@ class stratoweave_rfs__rfs__device__address_entry(yadata.MNode):
 _breaker25: None = None
 class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: str, port: ?u64=None) -> stratoweave_rfs__rfs__device__address_entry:
         e = self.get(key)
@@ -2905,7 +2941,7 @@ class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2948,7 +2984,7 @@ class stratoweave_rfs__rfs__device__credentials__key_entry(yadata.MNode):
 _breaker27: None = None
 class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -2958,7 +2994,7 @@ class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stra
             return e
         key = key_
         res = stratoweave_rfs__rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3028,7 +3064,7 @@ class stratoweave_rfs__rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker30: None = None
 class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -3036,7 +3072,7 @@ class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(usern
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3057,6 +3093,45 @@ class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(usern
 
 
 _breaker31: None = None
+class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
+    cipher: list[str]
+    mac: list[str]
+    key_exchange: list[str]
+    host_key_algorithm: list[str]
+    public_key_algorithm: list[str]
+    compression_algorithm: list[str]
+    compression_level: u64
+    rekey_after_bytes: ?u64
+    rekey_after_seconds: ?u64
+    minimum_rsa_bits: u64
+
+    mut def __init__(self, cipher: ?list[str]=None, mac: ?list[str]=None, key_exchange: ?list[str]=None, host_key_algorithm: ?list[str]=None, public_key_algorithm: ?list[str]=None, compression_algorithm: ?list[str]=None, compression_level: ?u64=None, rekey_after_bytes: ?u64, rekey_after_seconds: ?u64, minimum_rsa_bits: ?u64=None) -> None:
+        self.cipher = cipher if cipher is not None else []
+        self.mac = mac if mac is not None else []
+        self.key_exchange = key_exchange if key_exchange is not None else []
+        self.host_key_algorithm = host_key_algorithm if host_key_algorithm is not None else []
+        self.public_key_algorithm = public_key_algorithm if public_key_algorithm is not None else []
+        self.compression_algorithm = compression_algorithm if compression_algorithm is not None else []
+        self.compression_level = compression_level if compression_level is not None else u64(7)
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits if minimum_rsa_bits is not None else u64(1024)
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'fleetmgr-rfs:device', 'ssh'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__rfs__device__ssh:
+        if n is not None:
+            return stratoweave_rfs__rfs__device__ssh(cipher=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'cipher')), mac=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'mac')), key_exchange=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'key-exchange')), host_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'host-key-algorithm')), public_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'public-key-algorithm')), compression_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'compression-algorithm')), compression_level=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'compression-level')), rekey_after_bytes=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'rekey-after-bytes')), rekey_after_seconds=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'rekey-after-seconds')), minimum_rsa_bits=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'minimum-rsa-bits')))
+        return stratoweave_rfs__rfs__device__ssh()
+
+    mut def copy(self) -> stratoweave_rfs__rfs__device__ssh:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__rfs__device__ssh.from_gdata(self.to_gdata())
+
+
+_breaker32: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: str
@@ -3080,10 +3155,10 @@ class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker32: None = None
+_breaker33: None = None
 class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: str, revision: ?str=None) -> stratoweave_rfs__rfs__device__mock__module_entry:
         e = self.get(key)
@@ -3094,7 +3169,7 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
             return e
         name = key
         res = stratoweave_rfs__rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3114,7 +3189,7 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
         return stratoweave_rfs__rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker33: None = None
+_breaker34: None = None
 class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     enabled: bool
     module: stratoweave_rfs__rfs__device__mock__module
@@ -3137,7 +3212,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker34: None = None
+_breaker35: None = None
 class stratoweave_rfs__rfs__device__debug(yadata.MNode):
     connection: bool
 
@@ -3158,7 +3233,7 @@ class stratoweave_rfs__rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker35: None = None
+_breaker36: None = None
 class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: bool
 
@@ -3179,7 +3254,7 @@ class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker36: None = None
+_breaker37: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -3199,10 +3274,10 @@ class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker37: None = None
+_breaker38: None = None
 class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__rfs__device__software__veto_entry:
         e = self.get(key)
@@ -3212,7 +3287,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
             return e
         holder = key
         res = stratoweave_rfs__rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3232,7 +3307,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
         return stratoweave_rfs__rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker38: None = None
+_breaker39: None = None
 class stratoweave_rfs__rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -3261,7 +3336,7 @@ class stratoweave_rfs__rfs__device__software(yadata.MNode):
         return stratoweave_rfs__rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker39: None = None
+_breaker40: None = None
 class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     name: str
     type: str
@@ -3269,19 +3344,21 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     address: stratoweave_rfs__rfs__device__address
     credentials: stratoweave_rfs__rfs__device__credentials
     initial_credentials: stratoweave_rfs__rfs__device__initial_credentials
+    ssh: stratoweave_rfs__rfs__device__ssh
     approval_required: bool
     mock: stratoweave_rfs__rfs__device__mock
     debug: stratoweave_rfs__rfs__device__debug
     feature_flags: stratoweave_rfs__rfs__device__feature_flags
     software: stratoweave_rfs__rfs__device__software
 
-    mut def __init__(self, name: str, type: str, credentials: stratoweave_rfs__rfs__device__credentials, description: ?str, address: list[stratoweave_rfs__rfs__device__address_entry]=[], initial_credentials: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?stratoweave_rfs__rfs__device__mock=None, debug: ?stratoweave_rfs__rfs__device__debug=None, feature_flags: ?stratoweave_rfs__rfs__device__feature_flags=None, software: ?stratoweave_rfs__rfs__device__software=None) -> None:
+    mut def __init__(self, name: str, type: str, credentials: stratoweave_rfs__rfs__device__credentials, description: ?str, address: list[stratoweave_rfs__rfs__device__address_entry]=[], initial_credentials: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[], ssh: ?stratoweave_rfs__rfs__device__ssh=None, approval_required: ?bool=None, mock: ?stratoweave_rfs__rfs__device__mock=None, debug: ?stratoweave_rfs__rfs__device__debug=None, feature_flags: ?stratoweave_rfs__rfs__device__feature_flags=None, software: ?stratoweave_rfs__rfs__device__software=None) -> None:
         self.name = name
         self.type = type
         self.description = description
         self.address = stratoweave_rfs__rfs__device__address(elements=address)
         self.credentials = credentials
         self.initial_credentials = stratoweave_rfs__rfs__device__initial_credentials(elements=initial_credentials)
+        self.ssh = ssh if ssh is not None else stratoweave_rfs__rfs__device__ssh()
         self.approval_required = approval_required if approval_required is not None else False
         self.mock = mock if mock is not None else stratoweave_rfs__rfs__device__mock()
         self.debug = debug if debug is not None else stratoweave_rfs__rfs__device__debug()
@@ -3293,16 +3370,16 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ygdata.Node) -> stratoweave_rfs__rfs__device_entry:
-        return stratoweave_rfs__rfs__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), type=n.get_str(ygdata.Id(NS_fleetmgr_rfs, 'type')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'description')), address=stratoweave_rfs__rfs__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'address'))), credentials=stratoweave_rfs__rfs__device__credentials.from_gdata(n.get_cnt(ygdata.Id(NS_fleetmgr_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__rfs__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'approval-required')), mock=stratoweave_rfs__rfs__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'mock'))), debug=stratoweave_rfs__rfs__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'debug'))), feature_flags=stratoweave_rfs__rfs__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'feature-flags'))), software=stratoweave_rfs__rfs__device__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'software'))))
+        return stratoweave_rfs__rfs__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), type=n.get_str(ygdata.Id(NS_fleetmgr_rfs, 'type')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'description')), address=stratoweave_rfs__rfs__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'address'))), credentials=stratoweave_rfs__rfs__device__credentials.from_gdata(n.get_cnt(ygdata.Id(NS_fleetmgr_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__rfs__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'))), ssh=stratoweave_rfs__rfs__device__ssh.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'ssh'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'approval-required')), mock=stratoweave_rfs__rfs__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'mock'))), debug=stratoweave_rfs__rfs__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'debug'))), feature_flags=stratoweave_rfs__rfs__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'feature-flags'))), software=stratoweave_rfs__rfs__device__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'software'))))
 
     mut def copy(self) -> stratoweave_rfs__rfs__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker40: None = None
+_breaker41: None = None
 class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, type: str, credentials: stratoweave_rfs__rfs__device__credentials, description: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__rfs__device_entry:
         e = self.get(key)
@@ -3316,7 +3393,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
             return e
         name = key
         res = stratoweave_rfs__rfs__device_entry(name=name, type=type, credentials=credentials, description=description, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3336,7 +3413,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
         return stratoweave_rfs__rfs__device(elements=copied_elements)
 
 
-_breaker41: None = None
+_breaker42: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
     flotilla_status: stratoweave_rfs__rfs__flotilla_status
@@ -3358,10 +3435,10 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker42: None = None
+_breaker43: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> stratoweave_rfs__rfs_entry:
         e = self.get(key)
@@ -3369,7 +3446,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
             return e
         name = key
         res = stratoweave_rfs__rfs_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3389,7 +3466,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker43: None = None
+_breaker44: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs

--- a/fleetmgr/src/fleetmgr/layers/y_1_loose.act
+++ b/fleetmgr/src/fleetmgr/layers/y_1_loose.act
@@ -59,12 +59,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -154,9 +154,22 @@ SRC_DNODE_CHILD_22: DList = DList(module='fleetmgr-rfs', namespace='urn:fleetmgr
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='key', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_23: DLeaf = DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_23: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='minimum-rsa-bits', config=True, description='Reject RSA host and public keys shorter than this.', default='1024', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1024, 2147483647)])))
+])
 
-SRC_DNODE_CHILD_24: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mock', config=True, presence=False, children=[
+SRC_DNODE_CHILD_24: DLeaf = DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_25: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -166,15 +179,15 @@ SRC_DNODE_CHILD_24: DContainer = DContainer(module='fleetmgr-rfs', namespace='ur
     ])
 ])
 
-SRC_DNODE_CHILD_25: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='debug', config=True, presence=False, children=[
+SRC_DNODE_CHILD_26: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='debug', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='connection', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_26: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='feature-flags', config=True, presence=False, children=[
+SRC_DNODE_CHILD_27: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='feature-flags', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='runtime-schema-fetch', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_27: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='software', config=True, presence=False, children=[
+SRC_DNODE_CHILD_28: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='software', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='upgrade-campaign', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='target-release', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='image-url', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -187,7 +200,7 @@ SRC_DNODE_CHILD_27: DContainer = DContainer(module='fleetmgr-rfs', namespace='ur
 
 SRC_DNODE_CHILD_16: DList = DList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
         DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='rfs-transform', arg='fleetmgr.rfs.Device', exts=[])
-    ], children=[SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25, SRC_DNODE_CHILD_26, SRC_DNODE_CHILD_27])
+    ], children=[SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25, SRC_DNODE_CHILD_26, SRC_DNODE_CHILD_27, SRC_DNODE_CHILD_28])
 
 SRC_DNODE_CHILD_13: DList = DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rfs', key=['name'], config=True, min_elements=0, ordered_by='system', children=[SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16])
 
@@ -195,7 +208,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_13],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:rfs':('fleetmgr-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:rfs':('fleetmgr-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module fleetmgr-rfs {
@@ -274,6 +287,9 @@ SRC_YANG_1: str = r"""module fleetmgr-types {
   import ietf-inet-types {
     prefix inet;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
 
   grouping device-options {
     leaf description {
@@ -337,6 +353,13 @@ SRC_YANG_1: str = r"""module fleetmgr-types {
       leaf key {
         type string;
       }
+    }
+
+    container ssh {
+      description
+        "SSH transport parameters used when connecting to this device. Applies
+         to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -483,6 +506,9 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -491,211 +517,6 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -789,7 +610,7 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -984,7 +805,220 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_4: str = r"""module ietf-inet-types {
+SRC_YANG_4: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_5: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1444,7 +1478,7 @@ SRC_YANG_4: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_5: str = r"""module ietf-yang-types {
+SRC_YANG_6: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -2218,11 +2252,13 @@ pure def src_yang() -> list[str]:
         SRC_YANG_3,
         SRC_YANG_4,
         SRC_YANG_5,
+        SRC_YANG_6,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_fleetmgr_rfs: str = 'urn:fleetmgr:rfs'
 NS_fleetmgr_types: str = 'urn:fleetmgr:types'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
@@ -2254,7 +2290,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -2262,7 +2298,7 @@ class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2309,7 +2345,7 @@ class stratoweave_rfs__device__address_entry(yadata.MNode):
 _breaker4: None = None
 class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         e = self.get(key)
@@ -2321,7 +2357,7 @@ class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__d
             return e
         name = key
         res = stratoweave_rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2364,7 +2400,7 @@ class stratoweave_rfs__device__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -2374,7 +2410,7 @@ class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratowea
             return e
         key = key_
         res = stratoweave_rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2444,7 +2480,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -2452,7 +2488,7 @@ class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2538,7 +2574,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
 _breaker12: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         e = self.get(key)
@@ -2550,7 +2586,7 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2658,7 +2694,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
 _breaker17: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__device__software__veto_entry:
         e = self.get(key)
@@ -2668,7 +2704,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
             return e
         holder = key
         res = stratoweave_rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2760,7 +2796,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
 _breaker20: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         e = self.get(key)
@@ -2774,7 +2810,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
             return e
         name = key
         res = stratoweave_rfs__device_entry(name=name, description=description, type=type, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2840,7 +2876,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_entry(yadata.MN
 _breaker23: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -2848,7 +2884,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedLi
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2895,7 +2931,7 @@ class stratoweave_rfs__rfs__device__address_entry(yadata.MNode):
 _breaker25: None = None
 class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__rfs__device__address_entry:
         e = self.get(key)
@@ -2907,7 +2943,7 @@ class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2950,7 +2986,7 @@ class stratoweave_rfs__rfs__device__credentials__key_entry(yadata.MNode):
 _breaker27: None = None
 class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -2960,7 +2996,7 @@ class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stra
             return e
         key = key_
         res = stratoweave_rfs__rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3030,7 +3066,7 @@ class stratoweave_rfs__rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker30: None = None
 class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -3038,7 +3074,7 @@ class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(usern
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3059,6 +3095,45 @@ class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(usern
 
 
 _breaker31: None = None
+class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
+    cipher: list[str]
+    mac: list[str]
+    key_exchange: list[str]
+    host_key_algorithm: list[str]
+    public_key_algorithm: list[str]
+    compression_algorithm: list[str]
+    compression_level: ?u64
+    rekey_after_bytes: ?u64
+    rekey_after_seconds: ?u64
+    minimum_rsa_bits: ?u64
+
+    mut def __init__(self, cipher: ?list[str]=None, mac: ?list[str]=None, key_exchange: ?list[str]=None, host_key_algorithm: ?list[str]=None, public_key_algorithm: ?list[str]=None, compression_algorithm: ?list[str]=None, compression_level: ?u64, rekey_after_bytes: ?u64, rekey_after_seconds: ?u64, minimum_rsa_bits: ?u64) -> None:
+        self.cipher = cipher if cipher is not None else []
+        self.mac = mac if mac is not None else []
+        self.key_exchange = key_exchange if key_exchange is not None else []
+        self.host_key_algorithm = host_key_algorithm if host_key_algorithm is not None else []
+        self.public_key_algorithm = public_key_algorithm if public_key_algorithm is not None else []
+        self.compression_algorithm = compression_algorithm if compression_algorithm is not None else []
+        self.compression_level = compression_level
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'fleetmgr-rfs:device', 'ssh'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__rfs__device__ssh:
+        if n is not None:
+            return stratoweave_rfs__rfs__device__ssh(cipher=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'cipher')), mac=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'mac')), key_exchange=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'key-exchange')), host_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'host-key-algorithm')), public_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'public-key-algorithm')), compression_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'compression-algorithm')), compression_level=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'compression-level')), rekey_after_bytes=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'rekey-after-bytes')), rekey_after_seconds=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'rekey-after-seconds')), minimum_rsa_bits=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'minimum-rsa-bits')))
+        return stratoweave_rfs__rfs__device__ssh()
+
+    mut def copy(self) -> stratoweave_rfs__rfs__device__ssh:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__rfs__device__ssh.from_gdata(self.to_gdata())
+
+
+_breaker32: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -3082,10 +3157,10 @@ class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker32: None = None
+_breaker33: None = None
 class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__rfs__device__mock__module_entry:
         e = self.get(key)
@@ -3097,7 +3172,7 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
             return e
         name = key
         res = stratoweave_rfs__rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3117,7 +3192,7 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
         return stratoweave_rfs__rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker33: None = None
+_breaker34: None = None
 class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     enabled: ?bool
     module: stratoweave_rfs__rfs__device__mock__module
@@ -3140,7 +3215,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker34: None = None
+_breaker35: None = None
 class stratoweave_rfs__rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -3161,7 +3236,7 @@ class stratoweave_rfs__rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker35: None = None
+_breaker36: None = None
 class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -3182,7 +3257,7 @@ class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker36: None = None
+_breaker37: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -3202,10 +3277,10 @@ class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker37: None = None
+_breaker38: None = None
 class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__rfs__device__software__veto_entry:
         e = self.get(key)
@@ -3215,7 +3290,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
             return e
         holder = key
         res = stratoweave_rfs__rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3235,7 +3310,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
         return stratoweave_rfs__rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker38: None = None
+_breaker39: None = None
 class stratoweave_rfs__rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -3264,7 +3339,7 @@ class stratoweave_rfs__rfs__device__software(yadata.MNode):
         return stratoweave_rfs__rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker39: None = None
+_breaker40: None = None
 class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -3272,19 +3347,21 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     address: stratoweave_rfs__rfs__device__address
     credentials: stratoweave_rfs__rfs__device__credentials
     initial_credentials: stratoweave_rfs__rfs__device__initial_credentials
+    ssh: stratoweave_rfs__rfs__device__ssh
     approval_required: ?bool
     mock: stratoweave_rfs__rfs__device__mock
     debug: stratoweave_rfs__rfs__device__debug
     feature_flags: stratoweave_rfs__rfs__device__feature_flags
     software: stratoweave_rfs__rfs__device__software
 
-    mut def __init__(self, name: str, type: ?str, description: ?str, address: list[stratoweave_rfs__rfs__device__address_entry]=[], credentials: ?stratoweave_rfs__rfs__device__credentials=None, initial_credentials: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?stratoweave_rfs__rfs__device__mock=None, debug: ?stratoweave_rfs__rfs__device__debug=None, feature_flags: ?stratoweave_rfs__rfs__device__feature_flags=None, software: ?stratoweave_rfs__rfs__device__software=None) -> None:
+    mut def __init__(self, name: str, type: ?str, description: ?str, address: list[stratoweave_rfs__rfs__device__address_entry]=[], credentials: ?stratoweave_rfs__rfs__device__credentials=None, initial_credentials: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[], ssh: ?stratoweave_rfs__rfs__device__ssh=None, approval_required: ?bool, mock: ?stratoweave_rfs__rfs__device__mock=None, debug: ?stratoweave_rfs__rfs__device__debug=None, feature_flags: ?stratoweave_rfs__rfs__device__feature_flags=None, software: ?stratoweave_rfs__rfs__device__software=None) -> None:
         self.name = name
         self.type = type
         self.description = description
         self.address = stratoweave_rfs__rfs__device__address(elements=address)
         self.credentials = credentials if credentials is not None else stratoweave_rfs__rfs__device__credentials()
         self.initial_credentials = stratoweave_rfs__rfs__device__initial_credentials(elements=initial_credentials)
+        self.ssh = ssh if ssh is not None else stratoweave_rfs__rfs__device__ssh()
         self.approval_required = approval_required
         self.mock = mock if mock is not None else stratoweave_rfs__rfs__device__mock()
         self.debug = debug if debug is not None else stratoweave_rfs__rfs__device__debug()
@@ -3296,16 +3373,16 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ygdata.Node) -> stratoweave_rfs__rfs__device_entry:
-        return stratoweave_rfs__rfs__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), type=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'type')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'description')), address=stratoweave_rfs__rfs__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'address'))), credentials=stratoweave_rfs__rfs__device__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__rfs__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'approval-required')), mock=stratoweave_rfs__rfs__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'mock'))), debug=stratoweave_rfs__rfs__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'debug'))), feature_flags=stratoweave_rfs__rfs__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'feature-flags'))), software=stratoweave_rfs__rfs__device__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'software'))))
+        return stratoweave_rfs__rfs__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), type=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'type')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'description')), address=stratoweave_rfs__rfs__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'address'))), credentials=stratoweave_rfs__rfs__device__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__rfs__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'))), ssh=stratoweave_rfs__rfs__device__ssh.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'ssh'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'approval-required')), mock=stratoweave_rfs__rfs__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'mock'))), debug=stratoweave_rfs__rfs__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'debug'))), feature_flags=stratoweave_rfs__rfs__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'feature-flags'))), software=stratoweave_rfs__rfs__device__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'software'))))
 
     mut def copy(self) -> stratoweave_rfs__rfs__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker40: None = None
+_breaker41: None = None
 class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, type: ?str=None, description: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__rfs__device_entry:
         e = self.get(key)
@@ -3319,7 +3396,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
             return e
         name = key
         res = stratoweave_rfs__rfs__device_entry(name=name, type=type, description=description, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3339,7 +3416,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
         return stratoweave_rfs__rfs__device(elements=copied_elements)
 
 
-_breaker41: None = None
+_breaker42: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
     flotilla_status: stratoweave_rfs__rfs__flotilla_status
@@ -3361,10 +3438,10 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker42: None = None
+_breaker43: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> stratoweave_rfs__rfs_entry:
         e = self.get(key)
@@ -3372,7 +3449,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
             return e
         name = key
         res = stratoweave_rfs__rfs_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3392,7 +3469,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker43: None = None
+_breaker44: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs

--- a/fleetmgr/src/fleetmgr/layers/y_1_oper.act
+++ b/fleetmgr/src/fleetmgr/layers/y_1_oper.act
@@ -60,12 +60,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -191,9 +191,22 @@ SRC_DNODE_CHILD_29: DList = DList(module='fleetmgr-rfs', namespace='urn:fleetmgr
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='key', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_30: DLeaf = DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_30: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
+    DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='minimum-rsa-bits', config=True, description='Reject RSA host and public keys shorter than this.', default='1024', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1024, 2147483647)])))
+])
 
-SRC_DNODE_CHILD_31: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mock', config=True, presence=False, children=[
+SRC_DNODE_CHILD_31: DLeaf = DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='approval-required', config=True, description='Require approval of each individual configuration change to this device', default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_32: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -203,15 +216,15 @@ SRC_DNODE_CHILD_31: DContainer = DContainer(module='fleetmgr-rfs', namespace='ur
     ])
 ])
 
-SRC_DNODE_CHILD_32: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='debug', config=True, presence=False, children=[
+SRC_DNODE_CHILD_33: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='debug', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='connection', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_33: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='feature-flags', config=True, presence=False, children=[
+SRC_DNODE_CHILD_34: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='feature-flags', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='runtime-schema-fetch', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_34: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='software', config=True, presence=False, children=[
+SRC_DNODE_CHILD_35: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='software', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='upgrade-campaign', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='target-release', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='image-url', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -224,7 +237,7 @@ SRC_DNODE_CHILD_34: DContainer = DContainer(module='fleetmgr-rfs', namespace='ur
 
 SRC_DNODE_CHILD_23: DList = DList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
         DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave', prefix='sw', name='rfs-transform', arg='fleetmgr.rfs.Device', exts=[])
-    ], children=[SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25, SRC_DNODE_CHILD_26, SRC_DNODE_CHILD_27, SRC_DNODE_CHILD_28, SRC_DNODE_CHILD_29, SRC_DNODE_CHILD_30, SRC_DNODE_CHILD_31, SRC_DNODE_CHILD_32, SRC_DNODE_CHILD_33, SRC_DNODE_CHILD_34])
+    ], children=[SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25, SRC_DNODE_CHILD_26, SRC_DNODE_CHILD_27, SRC_DNODE_CHILD_28, SRC_DNODE_CHILD_29, SRC_DNODE_CHILD_30, SRC_DNODE_CHILD_31, SRC_DNODE_CHILD_32, SRC_DNODE_CHILD_33, SRC_DNODE_CHILD_34, SRC_DNODE_CHILD_35])
 
 SRC_DNODE_CHILD_20: DList = DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rfs', key=['name'], config=True, min_elements=0, ordered_by='system', children=[SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23])
 
@@ -232,7 +245,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_20],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:rfs':('fleetmgr-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'urn:fleetmgr:types':('fleetmgr-types', None), 'urn:fleetmgr:rfs':('fleetmgr-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module fleetmgr-rfs {
@@ -311,6 +324,9 @@ SRC_YANG_1: str = r"""module fleetmgr-types {
   import ietf-inet-types {
     prefix inet;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
 
   grouping device-options {
     leaf description {
@@ -374,6 +390,13 @@ SRC_YANG_1: str = r"""module fleetmgr-types {
       leaf key {
         type string;
       }
+    }
+
+    container ssh {
+      description
+        "SSH transport parameters used when connecting to this device. Applies
+         to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -520,6 +543,9 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -528,211 +554,6 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -826,7 +647,7 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -1021,7 +842,220 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_4: str = r"""module ietf-inet-types {
+SRC_YANG_4: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_5: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1481,7 +1515,7 @@ SRC_YANG_4: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_5: str = r"""module ietf-yang-types {
+SRC_YANG_6: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -2255,11 +2289,13 @@ pure def src_yang() -> list[str]:
         SRC_YANG_3,
         SRC_YANG_4,
         SRC_YANG_5,
+        SRC_YANG_6,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_fleetmgr_rfs: str = 'urn:fleetmgr:rfs'
 NS_fleetmgr_types: str = 'urn:fleetmgr:types'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
@@ -2291,7 +2327,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -2299,7 +2335,7 @@ class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2346,7 +2382,7 @@ class stratoweave_rfs__device__address_entry(yadata.MNode):
 _breaker4: None = None
 class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         e = self.get(key)
@@ -2358,7 +2394,7 @@ class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__d
             return e
         name = key
         res = stratoweave_rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2401,7 +2437,7 @@ class stratoweave_rfs__device__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -2411,7 +2447,7 @@ class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratowea
             return e
         key = key_
         res = stratoweave_rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2481,7 +2517,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -2489,7 +2525,7 @@ class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2575,7 +2611,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
 _breaker12: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         e = self.get(key)
@@ -2587,7 +2623,7 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2695,7 +2731,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
 _breaker17: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__device__software__veto_entry:
         e = self.get(key)
@@ -2705,7 +2741,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
             return e
         holder = key
         res = stratoweave_rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2756,7 +2792,7 @@ class stratoweave_rfs__device__software__state__job_entry(yadata.MNode):
 _breaker19: None = None
 class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, stratoweave_rfs__device__software__state__job_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__state__job_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, state: ?str=None, started: ?str=None, ended: ?str=None, progress: ?u64=None, message: ?str=None) -> stratoweave_rfs__device__software__state__job_entry:
         e = self.get(key)
@@ -2774,7 +2810,7 @@ class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, strat
             return e
         name = key
         res = stratoweave_rfs__device__software__state__job_entry(name=name, state=state, started=started, ended=ended, progress=progress, message=message)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2969,7 +3005,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
 _breaker26: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         e = self.get(key)
@@ -2983,7 +3019,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
             return e
         name = key
         res = stratoweave_rfs__device_entry(name=name, description=description, type=type, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3028,7 +3064,7 @@ class stratoweave_rfs__rfs__flotilla_status__state__device_entry(yadata.MNode):
 _breaker28: None = None
 class stratoweave_rfs__rfs__flotilla_status__state__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__flotilla_status__state__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__flotilla_status__state__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, status: ?str=None, running_release: ?str=None) -> stratoweave_rfs__rfs__flotilla_status__state__device_entry:
         e = self.get(key)
@@ -3040,7 +3076,7 @@ class stratoweave_rfs__rfs__flotilla_status__state__device(yadata.MKeyedList[str
             return e
         name = key
         res = stratoweave_rfs__rfs__flotilla_status__state__device_entry(name=name, status=status, running_release=running_release)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3129,7 +3165,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_entry(yadata.MN
 _breaker32: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -3137,7 +3173,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedLi
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3184,7 +3220,7 @@ class stratoweave_rfs__rfs__device__address_entry(yadata.MNode):
 _breaker34: None = None
 class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__rfs__device__address_entry:
         e = self.get(key)
@@ -3196,7 +3232,7 @@ class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3239,7 +3275,7 @@ class stratoweave_rfs__rfs__device__credentials__key_entry(yadata.MNode):
 _breaker36: None = None
 class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -3249,7 +3285,7 @@ class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stra
             return e
         key = key_
         res = stratoweave_rfs__rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3319,7 +3355,7 @@ class stratoweave_rfs__rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker39: None = None
 class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -3327,7 +3363,7 @@ class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(usern
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3348,6 +3384,45 @@ class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(usern
 
 
 _breaker40: None = None
+class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
+    cipher: list[str]
+    mac: list[str]
+    key_exchange: list[str]
+    host_key_algorithm: list[str]
+    public_key_algorithm: list[str]
+    compression_algorithm: list[str]
+    compression_level: ?u64
+    rekey_after_bytes: ?u64
+    rekey_after_seconds: ?u64
+    minimum_rsa_bits: ?u64
+
+    mut def __init__(self, cipher: ?list[str]=None, mac: ?list[str]=None, key_exchange: ?list[str]=None, host_key_algorithm: ?list[str]=None, public_key_algorithm: ?list[str]=None, compression_algorithm: ?list[str]=None, compression_level: ?u64, rekey_after_bytes: ?u64, rekey_after_seconds: ?u64, minimum_rsa_bits: ?u64) -> None:
+        self.cipher = cipher if cipher is not None else []
+        self.mac = mac if mac is not None else []
+        self.key_exchange = key_exchange if key_exchange is not None else []
+        self.host_key_algorithm = host_key_algorithm if host_key_algorithm is not None else []
+        self.public_key_algorithm = public_key_algorithm if public_key_algorithm is not None else []
+        self.compression_algorithm = compression_algorithm if compression_algorithm is not None else []
+        self.compression_level = compression_level
+        self.rekey_after_bytes = rekey_after_bytes
+        self.rekey_after_seconds = rekey_after_seconds
+        self.minimum_rsa_bits = minimum_rsa_bits
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'fleetmgr-rfs:device', 'ssh'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__rfs__device__ssh:
+        if n is not None:
+            return stratoweave_rfs__rfs__device__ssh(cipher=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'cipher')), mac=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'mac')), key_exchange=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'key-exchange')), host_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'host-key-algorithm')), public_key_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'public-key-algorithm')), compression_algorithm=n.get_opt_strs(ygdata.Id(NS_fleetmgr_rfs, 'compression-algorithm')), compression_level=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'compression-level')), rekey_after_bytes=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'rekey-after-bytes')), rekey_after_seconds=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'rekey-after-seconds')), minimum_rsa_bits=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'minimum-rsa-bits')))
+        return stratoweave_rfs__rfs__device__ssh()
+
+    mut def copy(self) -> stratoweave_rfs__rfs__device__ssh:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__rfs__device__ssh.from_gdata(self.to_gdata())
+
+
+_breaker41: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -3371,10 +3446,10 @@ class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker41: None = None
+_breaker42: None = None
 class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__rfs__device__mock__module_entry:
         e = self.get(key)
@@ -3386,7 +3461,7 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
             return e
         name = key
         res = stratoweave_rfs__rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3406,7 +3481,7 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
         return stratoweave_rfs__rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker42: None = None
+_breaker43: None = None
 class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     enabled: ?bool
     module: stratoweave_rfs__rfs__device__mock__module
@@ -3429,7 +3504,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker43: None = None
+_breaker44: None = None
 class stratoweave_rfs__rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -3450,7 +3525,7 @@ class stratoweave_rfs__rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker44: None = None
+_breaker45: None = None
 class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -3471,7 +3546,7 @@ class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker45: None = None
+_breaker46: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -3491,10 +3566,10 @@ class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker46: None = None
+_breaker47: None = None
 class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__rfs__device__software__veto_entry:
         e = self.get(key)
@@ -3504,7 +3579,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
             return e
         holder = key
         res = stratoweave_rfs__rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3524,7 +3599,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
         return stratoweave_rfs__rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker47: None = None
+_breaker48: None = None
 class stratoweave_rfs__rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -3553,7 +3628,7 @@ class stratoweave_rfs__rfs__device__software(yadata.MNode):
         return stratoweave_rfs__rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker48: None = None
+_breaker49: None = None
 class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -3561,19 +3636,21 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     address: stratoweave_rfs__rfs__device__address
     credentials: stratoweave_rfs__rfs__device__credentials
     initial_credentials: stratoweave_rfs__rfs__device__initial_credentials
+    ssh: stratoweave_rfs__rfs__device__ssh
     approval_required: ?bool
     mock: stratoweave_rfs__rfs__device__mock
     debug: stratoweave_rfs__rfs__device__debug
     feature_flags: stratoweave_rfs__rfs__device__feature_flags
     software: stratoweave_rfs__rfs__device__software
 
-    mut def __init__(self, name: str, type: ?str, description: ?str, address: list[stratoweave_rfs__rfs__device__address_entry]=[], credentials: ?stratoweave_rfs__rfs__device__credentials=None, initial_credentials: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?stratoweave_rfs__rfs__device__mock=None, debug: ?stratoweave_rfs__rfs__device__debug=None, feature_flags: ?stratoweave_rfs__rfs__device__feature_flags=None, software: ?stratoweave_rfs__rfs__device__software=None) -> None:
+    mut def __init__(self, name: str, type: ?str, description: ?str, address: list[stratoweave_rfs__rfs__device__address_entry]=[], credentials: ?stratoweave_rfs__rfs__device__credentials=None, initial_credentials: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[], ssh: ?stratoweave_rfs__rfs__device__ssh=None, approval_required: ?bool, mock: ?stratoweave_rfs__rfs__device__mock=None, debug: ?stratoweave_rfs__rfs__device__debug=None, feature_flags: ?stratoweave_rfs__rfs__device__feature_flags=None, software: ?stratoweave_rfs__rfs__device__software=None) -> None:
         self.name = name
         self.type = type
         self.description = description
         self.address = stratoweave_rfs__rfs__device__address(elements=address)
         self.credentials = credentials if credentials is not None else stratoweave_rfs__rfs__device__credentials()
         self.initial_credentials = stratoweave_rfs__rfs__device__initial_credentials(elements=initial_credentials)
+        self.ssh = ssh if ssh is not None else stratoweave_rfs__rfs__device__ssh()
         self.approval_required = approval_required
         self.mock = mock if mock is not None else stratoweave_rfs__rfs__device__mock()
         self.debug = debug if debug is not None else stratoweave_rfs__rfs__device__debug()
@@ -3585,16 +3662,16 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ygdata.Node) -> stratoweave_rfs__rfs__device_entry:
-        return stratoweave_rfs__rfs__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), type=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'type')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'description')), address=stratoweave_rfs__rfs__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'address'))), credentials=stratoweave_rfs__rfs__device__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__rfs__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'approval-required')), mock=stratoweave_rfs__rfs__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'mock'))), debug=stratoweave_rfs__rfs__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'debug'))), feature_flags=stratoweave_rfs__rfs__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'feature-flags'))), software=stratoweave_rfs__rfs__device__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'software'))))
+        return stratoweave_rfs__rfs__device_entry(name=n.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), type=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'type')), description=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'description')), address=stratoweave_rfs__rfs__device__address.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'address'))), credentials=stratoweave_rfs__rfs__device__credentials.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__rfs__device__initial_credentials.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'))), ssh=stratoweave_rfs__rfs__device__ssh.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'ssh'))), approval_required=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'approval-required')), mock=stratoweave_rfs__rfs__device__mock.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'mock'))), debug=stratoweave_rfs__rfs__device__debug.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'debug'))), feature_flags=stratoweave_rfs__rfs__device__feature_flags.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'feature-flags'))), software=stratoweave_rfs__rfs__device__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'software'))))
 
     mut def copy(self) -> stratoweave_rfs__rfs__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker49: None = None
+_breaker50: None = None
 class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, type: ?str=None, description: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__rfs__device_entry:
         e = self.get(key)
@@ -3608,7 +3685,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
             return e
         name = key
         res = stratoweave_rfs__rfs__device_entry(name=name, type=type, description=description, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3628,7 +3705,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
         return stratoweave_rfs__rfs__device(elements=copied_elements)
 
 
-_breaker50: None = None
+_breaker51: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
     flotilla_status: stratoweave_rfs__rfs__flotilla_status
@@ -3650,10 +3727,10 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker51: None = None
+_breaker52: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> stratoweave_rfs__rfs_entry:
         e = self.get(key)
@@ -3661,7 +3738,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
             return e
         name = key
         res = stratoweave_rfs__rfs_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -3681,7 +3758,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker52: None = None
+_breaker53: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
@@ -3709,7 +3786,7 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
-_breaker53: None = None
+_breaker54: None = None
 class stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3725,7 +3802,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry_subs(Subscript
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker54: None = None
+_breaker55: None = None
 class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3749,7 +3826,7 @@ class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNod
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker55: None = None
+_breaker56: None = None
 class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -3767,7 +3844,7 @@ class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker56: None = None
+_breaker57: None = None
 class stratoweave_rfs__device__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -3791,7 +3868,7 @@ class stratoweave_rfs__device__address_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker57: None = None
+_breaker58: None = None
 class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -3805,7 +3882,7 @@ class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker58: None = None
+_breaker59: None = None
 class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -3825,7 +3902,7 @@ class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker59: None = None
+_breaker60: None = None
 class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3841,7 +3918,7 @@ class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker60: None = None
+_breaker61: None = None
 class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3857,7 +3934,7 @@ class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker61: None = None
+_breaker62: None = None
 class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3881,7 +3958,7 @@ class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker62: None = None
+_breaker63: None = None
 class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
     cipher: SubscriptionNode
     mac: SubscriptionNode
@@ -3911,7 +3988,7 @@ class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
         return direct
 
-_breaker63: None = None
+_breaker64: None = None
 class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -3929,7 +4006,7 @@ class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker64: None = None
+_breaker65: None = None
 class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -3953,7 +4030,7 @@ class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker65: None = None
+_breaker66: None = None
 class stratoweave_rfs__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
     module: stratoweave_rfs__device__mock__module_subs
@@ -3967,7 +4044,7 @@ class stratoweave_rfs__device__mock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.module]
         return direct
 
-_breaker66: None = None
+_breaker67: None = None
 class stratoweave_rfs__device__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -3979,7 +4056,7 @@ class stratoweave_rfs__device__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
-_breaker67: None = None
+_breaker68: None = None
 class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -3991,7 +4068,7 @@ class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
 
-_breaker68: None = None
+_breaker69: None = None
 class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -4005,7 +4082,7 @@ class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker69: None = None
+_breaker70: None = None
 class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -4025,7 +4102,7 @@ class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker70: None = None
+_breaker71: None = None
 class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -4047,7 +4124,7 @@ class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker71: None = None
+_breaker72: None = None
 class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -4075,7 +4152,7 @@ class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker72: None = None
+_breaker73: None = None
 class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -4091,7 +4168,7 @@ class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
-_breaker73: None = None
+_breaker74: None = None
 class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -4107,7 +4184,7 @@ class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
-_breaker74: None = None
+_breaker75: None = None
 class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
     status: SubscriptionNode
     running_release: SubscriptionNode
@@ -4127,7 +4204,7 @@ class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.status, self.running_release, self.job, self.precheck, self.postcheck]
         return direct
 
-_breaker75: None = None
+_breaker76: None = None
 class stratoweave_rfs__device__software_subs(SubscriptionNode):
     upgrade_campaign: SubscriptionNode
     target_release: SubscriptionNode
@@ -4149,7 +4226,7 @@ class stratoweave_rfs__device__software_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.upgrade_campaign, self.target_release, self.image_url, self.allow_staging, self.veto, self.state]
         return direct
 
-_breaker76: None = None
+_breaker77: None = None
 class stratoweave_rfs__device__state_subs(SubscriptionNode):
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -4159,7 +4236,7 @@ class stratoweave_rfs__device__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = []
         return direct
 
-_breaker77: None = None
+_breaker78: None = None
 class stratoweave_rfs__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -4195,7 +4272,7 @@ class stratoweave_rfs__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker78: None = None
+_breaker79: None = None
 class stratoweave_rfs__device_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -4237,7 +4314,7 @@ class stratoweave_rfs__device_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker79: None = None
+_breaker80: None = None
 class stratoweave_rfs__rfs__flotilla_status__state__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     status: SubscriptionNode
@@ -4253,7 +4330,7 @@ class stratoweave_rfs__rfs__flotilla_status__state__device_entry_subs(Subscripti
         direct: list[SubscriptionNode] = [self.name, self.status, self.running_release]
         return direct
 
-_breaker80: None = None
+_breaker81: None = None
 class stratoweave_rfs__rfs__flotilla_status__state__device_subs(SubscriptionNode):
     name: SubscriptionNode
     status: SubscriptionNode
@@ -4275,7 +4352,7 @@ class stratoweave_rfs__rfs__flotilla_status__state__device_subs(SubscriptionNode
         direct: list[SubscriptionNode] = [self.name, self.status, self.running_release]
         return direct
 
-_breaker81: None = None
+_breaker82: None = None
 class stratoweave_rfs__rfs__flotilla_status__state_subs(SubscriptionNode):
     device: stratoweave_rfs__rfs__flotilla_status__state__device_subs
 
@@ -4287,7 +4364,7 @@ class stratoweave_rfs__rfs__flotilla_status__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.device]
         return direct
 
-_breaker82: None = None
+_breaker83: None = None
 class stratoweave_rfs__rfs__flotilla_status_subs(SubscriptionNode):
     enabled: SubscriptionNode
     state: stratoweave_rfs__rfs__flotilla_status__state_subs
@@ -4301,7 +4378,7 @@ class stratoweave_rfs__rfs__flotilla_status_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.state]
         return direct
 
-_breaker83: None = None
+_breaker84: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4317,7 +4394,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_entry_subs(Subs
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker84: None = None
+_breaker85: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4341,7 +4418,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_subs(Subscripti
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker85: None = None
+_breaker86: None = None
 class stratoweave_rfs__rfs__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -4359,7 +4436,7 @@ class stratoweave_rfs__rfs__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker86: None = None
+_breaker87: None = None
 class stratoweave_rfs__rfs__device__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -4383,7 +4460,7 @@ class stratoweave_rfs__rfs__device__address_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker87: None = None
+_breaker88: None = None
 class stratoweave_rfs__rfs__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -4397,7 +4474,7 @@ class stratoweave_rfs__rfs__device__credentials__key_entry_subs(SubscriptionNode
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker88: None = None
+_breaker89: None = None
 class stratoweave_rfs__rfs__device__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -4417,7 +4494,7 @@ class stratoweave_rfs__rfs__device__credentials__key_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker89: None = None
+_breaker90: None = None
 class stratoweave_rfs__rfs__device__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4433,7 +4510,7 @@ class stratoweave_rfs__rfs__device__credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker90: None = None
+_breaker91: None = None
 class stratoweave_rfs__rfs__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4449,7 +4526,7 @@ class stratoweave_rfs__rfs__device__initial_credentials_entry_subs(SubscriptionN
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker91: None = None
+_breaker92: None = None
 class stratoweave_rfs__rfs__device__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4473,7 +4550,37 @@ class stratoweave_rfs__rfs__device__initial_credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker92: None = None
+_breaker93: None = None
+class stratoweave_rfs__rfs__device__ssh_subs(SubscriptionNode):
+    cipher: SubscriptionNode
+    mac: SubscriptionNode
+    key_exchange: SubscriptionNode
+    host_key_algorithm: SubscriptionNode
+    public_key_algorithm: SubscriptionNode
+    compression_algorithm: SubscriptionNode
+    compression_level: SubscriptionNode
+    rekey_after_bytes: SubscriptionNode
+    rekey_after_seconds: SubscriptionNode
+    minimum_rsa_bits: SubscriptionNode
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.cipher = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'cipher'), parent=path))
+        self.mac = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'mac'), parent=path))
+        self.key_exchange = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'key-exchange'), parent=path))
+        self.host_key_algorithm = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'host-key-algorithm'), parent=path))
+        self.public_key_algorithm = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'public-key-algorithm'), parent=path))
+        self.compression_algorithm = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'compression-algorithm'), parent=path))
+        self.compression_level = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'compression-level'), parent=path))
+        self.rekey_after_bytes = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'rekey-after-bytes'), parent=path))
+        self.rekey_after_seconds = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'rekey-after-seconds'), parent=path))
+        self.minimum_rsa_bits = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'minimum-rsa-bits'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
+        return direct
+
+_breaker94: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -4491,7 +4598,7 @@ class stratoweave_rfs__rfs__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker93: None = None
+_breaker95: None = None
 class stratoweave_rfs__rfs__device__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -4515,7 +4622,7 @@ class stratoweave_rfs__rfs__device__mock__module_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker94: None = None
+_breaker96: None = None
 class stratoweave_rfs__rfs__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
     module: stratoweave_rfs__rfs__device__mock__module_subs
@@ -4529,7 +4636,7 @@ class stratoweave_rfs__rfs__device__mock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.module]
         return direct
 
-_breaker95: None = None
+_breaker97: None = None
 class stratoweave_rfs__rfs__device__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -4541,7 +4648,7 @@ class stratoweave_rfs__rfs__device__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
-_breaker96: None = None
+_breaker98: None = None
 class stratoweave_rfs__rfs__device__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -4553,7 +4660,7 @@ class stratoweave_rfs__rfs__device__feature_flags_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
 
-_breaker97: None = None
+_breaker99: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -4567,7 +4674,7 @@ class stratoweave_rfs__rfs__device__software__veto_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker98: None = None
+_breaker100: None = None
 class stratoweave_rfs__rfs__device__software__veto_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -4587,7 +4694,7 @@ class stratoweave_rfs__rfs__device__software__veto_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker99: None = None
+_breaker101: None = None
 class stratoweave_rfs__rfs__device__software_subs(SubscriptionNode):
     upgrade_campaign: SubscriptionNode
     target_release: SubscriptionNode
@@ -4607,7 +4714,7 @@ class stratoweave_rfs__rfs__device__software_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.upgrade_campaign, self.target_release, self.image_url, self.allow_staging, self.veto]
         return direct
 
-_breaker100: None = None
+_breaker102: None = None
 class stratoweave_rfs__rfs__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -4615,6 +4722,7 @@ class stratoweave_rfs__rfs__device_entry_subs(SubscriptionNode):
     address: stratoweave_rfs__rfs__device__address_subs
     credentials: stratoweave_rfs__rfs__device__credentials_subs
     initial_credentials: stratoweave_rfs__rfs__device__initial_credentials_subs
+    ssh: stratoweave_rfs__rfs__device__ssh_subs
     approval_required: SubscriptionNode
     mock: stratoweave_rfs__rfs__device__mock_subs
     debug: stratoweave_rfs__rfs__device__debug_subs
@@ -4629,6 +4737,7 @@ class stratoweave_rfs__rfs__device_entry_subs(SubscriptionNode):
         self.address = stratoweave_rfs__rfs__device__address_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'address'), parent=path))
         self.credentials = stratoweave_rfs__rfs__device__credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'credentials'), parent=path))
         self.initial_credentials = stratoweave_rfs__rfs__device__initial_credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'), parent=path))
+        self.ssh = stratoweave_rfs__rfs__device__ssh_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'ssh'), parent=path))
         self.approval_required = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'approval-required'), parent=path))
         self.mock = stratoweave_rfs__rfs__device__mock_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'mock'), parent=path))
         self.debug = stratoweave_rfs__rfs__device__debug_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'debug'), parent=path))
@@ -4636,10 +4745,10 @@ class stratoweave_rfs__rfs__device_entry_subs(SubscriptionNode):
         self.software = stratoweave_rfs__rfs__device__software_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'software'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.name, self.type, self.description, self.address, self.credentials, self.initial_credentials, self.approval_required, self.mock, self.debug, self.feature_flags, self.software]
+        direct: list[SubscriptionNode] = [self.name, self.type, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software]
         return direct
 
-_breaker101: None = None
+_breaker103: None = None
 class stratoweave_rfs__rfs__device_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -4647,6 +4756,7 @@ class stratoweave_rfs__rfs__device_subs(SubscriptionNode):
     address: stratoweave_rfs__rfs__device__address_subs
     credentials: stratoweave_rfs__rfs__device__credentials_subs
     initial_credentials: stratoweave_rfs__rfs__device__initial_credentials_subs
+    ssh: stratoweave_rfs__rfs__device__ssh_subs
     approval_required: SubscriptionNode
     mock: stratoweave_rfs__rfs__device__mock_subs
     debug: stratoweave_rfs__rfs__device__debug_subs
@@ -4660,6 +4770,7 @@ class stratoweave_rfs__rfs__device_subs(SubscriptionNode):
         self.address = stratoweave_rfs__rfs__device__address_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'address'), parent=path))
         self.credentials = stratoweave_rfs__rfs__device__credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'credentials'), parent=path))
         self.initial_credentials = stratoweave_rfs__rfs__device__initial_credentials_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'), parent=path))
+        self.ssh = stratoweave_rfs__rfs__device__ssh_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'ssh'), parent=path))
         self.approval_required = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'approval-required'), parent=path))
         self.mock = stratoweave_rfs__rfs__device__mock_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'mock'), parent=path))
         self.debug = stratoweave_rfs__rfs__device__debug_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'debug'), parent=path))
@@ -4674,10 +4785,10 @@ class stratoweave_rfs__rfs__device_subs(SubscriptionNode):
         return stratoweave_rfs__rfs__device_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'device'), predicates=predicates, parent=base_path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.name, self.type, self.description, self.address, self.credentials, self.initial_credentials, self.approval_required, self.mock, self.debug, self.feature_flags, self.software]
+        direct: list[SubscriptionNode] = [self.name, self.type, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software]
         return direct
 
-_breaker102: None = None
+_breaker104: None = None
 class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     flotilla_status: stratoweave_rfs__rfs__flotilla_status_subs
@@ -4693,7 +4804,7 @@ class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.flotilla_status, self.device]
         return direct
 
-_breaker103: None = None
+_breaker105: None = None
 class stratoweave_rfs__rfs_subs(SubscriptionNode):
     name: SubscriptionNode
     flotilla_status: stratoweave_rfs__rfs__flotilla_status_subs
@@ -4715,7 +4826,7 @@ class stratoweave_rfs__rfs_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.flotilla_status, self.device]
         return direct
 
-_breaker104: None = None
+_breaker106: None = None
 class root_subs(SubscriptionNode):
     device: stratoweave_rfs__device_subs
     rfs: stratoweave_rfs__rfs_subs

--- a/fleetmgr/src/fleetmgr/layers/y_2.act
+++ b/fleetmgr/src/fleetmgr/layers/y_2.act
@@ -163,7 +163,7 @@ class stratoweave_device__devices__device_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_device__devices__device_entry]):
     mut def __init__(self, elements: list[stratoweave_device__devices__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, modset_id: ?str=None) -> stratoweave_device__devices__device_entry:
         e = self.get(key)
@@ -173,7 +173,7 @@ class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_dev
             return e
         name = key
         res = stratoweave_device__devices__device_entry(name=name, modset_id=modset_id)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/fleetmgr/layers/y_2_loose.act
+++ b/fleetmgr/src/fleetmgr/layers/y_2_loose.act
@@ -163,7 +163,7 @@ class stratoweave_device__devices__device_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_device__devices__device_entry]):
     mut def __init__(self, elements: list[stratoweave_device__devices__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, modset_id: ?str=None) -> stratoweave_device__devices__device_entry:
         e = self.get(key)
@@ -173,7 +173,7 @@ class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_dev
             return e
         name = key
         res = stratoweave_device__devices__device_entry(name=name, modset_id=modset_id)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/fleetmgr/layers/y_2_oper.act
+++ b/fleetmgr/src/fleetmgr/layers/y_2_oper.act
@@ -164,7 +164,7 @@ class stratoweave_device__devices__device_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_device__devices__device_entry]):
     mut def __init__(self, elements: list[stratoweave_device__devices__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, modset_id: ?str=None) -> stratoweave_device__devices__device_entry:
         e = self.get(key)
@@ -174,7 +174,7 @@ class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_dev
             return e
         name = key
         res = stratoweave_device__devices__device_entry(name=name, modset_id=modset_id)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/fleetmgr/rfs.act
+++ b/fleetmgr/src/fleetmgr/rfs.act
@@ -100,6 +100,17 @@ class Device(base.Device):
                 key=credentials.key,
             ))
 
+        dev.ssh.cipher = i.ssh.cipher
+        dev.ssh.mac = i.ssh.mac
+        dev.ssh.key_exchange = i.ssh.key_exchange
+        dev.ssh.host_key_algorithm = i.ssh.host_key_algorithm
+        dev.ssh.public_key_algorithm = i.ssh.public_key_algorithm
+        dev.ssh.compression_algorithm = i.ssh.compression_algorithm
+        dev.ssh.compression_level = i.ssh.compression_level
+        dev.ssh.rekey_after_bytes = i.ssh.rekey_after_bytes
+        dev.ssh.rekey_after_seconds = i.ssh.rekey_after_seconds
+        dev.ssh.minimum_rsa_bits = i.ssh.minimum_rsa_bits
+
         dev.mock.enabled = i.mock.enabled
         for module in i.mock.module:
             out_module = dev.mock.module.create(

--- a/fleetmgr/src/flotilla/devices/iosxe_oper.act
+++ b/fleetmgr/src/flotilla/devices/iosxe_oper.act
@@ -339,11 +339,11 @@ class Cisco_IOS_XE_install_oper__install_oper_data__install_oper__install_txn_su
 _breaker5: None = None
 class Cisco_IOS_XE_install_oper__install_oper_data__install_oper__install_txn_summary_op(yadata.MList[Cisco_IOS_XE_install_oper__install_oper_data__install_oper__install_txn_summary_op_entry]):
     mut def __init__(self, elements: list[Cisco_IOS_XE_install_oper__install_oper_data__install_oper__install_txn_summary_op_entry]=[]) -> None:
-        self.elements = elements
+        self._elements = elements
 
     mut def create(self, txn_cmd: ?str=None, txn_status: ?str=None) -> Cisco_IOS_XE_install_oper__install_oper_data__install_oper__install_txn_summary_op_entry:
         res = Cisco_IOS_XE_install_oper__install_oper_data__install_oper__install_txn_summary_op_entry(txn_cmd=txn_cmd, txn_status=txn_status)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -392,11 +392,11 @@ class Cisco_IOS_XE_install_oper__install_oper_data__install_oper_entry(yadata.MN
 _breaker7: None = None
 class Cisco_IOS_XE_install_oper__install_oper_data__install_oper(yadata.MList[Cisco_IOS_XE_install_oper__install_oper_data__install_oper_entry]):
     mut def __init__(self, elements: list[Cisco_IOS_XE_install_oper__install_oper_data__install_oper_entry]=[]) -> None:
-        self.elements = elements
+        self._elements = elements
 
     mut def create(self, op_uuid: ?str=None, op_id: ?str=None, op_status: ?str=None, op_done: ?str=None) -> Cisco_IOS_XE_install_oper__install_oper_data__install_oper_entry:
         res = Cisco_IOS_XE_install_oper__install_oper_data__install_oper_entry(op_uuid=op_uuid, op_id=op_id, op_status=op_status, op_done=op_done)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -439,11 +439,11 @@ class Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist__install_t
 _breaker9: None = None
 class Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist__install_txn_sum_op_hist(yadata.MList[Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist__install_txn_sum_op_hist_entry]):
     mut def __init__(self, elements: list[Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist__install_txn_sum_op_hist_entry]=[]) -> None:
-        self.elements = elements
+        self._elements = elements
 
     mut def create(self, txn_cmd: ?str=None, txn_status: ?str=None) -> Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist__install_txn_sum_op_hist_entry:
         res = Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist__install_txn_sum_op_hist_entry(txn_cmd=txn_cmd, txn_status=txn_status)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -492,11 +492,11 @@ class Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist_entry(yada
 _breaker11: None = None
 class Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist(yadata.MList[Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist_entry]):
     mut def __init__(self, elements: list[Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist_entry]=[]) -> None:
-        self.elements = elements
+        self._elements = elements
 
     mut def create(self, op_uuid: ?str=None, op_id: ?str=None, op_status: ?str=None, op_done: ?str=None) -> Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist_entry:
         res = Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist_entry(op_uuid=op_uuid, op_id=op_id, op_status=op_status, op_done=op_done)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/flotilla/layers/y_0.act
+++ b/fleetmgr/src/flotilla/layers/y_0.act
@@ -59,12 +59,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -114,7 +114,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_13],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module stratoweave {
@@ -188,6 +188,9 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -196,211 +199,6 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -494,7 +292,7 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -689,7 +487,220 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_2: str = r"""module ietf-inet-types {
+SRC_YANG_2: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_3: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1149,7 +1160,7 @@ SRC_YANG_2: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-yang-types {
+SRC_YANG_4: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -1921,11 +1932,13 @@ pure def src_yang() -> list[str]:
         SRC_YANG_1,
         SRC_YANG_2,
         SRC_YANG_3,
+        SRC_YANG_4,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 
@@ -1955,7 +1968,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1963,7 +1976,7 @@ class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2010,7 +2023,7 @@ class stratoweave_rfs__device__address_entry(yadata.MNode):
 _breaker4: None = None
 class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: str, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         e = self.get(key)
@@ -2021,7 +2034,7 @@ class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__d
             return e
         name = key
         res = stratoweave_rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2064,7 +2077,7 @@ class stratoweave_rfs__device__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -2074,7 +2087,7 @@ class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratowea
             return e
         key = key_
         res = stratoweave_rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2144,7 +2157,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -2152,7 +2165,7 @@ class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2238,7 +2251,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
 _breaker12: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: str, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         e = self.get(key)
@@ -2249,7 +2262,7 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2357,7 +2370,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
 _breaker17: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__device__software__veto_entry:
         e = self.get(key)
@@ -2367,7 +2380,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
             return e
         holder = key
         res = stratoweave_rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2459,7 +2472,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
 _breaker20: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, credentials: stratoweave_rfs__device__credentials, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         e = self.get(key)
@@ -2474,7 +2487,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
             return e
         name = key
         res = stratoweave_rfs__device_entry(name=name, credentials=credentials, description=description, type=type, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2515,7 +2528,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
 _breaker22: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> stratoweave_rfs__rfs_entry:
         e = self.get(key)
@@ -2523,7 +2536,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
             return e
         name = key
         res = stratoweave_rfs__rfs_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/flotilla/layers/y_0_loose.act
+++ b/fleetmgr/src/flotilla/layers/y_0_loose.act
@@ -59,12 +59,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -114,7 +114,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_13],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module stratoweave {
@@ -188,6 +188,9 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -196,211 +199,6 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -494,7 +292,7 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -689,7 +487,220 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_2: str = r"""module ietf-inet-types {
+SRC_YANG_2: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_3: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1149,7 +1160,7 @@ SRC_YANG_2: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-yang-types {
+SRC_YANG_4: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -1921,11 +1932,13 @@ pure def src_yang() -> list[str]:
         SRC_YANG_1,
         SRC_YANG_2,
         SRC_YANG_3,
+        SRC_YANG_4,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 
@@ -1955,7 +1968,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1963,7 +1976,7 @@ class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2010,7 +2023,7 @@ class stratoweave_rfs__device__address_entry(yadata.MNode):
 _breaker4: None = None
 class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         e = self.get(key)
@@ -2022,7 +2035,7 @@ class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__d
             return e
         name = key
         res = stratoweave_rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2065,7 +2078,7 @@ class stratoweave_rfs__device__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -2075,7 +2088,7 @@ class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratowea
             return e
         key = key_
         res = stratoweave_rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2145,7 +2158,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -2153,7 +2166,7 @@ class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2239,7 +2252,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
 _breaker12: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         e = self.get(key)
@@ -2251,7 +2264,7 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2359,7 +2372,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
 _breaker17: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__device__software__veto_entry:
         e = self.get(key)
@@ -2369,7 +2382,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
             return e
         holder = key
         res = stratoweave_rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2461,7 +2474,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
 _breaker20: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         e = self.get(key)
@@ -2475,7 +2488,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
             return e
         name = key
         res = stratoweave_rfs__device_entry(name=name, description=description, type=type, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2516,7 +2529,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
 _breaker22: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> stratoweave_rfs__rfs_entry:
         e = self.get(key)
@@ -2524,7 +2537,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
             return e
         name = key
         res = stratoweave_rfs__rfs_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/flotilla/layers/y_0_oper.act
+++ b/fleetmgr/src/flotilla/layers/y_0_oper.act
@@ -60,12 +60,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -144,7 +144,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_20],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module stratoweave {
@@ -218,6 +218,9 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -226,211 +229,6 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -524,7 +322,7 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -719,7 +517,220 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_2: str = r"""module ietf-inet-types {
+SRC_YANG_2: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_3: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1179,7 +1190,7 @@ SRC_YANG_2: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-yang-types {
+SRC_YANG_4: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -1951,11 +1962,13 @@ pure def src_yang() -> list[str]:
         SRC_YANG_1,
         SRC_YANG_2,
         SRC_YANG_3,
+        SRC_YANG_4,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 
@@ -1985,7 +1998,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__address__initial_credentials_entry:
         e = self.get(key_)
@@ -1993,7 +2006,7 @@ class stratoweave_rfs__device__address__initial_credentials(yadata.MKeyedList[(u
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__address__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2040,7 +2053,7 @@ class stratoweave_rfs__device__address_entry(yadata.MNode):
 _breaker4: None = None
 class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         e = self.get(key)
@@ -2052,7 +2065,7 @@ class stratoweave_rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__d
             return e
         name = key
         res = stratoweave_rfs__device__address_entry(name=name, address=address, port=port)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2095,7 +2108,7 @@ class stratoweave_rfs__device__credentials__key_entry(yadata.MNode):
 _breaker6: None = None
 class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.key == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
 
     mut def create(self, key_: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         e = self.get(key_)
@@ -2105,7 +2118,7 @@ class stratoweave_rfs__device__credentials__key(yadata.MKeyedList[str, stratowea
             return e
         key = key_
         res = stratoweave_rfs__device__credentials__key_entry(key=key, private_key=private_key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2175,7 +2188,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yadata.MNode):
 _breaker9: None = None
 class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.username == k.username and e.password == k.password and e.key == k.key, elements)
+        yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
 
     mut def create(self, key_: (username: str, password: str, key: str)) -> stratoweave_rfs__device__initial_credentials_entry:
         e = self.get(key_)
@@ -2183,7 +2196,7 @@ class stratoweave_rfs__device__initial_credentials(yadata.MKeyedList[(username: 
             return e
         (username=username, password=password, key=key) = key_
         res = stratoweave_rfs__device__initial_credentials_entry(username=username, password=password, key=key)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2269,7 +2282,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
 _breaker12: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         e = self.get(key)
@@ -2281,7 +2294,7 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
             return e
         name = key
         res = stratoweave_rfs__device__mock__module_entry(name=name, namespace=namespace, revision=revision)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2389,7 +2402,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
 _breaker17: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.holder == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
 
     mut def create(self, key: str, reason: ?str=None) -> stratoweave_rfs__device__software__veto_entry:
         e = self.get(key)
@@ -2399,7 +2412,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
             return e
         holder = key
         res = stratoweave_rfs__device__software__veto_entry(holder=holder, reason=reason)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2450,7 +2463,7 @@ class stratoweave_rfs__device__software__state__job_entry(yadata.MNode):
 _breaker19: None = None
 class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, stratoweave_rfs__device__software__state__job_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__state__job_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, state: ?str=None, started: ?str=None, ended: ?str=None, progress: ?u64=None, message: ?str=None) -> stratoweave_rfs__device__software__state__job_entry:
         e = self.get(key)
@@ -2468,7 +2481,7 @@ class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, strat
             return e
         name = key
         res = stratoweave_rfs__device__software__state__job_entry(name=name, state=state, started=started, ended=ended, progress=progress, message=message)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2663,7 +2676,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
 _breaker26: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         e = self.get(key)
@@ -2677,7 +2690,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
             return e
         name = key
         res = stratoweave_rfs__device_entry(name=name, description=description, type=type, approval_required=approval_required)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -2718,7 +2731,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
 _breaker28: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str) -> stratoweave_rfs__rfs_entry:
         e = self.get(key)
@@ -2726,7 +2739,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
             return e
         name = key
         res = stratoweave_rfs__rfs_entry(name=name)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/flotilla/layers/y_1.act
+++ b/fleetmgr/src/flotilla/layers/y_1.act
@@ -163,7 +163,7 @@ class stratoweave_device__devices__device_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_device__devices__device_entry]):
     mut def __init__(self, elements: list[stratoweave_device__devices__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, modset_id: ?str=None) -> stratoweave_device__devices__device_entry:
         e = self.get(key)
@@ -173,7 +173,7 @@ class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_dev
             return e
         name = key
         res = stratoweave_device__devices__device_entry(name=name, modset_id=modset_id)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/flotilla/layers/y_1_loose.act
+++ b/fleetmgr/src/flotilla/layers/y_1_loose.act
@@ -163,7 +163,7 @@ class stratoweave_device__devices__device_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_device__devices__device_entry]):
     mut def __init__(self, elements: list[stratoweave_device__devices__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, modset_id: ?str=None) -> stratoweave_device__devices__device_entry:
         e = self.get(key)
@@ -173,7 +173,7 @@ class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_dev
             return e
         name = key
         res = stratoweave_device__devices__device_entry(name=name, modset_id=modset_id)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/flotilla/layers/y_1_oper.act
+++ b/fleetmgr/src/flotilla/layers/y_1_oper.act
@@ -164,7 +164,7 @@ class stratoweave_device__devices__device_entry(yadata.MNode):
 _breaker2: None = None
 class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_device__devices__device_entry]):
     mut def __init__(self, elements: list[stratoweave_device__devices__device_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
     mut def create(self, key: str, modset_id: ?str=None) -> stratoweave_device__devices__device_entry:
         e = self.get(key)
@@ -174,7 +174,7 @@ class stratoweave_device__devices__device(yadata.MKeyedList[str, stratoweave_dev
             return e
         name = key
         res = stratoweave_device__devices__device_entry(name=name, modset_id=modset_id)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod

--- a/fleetmgr/src/test_fleetmgr_cfs.act
+++ b/fleetmgr/src/test_fleetmgr_cfs.act
@@ -1,11 +1,20 @@
 import testing
+import std.xml as xml
+import yang.xml as yxml
 
 import stratoweave
+import stratoweave.adapters.adapter as swadapt
+import stratoweave.ttt as ttt
+from stratoweave.device_meta_config import \
+    stratoweave_rfs__device_entry as DeviceMetaConfig
 
 import fleetmgr.cfs as cfs
+import fleetmgr.rfs as rfs
 import fleetmgr.layers.y_0 as y_0
+import fleetmgr.layers.y_1 as y_1_config
 import fleetmgr.layers.y_1_loose as y_1
 import fleetmgr.sysspec as sysspec
+import flotilla.layers.y_0 as flotilla_rfs
 from fleetmgr.layers.y_0 import \
     fleetmgr__fleet__device__address_entry as InputAddress, \
     fleetmgr__fleet__device__credentials as InputCredentials, \
@@ -31,6 +40,10 @@ actor _test_node_transform(t: testing.AsyncT):
         credentials=NodeCredentials(username="admin", password="admin"),
     )
     address = i.address.create("primary", address="127.0.0.1", port=u64(12031))
+    i.ssh.cipher = ["aes256-ctr", "aes128-ctr"]
+    i.ssh.key_exchange = ["curve25519-sha256"]
+    i.ssh.minimum_rsa_bits = u64(3072)
+    i.ssh.rekey_after_seconds = u64(0)
 
     transform: cfs.Node = cfs.Node()
     o: y_1.root = y_1.root.from_gdata(transform.transform(i).to_gdata())
@@ -43,10 +56,102 @@ actor _test_node_transform(t: testing.AsyncT):
         t.failure(ValueError("flotilla address was not preserved"))
     elif dev.credentials.username != "admin" or dev.credentials.password != "admin":
         t.failure(ValueError("flotilla credentials were not preserved"))
+    elif dev.ssh.cipher != ["aes256-ctr", "aes128-ctr"] or \
+         dev.ssh.key_exchange != ["curve25519-sha256"] or \
+         dev.ssh.minimum_rsa_bits != 3072 or \
+         dev.ssh.rekey_after_seconds != 0:
+        t.failure(ValueError("flotilla SSH options were not preserved"))
     elif o.rfs.get("flotilla-1")!.flotilla_status.enabled != True:
         t.failure(ValueError("flotilla status collector was not enabled"))
     else:
         t.success()
+
+
+def _test_device_ssh_propagation():
+    """CFS SSH options survive both transforms and the flotilla XML boundary."""
+    config = xml.decode("""<config>
+      <fleet xmlns="urn:fleetmgr:fleetmgr">
+        <device>
+          <name>configured</name>
+          <type>iosxe</type>
+          <shard>flotilla-1</shard>
+          <credentials><username>admin</username></credentials>
+          <ssh>
+            <cipher>aes256-ctr</cipher>
+            <cipher>aes128-ctr</cipher>
+            <mac>hmac-sha2-512</mac>
+            <mac>hmac-sha2-256</mac>
+            <key-exchange>ecdh-sha2-nistp384</key-exchange>
+            <key-exchange>curve25519-sha256</key-exchange>
+            <host-key-algorithm>ssh-ed25519</host-key-algorithm>
+            <host-key-algorithm>rsa-sha2-512</host-key-algorithm>
+            <public-key-algorithm>ssh-ed25519</public-key-algorithm>
+            <public-key-algorithm>rsa-sha2-256</public-key-algorithm>
+            <compression-algorithm>zlib@openssh.com</compression-algorithm>
+            <compression-algorithm>none</compression-algorithm>
+            <compression-level>3</compression-level>
+            <rekey-after-bytes>1048576</rekey-after-bytes>
+            <rekey-after-seconds>3600</rekey-after-seconds>
+            <minimum-rsa-bits>3072</minimum-rsa-bits>
+          </ssh>
+        </device>
+        <device>
+          <name>defaults</name>
+          <type>iosxe</type>
+          <shard>flotilla-1</shard>
+          <credentials><username>admin</username></credentials>
+        </device>
+      </fleet>
+    </config>""")
+    inputs = y_0.root.from_gdata(yxml.from_xml(y_0.SRC_DNODE, config))
+    di = ttt.DeviceInfo("flotilla-1", {
+        "stratoweave-rfs": swadapt.ModCap(
+            "stratoweave-rfs",
+            "http://stratoweave.org/yang/stratoweave-rfs",
+        )
+    })
+    devices: dict[str, DeviceMetaConfig] = {}
+    for i in inputs.fleet.device:
+        lower = y_1_config.root.from_gdata(cfs.Device().transform(i).to_gdata())
+        entry = lower.rfs.get("flotilla-1")!.device.get(i.name)!
+        rendered = rfs.Device().transform(entry, di).to_gdata()
+        wire = xml.Node("config", children=rendered.to_xml())
+        received = flotilla_rfs.root.from_gdata(
+            yxml.from_xml(flotilla_rfs.SRC_DNODE, xml.decode(xml.encode(wire)))
+        )
+        devices[i.name] = DeviceMetaConfig.from_gdata(
+            received.device.get(i.name)!.to_gdata()
+        )
+
+    configured = swadapt.ssh_transport_config(devices["configured"].ssh)
+    testing.assertEqual([str(c) for c in configured.ciphers],
+                        ["aes256-ctr", "aes128-ctr"])
+    testing.assertEqual([str(m) for m in configured.macs],
+                        ["hmac-sha2-512", "hmac-sha2-256"])
+    testing.assertEqual([str(k) for k in configured.key_exchanges],
+                        ["ecdh-sha2-nistp384", "curve25519-sha256"])
+    testing.assertEqual([str(k) for k in configured.host_key_algorithms],
+                        ["ssh-ed25519", "rsa-sha2-512"])
+    testing.assertEqual([str(k) for k in configured.public_key_algorithms],
+                        ["ssh-ed25519", "rsa-sha2-256"])
+    testing.assertEqual([str(c) for c in configured.compression_algorithms],
+                        ["zlib@openssh.com", "none"])
+    testing.assertEqual(configured.compression_level, 3)
+    testing.assertEqual(configured.rekey_after_bytes, 1048576)
+    testing.assertEqual(configured.rekey_after_seconds, 3600)
+    testing.assertEqual(configured.minimum_rsa_bits, 3072)
+
+    defaults = devices["defaults"].ssh
+    testing.assertEqual(defaults.cipher, [])
+    testing.assertEqual(defaults.mac, [])
+    testing.assertEqual(defaults.key_exchange, [])
+    testing.assertEqual(defaults.host_key_algorithm, [])
+    testing.assertEqual(defaults.public_key_algorithm, [])
+    testing.assertEqual(defaults.compression_algorithm, [])
+    testing.assertEqual(defaults.compression_level, u64(7))
+    testing.assertEqual(defaults.rekey_after_bytes, None)
+    testing.assertEqual(defaults.rekey_after_seconds, None)
+    testing.assertEqual(defaults.minimum_rsa_bits, u64(1024))
 
 
 actor _test_campaign_transform(t: testing.AsyncT):

--- a/gen_adata/src/gen_adata.act
+++ b/gen_adata/src/gen_adata.act
@@ -10,7 +10,7 @@ actor main(env):
     wfc = file.WriteFileCap(file.FileCap(env.cap))
 
     try:
-        schema_yang = [swyang.rfs, swyang.stratoweave, swyang.ietf_inet_types, swyang.ietf_yang_types]
+        schema_yang = [swyang.rfs, swyang.ssh, swyang.stratoweave, swyang.ietf_inet_types, swyang.ietf_yang_types]
         y = yang.compile(schema_yang)
 
         # Emit the oper view first: the config-only prdaclass below strips

--- a/gen_adata/src/swyang.act
+++ b/gen_adata/src/swyang.act
@@ -62,22 +62,12 @@ stratoweave = r"""module stratoweave {
 }"""
 
 
-rfs = r"""module stratoweave-rfs {
+ssh = r"""module stratoweave-ssh {
   yang-version "1.1";
-  namespace "http://stratoweave.org/yang/stratoweave-rfs";
-  prefix "sw-rfs";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
 
-  import stratoweave {
-    prefix sw;
-  }
-  import ietf-inet-types {
-    prefix inet;
-  }
-  import ietf-yang-types {
-    prefix yang;
-  }
-
-  description "RFS services";
+  description "Reusable SSH client transport types and groupings.";
 
   typedef ssh-cipher {
     type enumeration {
@@ -206,21 +196,21 @@ rfs = r"""module stratoweave-rfs {
     leaf-list cipher {
       description
         "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
+      type sw-ssh:ssh-cipher;
       ordered-by user;
     }
 
     leaf-list mac {
       description
         "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
+      type sw-ssh:ssh-mac;
       ordered-by user;
     }
 
     leaf-list key-exchange {
       description
         "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
+      type sw-ssh:ssh-key-exchange;
       ordered-by user;
     }
 
@@ -228,7 +218,7 @@ rfs = r"""module stratoweave-rfs {
       description
         "Server host key algorithms to accept, most preferred first. This is
          what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
+      type sw-ssh:ssh-host-key-algorithm;
       ordered-by user;
     }
 
@@ -236,7 +226,7 @@ rfs = r"""module stratoweave-rfs {
       description
         "Public key algorithms to offer for publickey authentication, most
          preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
+      type sw-ssh:ssh-public-key-algorithm;
       ordered-by user;
     }
 
@@ -244,7 +234,7 @@ rfs = r"""module stratoweave-rfs {
       description
         "Compression algorithms to offer, most preferred first. 'none' first
          disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
+      type sw-ssh:ssh-compression-algorithm;
       ordered-by user;
     }
 
@@ -283,6 +273,28 @@ rfs = r"""module stratoweave-rfs {
       default 1024;
     }
   }
+}"""
+
+
+rfs = r"""module stratoweave-rfs {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-rfs";
+  prefix "sw-rfs";
+
+  import stratoweave {
+    prefix sw;
+  }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
+  import ietf-inet-types {
+    prefix inet;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  description "RFS services";
 
   grouping check-result {
     leaf verdict {
@@ -376,7 +388,7 @@ rfs = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {

--- a/minisys/gen/src/gen.act
+++ b/minisys/gen/src/gen.act
@@ -11,7 +11,7 @@ actor main(env):
     cfs_layer = swbuild.Layer.from_dir(fc, "yang/cfs")
     cfs_layer.models.extend([swyang.stratoweave, swyang.ietf_inet_types])
     rfs_layer = swbuild.Layer.from_dir(fc, "yang/rfs")
-    rfs_layer.models.extend([swyang.stratoweave, swyang.rfs, swyang.ietf_inet_types, swyang.ietf_yang_types])
+    rfs_layer.models.extend([swyang.stratoweave, swyang.rfs, swyang.ssh, swyang.ietf_inet_types, swyang.ietf_yang_types])
 
     spec = swbuild.SysSpec("mini", [
         cfs_layer,

--- a/minisys/src/mini/layers/y_1.act
+++ b/minisys/src/mini/layers/y_1.act
@@ -59,12 +59,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -144,7 +144,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_13],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'http://example.com/mini-rfs':('mini-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'http://example.com/mini-rfs':('mini-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module mini-rfs {
@@ -335,6 +335,9 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -343,211 +346,6 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -641,7 +439,7 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -836,7 +634,220 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-inet-types {
+SRC_YANG_3: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_4: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1296,7 +1307,7 @@ SRC_YANG_3: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_4: str = r"""module ietf-yang-types {
+SRC_YANG_5: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -2069,12 +2080,14 @@ pure def src_yang() -> list[str]:
         SRC_YANG_2,
         SRC_YANG_3,
         SRC_YANG_4,
+        SRC_YANG_5,
     ]
 
 
 NS_mini_rfs: str = 'http://example.com/mini-rfs'
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 

--- a/minisys/src/mini/layers/y_1_loose.act
+++ b/minisys/src/mini/layers/y_1_loose.act
@@ -59,12 +59,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -144,7 +144,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_13],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'http://example.com/mini-rfs':('mini-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'http://example.com/mini-rfs':('mini-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module mini-rfs {
@@ -335,6 +335,9 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -343,211 +346,6 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -641,7 +439,7 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -836,7 +634,220 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-inet-types {
+SRC_YANG_3: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_4: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1296,7 +1307,7 @@ SRC_YANG_3: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_4: str = r"""module ietf-yang-types {
+SRC_YANG_5: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -2069,12 +2080,14 @@ pure def src_yang() -> list[str]:
         SRC_YANG_2,
         SRC_YANG_3,
         SRC_YANG_4,
+        SRC_YANG_5,
     ]
 
 
 NS_mini_rfs: str = 'http://example.com/mini-rfs'
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 

--- a/minisys/src/mini/layers/y_1_oper.act
+++ b/minisys/src/mini/layers/y_1_oper.act
@@ -60,12 +60,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -177,7 +177,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_20],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'http://example.com/mini-rfs':('mini-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None), 'http://example.com/mini-rfs':('mini-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module mini-rfs {
@@ -368,6 +368,9 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -376,211 +379,6 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -674,7 +472,7 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -869,7 +667,220 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-inet-types {
+SRC_YANG_3: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_4: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1329,7 +1340,7 @@ SRC_YANG_3: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_4: str = r"""module ietf-yang-types {
+SRC_YANG_5: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -2102,12 +2113,14 @@ pure def src_yang() -> list[str]:
         SRC_YANG_2,
         SRC_YANG_3,
         SRC_YANG_4,
+        SRC_YANG_5,
     ]
 
 
 NS_mini_rfs: str = 'http://example.com/mini-rfs'
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 

--- a/src/device_meta_config.act
+++ b/src/device_meta_config.act
@@ -59,12 +59,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -114,7 +114,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_13],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module stratoweave-rfs {
@@ -125,6 +125,9 @@ SRC_YANG_0: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -133,211 +136,6 @@ SRC_YANG_0: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -431,7 +229,7 @@ SRC_YANG_0: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -626,7 +424,220 @@ SRC_YANG_0: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_1: str = r"""module stratoweave {
+SRC_YANG_1: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_2: str = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave";
   prefix "sw";
@@ -689,7 +700,7 @@ SRC_YANG_1: str = r"""module stratoweave {
   }
 }"""
 
-SRC_YANG_2: str = r"""module ietf-inet-types {
+SRC_YANG_3: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1149,7 +1160,7 @@ SRC_YANG_2: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-yang-types {
+SRC_YANG_4: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -1921,11 +1932,13 @@ pure def src_yang() -> list[str]:
         SRC_YANG_1,
         SRC_YANG_2,
         SRC_YANG_3,
+        SRC_YANG_4,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 

--- a/src/device_oper.act
+++ b/src/device_oper.act
@@ -59,12 +59,12 @@ SRC_DNODE_CHILD_6: DList = DList(module='stratoweave-rfs', namespace='http://str
 ])
 
 SRC_DNODE_CHILD_7: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='ssh', config=True, description='SSH transport parameters used when connecting to this device. Applies\nto every SSH-based adapter (NETCONF over SSH, CLI, ...).', presence=False, children=[
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-rfs:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='cipher', config=True, description='Symmetric ciphers to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-cipher', description='Symmetric cipher, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'chacha20-poly1305@openssh.com':0, 'aes256-gcm@openssh.com':1, 'aes128-gcm@openssh.com':2, 'aes256-ctr':3, 'aes192-ctr':4, 'aes128-ctr':5, 'aes256-cbc':6, 'aes192-cbc':7, 'aes128-cbc':8, '3des-cbc':9, 'none':10})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mac', config=True, description='MAC algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-mac', description='Message authentication code, as negotiated in the SSH transport\nprotocol. Not used with AEAD ciphers, which authenticate themselves.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'hmac-sha2-256-etm@openssh.com':0, 'hmac-sha2-512-etm@openssh.com':1, 'hmac-sha1-etm@openssh.com':2, 'hmac-sha2-256':3, 'hmac-sha2-512':4, 'hmac-sha1':5, 'none':6})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='key-exchange', config=True, description='Key exchange algorithms to offer, most preferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-key-exchange', description='Key exchange algorithm, as negotiated in the SSH transport protocol.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'diffie-hellman-group-exchange-sha1':0, 'mlkem768x25519-sha256':1, 'mlkem768nistp256-sha256':2, 'sntrup761x25519-sha512':3, 'sntrup761x25519-sha512@openssh.com':4, 'curve25519-sha256':5, 'curve25519-sha256@libssh.org':6, 'ecdh-sha2-nistp256':7, 'ecdh-sha2-nistp384':8, 'ecdh-sha2-nistp521':9, 'diffie-hellman-group18-sha512':10, 'diffie-hellman-group16-sha512':11, 'diffie-hellman-group-exchange-sha256':12, 'diffie-hellman-group14-sha256':13, 'diffie-hellman-group14-sha1':14, 'diffie-hellman-group1-sha1':15})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='host-key-algorithm', config=True, description='Server host key algorithms to accept, most preferred first. This is\nwhat decides which host key type the device presents.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-host-key-algorithm', description='Server host key algorithm, i.e. the key type we are willing to accept\nfrom the far end and verify the session signature with.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='public-key-algorithm', config=True, description='Public key algorithms to offer for publickey authentication, most\npreferred first.', min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-public-key-algorithm', description='Public key algorithm offered during publickey authentication.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'ssh-ed25519-cert-v01@openssh.com':0, 'sk-ssh-ed25519-cert-v01@openssh.com':1, 'ecdsa-sha2-nistp521-cert-v01@openssh.com':2, 'ecdsa-sha2-nistp384-cert-v01@openssh.com':3, 'ecdsa-sha2-nistp256-cert-v01@openssh.com':4, 'sk-ecdsa-sha2-nistp256-cert-v01@openssh.com':5, 'rsa-sha2-512-cert-v01@openssh.com':6, 'rsa-sha2-256-cert-v01@openssh.com':7, 'ssh-rsa-cert-v01@openssh.com':8, 'ssh-ed25519':9, 'ecdsa-sha2-nistp521':10, 'ecdsa-sha2-nistp384':11, 'ecdsa-sha2-nistp256':12, 'sk-ssh-ed25519@openssh.com':13, 'sk-ecdsa-sha2-nistp256@openssh.com':14, 'rsa-sha2-512':15, 'rsa-sha2-256':16, 'ssh-rsa':17})),
+    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-algorithm', config=True, description="Compression algorithms to offer, most preferred first. 'none' first\ndisables compression against peers that also offer it.", min_elements=0, ordered_by='user', type=DTypeEnum(name='sw-ssh:ssh-compression-algorithm', description='Transport compression algorithm.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'zlib@openssh.com':1, 'zlib':2})),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='compression-level', config=True, description='zlib compression level, 1 (fastest) to 9 (smallest). Only relevant\nwhen a zlib compression algorithm is negotiated.', default='7', mandatory=False, type=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(1, 9)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-bytes', config=True, description='Rekey after this many bytes have passed over the session. Absent\nmeans the RFC 4344 volume limit of the negotiated cipher. A value\ncan only lower that limit, never raise it.', mandatory=False, type=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='rekey-after-seconds', config=True, description='Rekey after this many seconds. Absent disables time-based rekeying.', mandatory=False, type=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967)]))),
@@ -143,7 +143,7 @@ SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_20],
     identities=[],
     rpcs=[],
-    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
+    module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-ssh':('stratoweave-ssh', None), 'http://stratoweave.org/yang/stratoweave-rfs':('stratoweave-rfs', None)},
 )
 
 SRC_YANG_0: str = r"""module stratoweave-rfs {
@@ -154,6 +154,9 @@ SRC_YANG_0: str = r"""module stratoweave-rfs {
   import stratoweave {
     prefix sw;
   }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
   import ietf-inet-types {
     prefix inet;
   }
@@ -162,211 +165,6 @@ SRC_YANG_0: str = r"""module stratoweave-rfs {
   }
 
   description "RFS services";
-
-  typedef ssh-cipher {
-    type enumeration {
-      enum "chacha20-poly1305@openssh.com";
-      enum "aes256-gcm@openssh.com";
-      enum "aes128-gcm@openssh.com";
-      enum "aes256-ctr";
-      enum "aes192-ctr";
-      enum "aes128-ctr";
-      enum "aes256-cbc";
-      enum "aes192-cbc";
-      enum "aes128-cbc";
-      enum "3des-cbc";
-      enum "none";
-    }
-    description
-      "Symmetric cipher, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-mac {
-    type enumeration {
-      enum "hmac-sha2-256-etm@openssh.com";
-      enum "hmac-sha2-512-etm@openssh.com";
-      enum "hmac-sha1-etm@openssh.com";
-      enum "hmac-sha2-256";
-      enum "hmac-sha2-512";
-      enum "hmac-sha1";
-      enum "none";
-    }
-    description
-      "Message authentication code, as negotiated in the SSH transport
-     protocol. Not used with AEAD ciphers, which authenticate themselves.";
-  }
-
-  typedef ssh-key-exchange {
-    type enumeration {
-      enum "diffie-hellman-group-exchange-sha1";
-      enum "mlkem768x25519-sha256";
-      enum "mlkem768nistp256-sha256";
-      enum "sntrup761x25519-sha512";
-      enum "sntrup761x25519-sha512@openssh.com";
-      enum "curve25519-sha256";
-      enum "curve25519-sha256@libssh.org";
-      enum "ecdh-sha2-nistp256";
-      enum "ecdh-sha2-nistp384";
-      enum "ecdh-sha2-nistp521";
-      enum "diffie-hellman-group18-sha512";
-      enum "diffie-hellman-group16-sha512";
-      enum "diffie-hellman-group-exchange-sha256";
-      enum "diffie-hellman-group14-sha256";
-      enum "diffie-hellman-group14-sha1";
-      enum "diffie-hellman-group1-sha1";
-    }
-    description
-      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
-  }
-
-  typedef ssh-host-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Server host key algorithm, i.e. the key type we are willing to accept
-     from the far end and verify the session signature with.";
-  }
-
-  typedef ssh-public-key-algorithm {
-    type enumeration {
-      enum "ssh-ed25519-cert-v01@openssh.com";
-      enum "sk-ssh-ed25519-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
-      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
-      enum "rsa-sha2-512-cert-v01@openssh.com";
-      enum "rsa-sha2-256-cert-v01@openssh.com";
-      enum "ssh-rsa-cert-v01@openssh.com";
-      enum "ssh-ed25519";
-      enum "ecdsa-sha2-nistp521";
-      enum "ecdsa-sha2-nistp384";
-      enum "ecdsa-sha2-nistp256";
-      enum "sk-ssh-ed25519@openssh.com";
-      enum "sk-ecdsa-sha2-nistp256@openssh.com";
-      enum "rsa-sha2-512";
-      enum "rsa-sha2-256";
-      enum "ssh-rsa";
-    }
-    description
-      "Public key algorithm offered during publickey authentication.";
-  }
-
-  typedef ssh-compression-algorithm {
-    type enumeration {
-      enum "none";
-      enum "zlib@openssh.com";
-      enum "zlib";
-    }
-    description
-      "Transport compression algorithm.";
-  }
-
-  grouping ssh-client-config {
-    description
-      "SSH client transport parameters, shared by every adapter that talks to
-       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
-       ordered preference list sent in the SSH key exchange; leaving one empty
-       means the SSH library picks its own default set.";
-
-    leaf-list cipher {
-      description
-        "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
-      ordered-by user;
-    }
-
-    leaf-list mac {
-      description
-        "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
-      ordered-by user;
-    }
-
-    leaf-list key-exchange {
-      description
-        "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
-      ordered-by user;
-    }
-
-    leaf-list host-key-algorithm {
-      description
-        "Server host key algorithms to accept, most preferred first. This is
-         what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list public-key-algorithm {
-      description
-        "Public key algorithms to offer for publickey authentication, most
-         preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
-      ordered-by user;
-    }
-
-    leaf-list compression-algorithm {
-      description
-        "Compression algorithms to offer, most preferred first. 'none' first
-         disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
-      ordered-by user;
-    }
-
-    leaf compression-level {
-      description
-        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
-         when a zlib compression algorithm is negotiated.";
-      type uint8 {
-        range "1..9";
-      }
-      default 7;
-    }
-
-    leaf rekey-after-bytes {
-      description
-        "Rekey after this many bytes have passed over the session. Absent
-         means the RFC 4344 volume limit of the negotiated cipher. A value
-         can only lower that limit, never raise it.";
-      type uint64;
-    }
-
-    leaf rekey-after-seconds {
-      description
-        "Rekey after this many seconds. Absent disables time-based rekeying.";
-      type uint32 {
-        range "0..4294967";
-      }
-    }
-
-    leaf minimum-rsa-bits {
-      description
-        "Reject RSA host and public keys shorter than this.";
-      type uint32 {
-        range "1024..2147483647";
-      }
-      default 1024;
-    }
-  }
 
   grouping check-result {
     leaf verdict {
@@ -460,7 +258,7 @@ SRC_YANG_0: str = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {
@@ -655,7 +453,220 @@ SRC_YANG_0: str = r"""module stratoweave-rfs {
 }
 """
 
-SRC_YANG_1: str = r"""module stratoweave {
+SRC_YANG_1: str = r"""module stratoweave-ssh {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
+
+  description "Reusable SSH client transport types and groupings.";
+
+  typedef ssh-cipher {
+    type enumeration {
+      enum "chacha20-poly1305@openssh.com";
+      enum "aes256-gcm@openssh.com";
+      enum "aes128-gcm@openssh.com";
+      enum "aes256-ctr";
+      enum "aes192-ctr";
+      enum "aes128-ctr";
+      enum "aes256-cbc";
+      enum "aes192-cbc";
+      enum "aes128-cbc";
+      enum "3des-cbc";
+      enum "none";
+    }
+    description
+      "Symmetric cipher, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-mac {
+    type enumeration {
+      enum "hmac-sha2-256-etm@openssh.com";
+      enum "hmac-sha2-512-etm@openssh.com";
+      enum "hmac-sha1-etm@openssh.com";
+      enum "hmac-sha2-256";
+      enum "hmac-sha2-512";
+      enum "hmac-sha1";
+      enum "none";
+    }
+    description
+      "Message authentication code, as negotiated in the SSH transport
+     protocol. Not used with AEAD ciphers, which authenticate themselves.";
+  }
+
+  typedef ssh-key-exchange {
+    type enumeration {
+      enum "diffie-hellman-group-exchange-sha1";
+      enum "mlkem768x25519-sha256";
+      enum "mlkem768nistp256-sha256";
+      enum "sntrup761x25519-sha512";
+      enum "sntrup761x25519-sha512@openssh.com";
+      enum "curve25519-sha256";
+      enum "curve25519-sha256@libssh.org";
+      enum "ecdh-sha2-nistp256";
+      enum "ecdh-sha2-nistp384";
+      enum "ecdh-sha2-nistp521";
+      enum "diffie-hellman-group18-sha512";
+      enum "diffie-hellman-group16-sha512";
+      enum "diffie-hellman-group-exchange-sha256";
+      enum "diffie-hellman-group14-sha256";
+      enum "diffie-hellman-group14-sha1";
+      enum "diffie-hellman-group1-sha1";
+    }
+    description
+      "Key exchange algorithm, as negotiated in the SSH transport protocol.";
+  }
+
+  typedef ssh-host-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Server host key algorithm, i.e. the key type we are willing to accept
+     from the far end and verify the session signature with.";
+  }
+
+  typedef ssh-public-key-algorithm {
+    type enumeration {
+      enum "ssh-ed25519-cert-v01@openssh.com";
+      enum "sk-ssh-ed25519-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+      enum "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+      enum "rsa-sha2-512-cert-v01@openssh.com";
+      enum "rsa-sha2-256-cert-v01@openssh.com";
+      enum "ssh-rsa-cert-v01@openssh.com";
+      enum "ssh-ed25519";
+      enum "ecdsa-sha2-nistp521";
+      enum "ecdsa-sha2-nistp384";
+      enum "ecdsa-sha2-nistp256";
+      enum "sk-ssh-ed25519@openssh.com";
+      enum "sk-ecdsa-sha2-nistp256@openssh.com";
+      enum "rsa-sha2-512";
+      enum "rsa-sha2-256";
+      enum "ssh-rsa";
+    }
+    description
+      "Public key algorithm offered during publickey authentication.";
+  }
+
+  typedef ssh-compression-algorithm {
+    type enumeration {
+      enum "none";
+      enum "zlib@openssh.com";
+      enum "zlib";
+    }
+    description
+      "Transport compression algorithm.";
+  }
+
+  grouping ssh-client-config {
+    description
+      "SSH client transport parameters, shared by every adapter that talks to
+       a device over SSH (NETCONF, CLI, ...). Each algorithm leaf-list is the
+       ordered preference list sent in the SSH key exchange; leaving one empty
+       means the SSH library picks its own default set.";
+
+    leaf-list cipher {
+      description
+        "Symmetric ciphers to offer, most preferred first.";
+      type sw-ssh:ssh-cipher;
+      ordered-by user;
+    }
+
+    leaf-list mac {
+      description
+        "MAC algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-mac;
+      ordered-by user;
+    }
+
+    leaf-list key-exchange {
+      description
+        "Key exchange algorithms to offer, most preferred first.";
+      type sw-ssh:ssh-key-exchange;
+      ordered-by user;
+    }
+
+    leaf-list host-key-algorithm {
+      description
+        "Server host key algorithms to accept, most preferred first. This is
+         what decides which host key type the device presents.";
+      type sw-ssh:ssh-host-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list public-key-algorithm {
+      description
+        "Public key algorithms to offer for publickey authentication, most
+         preferred first.";
+      type sw-ssh:ssh-public-key-algorithm;
+      ordered-by user;
+    }
+
+    leaf-list compression-algorithm {
+      description
+        "Compression algorithms to offer, most preferred first. 'none' first
+         disables compression against peers that also offer it.";
+      type sw-ssh:ssh-compression-algorithm;
+      ordered-by user;
+    }
+
+    leaf compression-level {
+      description
+        "zlib compression level, 1 (fastest) to 9 (smallest). Only relevant
+         when a zlib compression algorithm is negotiated.";
+      type uint8 {
+        range "1..9";
+      }
+      default 7;
+    }
+
+    leaf rekey-after-bytes {
+      description
+        "Rekey after this many bytes have passed over the session. Absent
+         means the RFC 4344 volume limit of the negotiated cipher. A value
+         can only lower that limit, never raise it.";
+      type uint64;
+    }
+
+    leaf rekey-after-seconds {
+      description
+        "Rekey after this many seconds. Absent disables time-based rekeying.";
+      type uint32 {
+        range "0..4294967";
+      }
+    }
+
+    leaf minimum-rsa-bits {
+      description
+        "Reject RSA host and public keys shorter than this.";
+      type uint32 {
+        range "1024..2147483647";
+      }
+      default 1024;
+    }
+  }
+}"""
+
+SRC_YANG_2: str = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave";
   prefix "sw";
@@ -718,7 +729,7 @@ SRC_YANG_1: str = r"""module stratoweave {
   }
 }"""
 
-SRC_YANG_2: str = r"""module ietf-inet-types {
+SRC_YANG_3: str = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1178,7 +1189,7 @@ SRC_YANG_2: str = r"""module ietf-inet-types {
 }
 """
 
-SRC_YANG_3: str = r"""module ietf-yang-types {
+SRC_YANG_4: str = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -1950,11 +1961,13 @@ pure def src_yang() -> list[str]:
         SRC_YANG_1,
         SRC_YANG_2,
         SRC_YANG_3,
+        SRC_YANG_4,
     ]
 
 
 NS_stratoweave: str = 'http://stratoweave.org/yang/stratoweave'
 NS_stratoweave_rfs: str = 'http://stratoweave.org/yang/stratoweave-rfs'
+NS_stratoweave_ssh: str = 'http://stratoweave.org/yang/stratoweave-ssh'
 NS_ietf_inet_types: str = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 NS_ietf_yang_types: str = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 

--- a/src/swyang.act
+++ b/src/swyang.act
@@ -62,22 +62,12 @@ stratoweave = r"""module stratoweave {
 }"""
 
 
-rfs = r"""module stratoweave-rfs {
+ssh = r"""module stratoweave-ssh {
   yang-version "1.1";
-  namespace "http://stratoweave.org/yang/stratoweave-rfs";
-  prefix "sw-rfs";
+  namespace "http://stratoweave.org/yang/stratoweave-ssh";
+  prefix "sw-ssh";
 
-  import stratoweave {
-    prefix sw;
-  }
-  import ietf-inet-types {
-    prefix inet;
-  }
-  import ietf-yang-types {
-    prefix yang;
-  }
-
-  description "RFS services";
+  description "Reusable SSH client transport types and groupings.";
 
   typedef ssh-cipher {
     type enumeration {
@@ -206,21 +196,21 @@ rfs = r"""module stratoweave-rfs {
     leaf-list cipher {
       description
         "Symmetric ciphers to offer, most preferred first.";
-      type sw-rfs:ssh-cipher;
+      type sw-ssh:ssh-cipher;
       ordered-by user;
     }
 
     leaf-list mac {
       description
         "MAC algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-mac;
+      type sw-ssh:ssh-mac;
       ordered-by user;
     }
 
     leaf-list key-exchange {
       description
         "Key exchange algorithms to offer, most preferred first.";
-      type sw-rfs:ssh-key-exchange;
+      type sw-ssh:ssh-key-exchange;
       ordered-by user;
     }
 
@@ -228,7 +218,7 @@ rfs = r"""module stratoweave-rfs {
       description
         "Server host key algorithms to accept, most preferred first. This is
          what decides which host key type the device presents.";
-      type sw-rfs:ssh-host-key-algorithm;
+      type sw-ssh:ssh-host-key-algorithm;
       ordered-by user;
     }
 
@@ -236,7 +226,7 @@ rfs = r"""module stratoweave-rfs {
       description
         "Public key algorithms to offer for publickey authentication, most
          preferred first.";
-      type sw-rfs:ssh-public-key-algorithm;
+      type sw-ssh:ssh-public-key-algorithm;
       ordered-by user;
     }
 
@@ -244,7 +234,7 @@ rfs = r"""module stratoweave-rfs {
       description
         "Compression algorithms to offer, most preferred first. 'none' first
          disables compression against peers that also offer it.";
-      type sw-rfs:ssh-compression-algorithm;
+      type sw-ssh:ssh-compression-algorithm;
       ordered-by user;
     }
 
@@ -283,6 +273,28 @@ rfs = r"""module stratoweave-rfs {
       default 1024;
     }
   }
+}"""
+
+
+rfs = r"""module stratoweave-rfs {
+  yang-version "1.1";
+  namespace "http://stratoweave.org/yang/stratoweave-rfs";
+  prefix "sw-rfs";
+
+  import stratoweave {
+    prefix sw;
+  }
+  import stratoweave-ssh {
+    prefix sw-ssh;
+  }
+  import ietf-inet-types {
+    prefix inet;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  description "RFS services";
 
   grouping check-result {
     leaf verdict {
@@ -376,7 +388,7 @@ rfs = r"""module stratoweave-rfs {
       description
         "SSH transport parameters used when connecting to this device. Applies
          to every SSH-based adapter (NETCONF over SSH, CLI, ...).";
-      uses sw-rfs:ssh-client-config;
+      uses sw-ssh:ssh-client-config;
     }
 
     leaf approval-required {

--- a/src/test_ttt_gen.act
+++ b/src/test_ttt_gen.act
@@ -190,12 +190,12 @@ ys_bad_transform_module_name = r"""module foo {
 """
 
 def _test_ttt_gen_rfs_base():
-    y = yang.compile([swyang.stratoweave, swyang.rfs, swyang.ietf_inet_types, swyang.ietf_yang_types, ys_rfs])
+    y = yang.compile([swyang.stratoweave, swyang.rfs, swyang.ssh, swyang.ietf_inet_types, swyang.ietf_yang_types, ys_rfs])
     r = ttt_gen.ttt_prsrc(y, 'respnet.layers.y_1', '')
     return r.base
 
 def _test_ttt_gen_rfs_ttt():
-    y = yang.compile([swyang.stratoweave, swyang.rfs, swyang.ietf_inet_types, swyang.ietf_yang_types, ys_rfs])
+    y = yang.compile([swyang.stratoweave, swyang.rfs, swyang.ssh, swyang.ietf_inet_types, swyang.ietf_yang_types, ys_rfs])
     r = ttt_gen.ttt_prsrc(y, 'respnet.layers.y_1', '')
     return r.ttt
 


### PR DESCRIPTION
FleetMgr devices and nodes cannot configure the SSH client options defined in stratoweave-rfs. Move those options into a reusable stratoweave-ssh grouping and propagate them through both transform layers.

Align FleetMgr's YANG dependency and regenerate the affected bindings.
