### PR TITLE
Upgrade acton-yang

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -28,8 +28,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/a4ebb78c7cc75912b083f7395fd0fd294a2f43bc.zip",
-        hash="N-V-__8AAFaFKADPehkA-iHnOAy-xtwGmNuoHaO0Fr4KIsRU"
+        url="https://github.com/stratoweave/acton-yang/archive/d5524ee8c3c60dd0240ddb8437cb51b2ae01898f.zip",
+        hash="N-V-__8AAMWGKADdIkyQiSDHVV8K-KOaLLOL8vtj7rxuZ4Sr"
     )
 }
 zig_dependencies = {}

--- a/gen_adata/Build.act
+++ b/gen_adata/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x7d1c1e932a731ef0
 dependencies = {
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/a4ebb78c7cc75912b083f7395fd0fd294a2f43bc.zip",
-        hash="N-V-__8AAFaFKADPehkA-iHnOAy-xtwGmNuoHaO0Fr4KIsRU"
+        url="https://github.com/stratoweave/acton-yang/archive/d5524ee8c3c60dd0240ddb8437cb51b2ae01898f.zip",
+        hash="N-V-__8AAMWGKADdIkyQiSDHVV8K-KOaLLOL8vtj7rxuZ4Sr"
     )
 }
 zig_dependencies = {}

--- a/minisys/Build.act
+++ b/minisys/Build.act
@@ -11,8 +11,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/a4ebb78c7cc75912b083f7395fd0fd294a2f43bc.zip",
-        hash="N-V-__8AAFaFKADPehkA-iHnOAy-xtwGmNuoHaO0Fr4KIsRU"
+        url="https://github.com/stratoweave/acton-yang/archive/d5524ee8c3c60dd0240ddb8437cb51b2ae01898f.zip",
+        hash="N-V-__8AAMWGKADdIkyQiSDHVV8K-KOaLLOL8vtj7rxuZ4Sr"
     )
 }
 zig_dependencies = {}

--- a/minisys/gen/Build.act
+++ b/minisys/gen/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/a4ebb78c7cc75912b083f7395fd0fd294a2f43bc.zip",
-        hash="N-V-__8AAFaFKADPehkA-iHnOAy-xtwGmNuoHaO0Fr4KIsRU"
+        url="https://github.com/stratoweave/acton-yang/archive/d5524ee8c3c60dd0240ddb8437cb51b2ae01898f.zip",
+        hash="N-V-__8AAMWGKADdIkyQiSDHVV8K-KOaLLOL8vtj7rxuZ4Sr"
     )
 }
 zig_dependencies = {}

--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -256,7 +256,7 @@ def subscription_delay(spec: ygdata.SubscriptionSpec) -> float:
 
 def merge_subscription_tree(want: set[ygdata.SubscriptionSpec], subs: dict[ygdata.SubscriptionSpec, SharedSubscription]) -> ?ygdata.Node:
     merged = None
-    for spec in ygdata.hack_sorted(iter(want)):
+    for spec in want:
         if spec in subs:
             sub = subs[spec]
             if sub.latest is not None:

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -455,7 +455,7 @@ def fold(want: set[gdata.SubscriptionSpec]) -> dict[u64, ?gdata.FNode]:
     nothing, or no filter, is everything."""
     branches: dict[u64, list[gdata.FNode]] = {}
     whole: set[u64] = set()
-    for spec in gdata.hack_sorted(iter(want)):           # a canonical union, whatever the set order
+    for spec in want:
         period = spec.period
         if period is not None:
             if period not in branches:
@@ -1313,7 +1313,7 @@ class _ContainerTransaction(_Transaction):
     # yield action
     def lock(self, actself, tid, out: ?Session, done, dbuf: ?swdb.Buffer=None):
         #print('####', tid, '(Container)', _format_path(self.path), 'lock', sorted(self.accum.keys()), err=True)
-        it = iter(gdata.hack_sorted(self.accum.keys()))
+        it = iter(sorted(self.accum.keys()))
         try:
             key = next(it)
             self.state = YieldState(it, key, tid, out, done, dbuf)
@@ -1354,7 +1354,7 @@ class _ContainerTransaction(_Transaction):
     # yield action
     def wait_complete(self, actself, tid, done):
         #print('####', tid, '(Container)', _format_path(self.path), 'wait_complete', list(self.accum.keys()), err=True)
-        it = iter(gdata.hack_sorted(self.elems.keys()))
+        it = iter(sorted(self.elems.keys()))
         try:
             key = next(it)
             self.state = YieldState(it, key, tid, None, done)


### PR DESCRIPTION
Acton-yang now exposes native ordering for gdata IDs and no longer exports the temporary hack_sorted helper.

Update every managed dependency pin. Iterate subscription specs without imposing an order, matching the acton-yang contract, and use native sorting for deterministic string-key traversal.