### PR TITLE
Serve on-change subscriptions from a TTT layer and the northbound

### DIFF
--- a/docs/reference/subscriptions.md
+++ b/docs/reference/subscriptions.md
@@ -314,6 +314,18 @@ call describes the full desired subscription set for that owner.
 The update callback receives one merged gdata tree for the owner, not
 one callback per subscription.
 
+## Northbound On-Change
+
+The northbound NETCONF server serves on-change YANG-Push from a TTT layer,
+for the operational datastore: a `push-update` with the baseline when
+sync-on-start is asked for, then one `push-change-update` per change. Its
+yang-patch is built from the change itself, with no tree diff: a `replace`
+of the changed transform's subtree, so omitted descendants disappear at the
+client, or a `remove` of the node that emptied, so a deleted list entry is
+one edit. Targets are module-qualified from the served schema. A failure
+while serving ends the subscription with `subscription-terminated`. A
+non-zero dampening-period and excluded change types are rejected.
+
 ## Internal Model
 
 `SubscriptionManager` is the declarative owner-facing API. Below it, a TTT

--- a/docs/reference/subscriptions.md
+++ b/docs/reference/subscriptions.md
@@ -190,11 +190,12 @@ callback `keys.device_name`, `keys.interface_name` and the interface.
 
 The first pass delivers every instance the filter selects, one call each,
 and then calls `synced`. After that each read delivers the instances that
-changed since the last one, whatever the size of the list, so a
-subscriber to a hundred thousand devices is called with one device. The
-filters handed to a rooted destination must lead to its node, and they
-are read on one period. A destination rooted at a container receives
-that container, or `None` when it is gone.
+changed since the last one, and on-change each change delivers the
+instances it touched, whatever the size of the list, so a subscriber to a
+hundred thousand devices is called with one device. The filters handed to
+a rooted destination must lead to its node, and they are read on one
+period or served on-change, not both. A destination rooted at a container
+receives that container, or `None` when it is gone.
 
 `synced` belongs to the declaration, not to one destination: it is
 called once, when every delivery in that `declare` has had its first
@@ -228,9 +229,34 @@ Omitting `period` creates an on-change `SubscriptionSpec`:
 spec = sub.system_state.clock.subscribe(depth=1)
 ```
 
-The generated filter helper supports this directly. The current
-`NetconfDriver` limitation still applies, so on-change subscriptions are
-not yet accepted there.
+On a TTT layer an on-change subscription carries the operational state the
+layer's transforms publish with `update_oper`, and nothing else: no config,
+except the keys of the list entries the state sits under. What a transform
+passes to `update_oper` replaces its whole contribution; `None` removes it.
+
+The delivery contract:
+
+- The first delivery is the complete baseline, and may be `None` when no
+  transform under the filter has published yet. A consumer must accept that.
+- After the baseline every `update_oper` under the filter is delivered as it
+  happens, in the order the layer received them, with the tree rebuilt
+  along the changed path and everything else shared by reference. An update
+  that leaves a transform's filtered slice unchanged is not delivered.
+- On-change and periodic filters of one consumer are delivered as one view.
+  Rooted at a node, each change delivers the instances it touched.
+- A list entry joins the subscription when its transaction commits, never
+  while it is provisional. TTT does not clear a transform's oper when its
+  config is removed: the transform actor does, from its `shutdown`, with
+  `update_oper(None)`, and the entry leaves the tree.
+- Oper is not transactional: a commit that touches several entries can be
+  seen entry by entry, and a config change and an oper push can race.
+- A filter that the tree cannot route, such as a content predicate on a
+  container entry that would span several transforms, is reported once as
+  an error and the subscription is dropped.
+
+TTT decides on-change from `period` alone; the `on_change` flag on
+`SubscriptionSpec` exists for device subscriptions and is ignored here. The
+`NetconfDriver` accepts on-change only against a device that pushes natively.
 
 ## `SubscriptionSpec`
 
@@ -288,13 +314,6 @@ call describes the full desired subscription set for that owner.
 The update callback receives one merged gdata tree for the owner, not
 one callback per subscription.
 
-## Current NETCONF Limitation
-
-The current `NetconfDriver` only implements periodic subscriptions by
-issuing periodic `<get>` operations. On-change subscriptions are not yet
-implemented there, so a `SubscriptionSpec` with `period=None` will be
-rejected by that driver.
-
 ## Internal Model
 
 `SubscriptionManager` is the declarative owner-facing API. Below it, a TTT
@@ -306,12 +325,35 @@ latest trees merged into one view, sent straight to the consumer, by
 reference when there is one read. The Layer keeps only which actor serves
 which consumer.
 
-Each `declare(...)` call is the consumer's complete desired state. The
-actor drops the reads no longer wanted, starts changed ones over, keeps
-the rest with their latest trees, and calls `synced` once every read of
-the declaration has run.
+The consumer's on-change filters fold into one subscription in the tree.
+This is telemetry, apart from the link subscriptions that carry config
+between transforms: nothing in it is transactional or waits. The actor
+walks the layer's tree once to lay it: each node answers with its path,
+its oper slice if it is a producer, and the children to continue with. A
+container transposes the filter and decides predicates on its own keys;
+a list selects entries by exact key or all of them and keeps the
+subscription so entries that commit later join it; a transform keeps it
+and answers its slice. The answers become the actor's shadow of the
+subscribed part of the tree, and the end of the walk is the baseline.
+After that every producer under the subscription pushes its slice to the
+actor as it changes, when it changed; the actor rebuilds the shadow
+along the changed path, shares everything else by reference, and
+delivers the view with the reads' latest trees merged in. A consumer
+that asks for it, the northbound NETCONF server does, gets each change
+alone first: the path of the node that changed with what it held before
+and after. TTT does not clear a transform's oper when its config goes:
+the transform actor does, from its `shutdown`, with `update_oper(None)`,
+and the entry leaves the view. The subscription is laid again only when
+its filter changes.
 
-A consumer rooted at a node has one read, and instead of one view gets,
-after each read, every instance that differs from the last read and
-every instance gone, each as a tree from the top down to that one
-instance.
+Each `declare(...)` call is the consumer's complete desired state. The
+actor drops the reads and the subscription no longer wanted, starts
+changed ones over, keeps the rest with their latest trees, and calls
+`synced` once every read of the declaration has run and its subscription
+has been laid.
+
+A consumer rooted at a node has one read, or one subscription in the
+tree, and instead of one view gets, after each read, every instance that
+differs from the last read and every instance gone, and after each
+change the instances it touched, each as a tree from the top down to
+that one instance.

--- a/minisys/src/mini/cfs.act
+++ b/minisys/src/mini/cfs.act
@@ -42,7 +42,7 @@ actor RouterTransform(path: ttt.Path, update_dynstate: proc(?y_0.netinfra__netin
         want = set()
         rfs = y1_oper.subs.rfs
         want.add(rfs.dst(on_rfs_state).deliver({
-            rfs.entry(router_name).base_config.state.current_datetime.subscribe(period=0.1)
+            rfs.entry(router_name).base_config.state.current_datetime.subscribe()
         }))
         _subs.declare(want)
 

--- a/src/netconf_server.act
+++ b/src/netconf_server.act
@@ -22,7 +22,7 @@ CAP_WRITABLE_RUNNING = "urn:ietf:params:netconf:capability:writable-running:1.0"
 # YANG-push / subscribed-notifications module capabilities (RFC 8639 / 8641),
 # advertised in <hello> so a client can discover dynamic-subscription support.
 CAP_SUBSCRIBED_NOTIFICATIONS = "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications?module=ietf-subscribed-notifications"
-CAP_YANG_PUSH = "urn:ietf:params:xml:ns:yang:ietf-yang-push?module=ietf-yang-push"
+CAP_YANG_PUSH = "urn:ietf:params:xml:ns:yang:ietf-yang-push?module=ietf-yang-push&features=on-change"
 
 
 def build_capabilities(schema: yschema.DRoot) -> list[str]:

--- a/src/test_netconf_server.act
+++ b/src/test_netconf_server.act
@@ -10,8 +10,9 @@ Two angles, both against a real TTT layer:
 
 YANG-push subscriptions are served per session by a TttSubscriptionService, and
 covered over the pipe: a periodic establish-subscription is accepted (returns a
-subscription-id), a raw on-change establish-subscription is rejected with an
-rpc-error (the client helper only builds periodic requests), subtree and XPath
+subscription-id), an on-change establish-subscription gets a sync-on-start
+push-update and then a push-change-update yang-patch per transform oper update,
+which the client applies to rebuild the tree, subtree and XPath
 filters narrow the push to selected nodes (a container leaf, and one keyed list
 entry's oper subtree), invalid filters are rejected without allocating an id,
 and two sessions on one TTT layer stay isolated, with a datastore change
@@ -30,6 +31,8 @@ import ttt as ttt
 import yang
 import yang.gdata as gdata
 import yang.schema as yschema
+import yang.xml as yxml
+import yang.ypatch as ypatch
 
 import netconf_server as swnetconf
 import yp
@@ -43,6 +46,10 @@ DEMO_YANG = r"""module demo {
   container system {
     leaf hostname { type string; }
     leaf location { type string; }
+    container state {
+      config false;
+      leaf status { type string; }
+    }
   }
 }"""
 
@@ -131,6 +138,77 @@ def _demo_layer() -> ttt.Layer:
     return ttt.Layer("top", ttt.Container({
         _q("system"): ttt.Transform(ttt.PassThrough),
     }), None)
+
+
+actor DemoTelemetryPublisher(update_oper: action(?gdata.Node) -> None):
+    """Publishes operational state independently of the config transaction."""
+    def _publish(status: str):
+        # A producer's tree carries the module at its namespace boundary, as
+        # the generated adata to_gdata() does; yang-patch targets need it.
+        update_oper(gdata.Container({
+            _q("state"): gdata.Container({
+                _q("status"): gdata.Leaf(status),
+            }),
+        }, ns=DEMO_NS, module="demo"))
+
+    def on_conf(_conf: gdata.Node, _memory: ?gdata.Node):
+        _publish("starting")
+        after 0.05: _publish("ready")
+
+    def shutdown(_memory: ?gdata.Node):
+        update_oper(None)
+
+
+def DemoTelemetryPublisherCtor(params: ttt.TransformActorParams) -> ttt.TransformActor:
+    p = DemoTelemetryPublisher(params.update_oper)
+    return ttt.TransformActor(p.on_conf, p.shutdown)
+
+
+def _demo_telemetry_layer() -> ttt.Layer:
+    return ttt.Layer("top", ttt.Container({
+        _q("system"): ttt.Transform(ttt.PassThrough, DemoTelemetryPublisherCtor),
+    }), None)
+
+
+actor DemoRelay(update_oper: action(?gdata.Node) -> None, lower: ?gdata.TreeProvider):
+    """An upper-layer transform actor: subscribes on-change to the layer below
+    and republishes its system state as this node's own oper."""
+    _subs = gdata.SubscriptionManager(lower!, "relay")
+
+    def on_lower(tree: ?gdata.Node, err: ?Exception):
+        oper: ?gdata.Node = None
+        if tree is not None:
+            if isinstance(tree, gdata.Container):
+                oper = tree.children.get(_q("system"))
+        update_oper(oper)
+
+    def on_conf(_conf: gdata.Node, _memory: ?gdata.Node):
+        _subs.declare({gdata.Dst(on_lower).deliver({gdata.SubscriptionSpec(None)})})
+
+    def shutdown(_memory: ?gdata.Node):
+        update_oper(None)
+
+
+def DemoRelayCtor(params: ttt.TransformActorParams) -> ttt.TransformActor:
+    r = DemoRelay(params.update_oper, params.lower_tree_provider)
+    return ttt.TransformActor(r.on_conf, r.shutdown)
+
+
+class DemoDown(ttt.TransformFunction):
+    """Writes this node's config to the same node in the layer below."""
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
+        return gdata.Container({_q("system"): cfg}), memory
+
+
+def _demo_two_layers() -> ttt.Layer:
+    """The served layer writes its config down to a lower layer whose transform
+    publishes the state; the served layer's actor relays that state back up."""
+    lower = ttt.Layer("lower", ttt.Container({
+        _q("system"): ttt.Transform(ttt.PassThrough, DemoTelemetryPublisherCtor),
+    }), None)
+    return ttt.Layer("top", ttt.Container({
+        _q("system"): ttt.Transform(DemoDown, DemoRelayCtor, None, lower),
+    }), lower)
 
 
 def _leaf_text_from_reply(reply: ?xml.Node, leaf_name: str) -> ?str:
@@ -294,42 +372,92 @@ actor _test_edit_config_rejects_nonrunning_target(t: testing.AsyncT):
     after 5.0: fail(ValueError("timed out waiting for edit-config rejection"))
 
 
-actor _test_subscription_rejects_on_change(t: testing.AsyncT):
-    """An on-change establish-subscription is rejected: v1 serves periodic only,
-    so the server fails closed rather than quietly serving full-tree pushes."""
+actor _OnChangeOperUpdate(t: testing.AsyncT, layer: ttt.Layer):
+    """A transform's update_oper reaches the client as a yang-patch: the
+    establish gets a sync-on-start push-update, then every oper change a
+    push-change-update, and the client rebuilds the tree from them."""
     lh = logging.Handler("nctest")
     schema = _demo_schema()
-    layer = _demo_layer()
     caps = swnetconf.build_capabilities(schema)
 
     pipes = netconf.actor_pipe_pair()
     server = swnetconf.NetconfSession(pipes.server, lh, schema, layer, caps)
 
     var done = False
+    var synced = False
+    var client_tree: ?gdata.Node = None
+
     def fail(e: Exception):
         if not done:
             done = True
             t.failure(e)
 
-    def _on_reply(c: netconf.Client, reply: ?xml.Node, err: ?netconf.NetconfError):
-        # The client helper only builds periodic requests, so send a raw on-change
-        # establish; the server must reject it with an rpc-error.
+    def _on_deleted(c: netconf.Client, err: ?netconf.NetconfError):
         if err is not None:
-            if not done:
-                done = True
-                t.success()
+            fail(err)
+        elif not done:
+            done = True
+            c.close(None)
+            t.success()
+
+    def _on_notif(c: netconf.Client, notif: xml.Node):
+        pu = yp.parse_push_update(notif)
+        if pu is not None:
+            synced = True
+            return
+        pcu = yp.parse_push_change_update(notif)
+        if pcu is not None:
+            if not synced:
+                fail(ValueError("push-change-update arrived before sync-on-start"))
+                return
+            patch_xml = pcu.yang_patch
+            if patch_xml is not None:
+                for edit in ypatch.Patch.from_xml(patch_xml).edits:
+                    client_tree = gdata.patch(client_tree, ypatch.edit_to_gdata(schema, edit))
+                ct = client_tree
+                if ct is not None and ct.to_xmlstr().find(">ready<") != -1:
+                    sid = pcu.sub_id
+                    if sid is not None:
+                        c.delete_subscription(_on_deleted, sid)
+                    else:
+                        fail(ValueError("push-change-update carried no subscription id"))
+            return
+        fail(ValueError("unexpected notification: " + notif.encode()))
+
+    def _on_edited(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+
+    def _on_sub(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+        elif sub_id is None:
+            fail(ValueError("on-change establish-subscription returned no id"))
         else:
-            fail(ValueError("expected on-change to be rejected, got a reply"))
+            # Committing config starts the transform's actor, which publishes.
+            config = xml.decode('<system xmlns="urn:demo"><hostname>r1</hostname></system>')
+            c.edit_config([config], _on_edited)
 
     def _on_connect(c: netconf.Client, e: ?Exception):
         if e is not None:
             fail(ValueError("client connect failed: {e}"))
             return
-        op = xml.decode('<establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications"><datastore xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push" xmlns:ds="urn:ietf:params:xml:ns:yang:ietf-datastores">ds:operational</datastore><on-change xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"><dampening-period>0</dampening-period></on-change></establish-subscription>')
-        c.rpc(op, _on_reply)
+        c.establish_subscription(_on_sub, on_change=True, dampening_period=0)
 
-    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, None, True, lh, pipe=pipes.client)
-    after 5.0: fail(ValueError("timed out waiting for on-change rejection"))
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, _on_notif, True, lh, pipe=pipes.client)
+    after 5.0: fail(ValueError("timed out waiting for the on-change oper update (synced={synced})"))
+
+
+actor _test_subscription_on_change_oper_update(t: testing.AsyncT):
+    """One layer: the served transform's own actor publishes the state."""
+    _OnChangeOperUpdate(t, _demo_telemetry_layer())
+
+
+actor _test_subscription_on_change_through_two_layers(t: testing.AsyncT):
+    """Two layers: the state is published in the lower layer, crosses into the
+    served layer through its transform actor's on-change subscription, and
+    reaches the NETCONF client as yang-patches, with no sampling anywhere."""
+    _OnChangeOperUpdate(t, _demo_two_layers())
 
 
 actor _test_subscription_periodic_accepted(t: testing.AsyncT):

--- a/src/test_ttt_on_change.act
+++ b/src/test_ttt_on_change.act
@@ -1,0 +1,1191 @@
+"""On-change oper subscriptions on a TTT layer.
+
+A subscription without a period is served by the consumer's Subscription
+actor from a route down to the transforms under its filter: the walk that
+registers the route ends with one complete baseline, and after that every
+update_oper reaches the subscriber at once, as the whole tree and, for a
+consumer that asks, as the change alone: the path of the node that changed
+with what it held before and after. Rooted at a node, the consumer gets the
+instances a change touched instead. Config is not part of it: these tests
+push oper into transforms through a Hub and watch what the subscriber
+receives.
+"""
+
+import testing
+
+import ttt as ttt
+import yang.gdata as gdata
+from test_ttt_subscriptions import Noop, Hub, Pusher, pusher_ctor
+
+TEST_NS = "urn:test-on-change"
+
+def q(n: str) -> gdata.Id:
+    return gdata.Id(TEST_NS, n)
+
+
+def service_layer(hub: Hub, name: str="top") -> ttt.Layer:
+    return ttt.Layer(name, ttt.Container({
+        q("service"): ttt.List(ttt.Transform(Noop, pusher_ctor(hub)), [q("name")], ns=TEST_NS, module="test-on-change"),
+    }), None)
+
+def services(names: list[str]) -> gdata.Node:
+    return gdata.Container({
+        q("service"): gdata.List([q("name")], [
+            gdata.Container({q("name"): gdata.Leaf(n), q("enabled"): gdata.Leaf(True)}) for n in names
+        ]),
+    })
+
+def status(s: str) -> gdata.Node:
+    return gdata.Container({q("status"): gdata.Leaf(s)})
+
+def entry(name: str, s: str) -> gdata.Node:
+    return gdata.Container({q("name"): gdata.Leaf(name), q("status"): gdata.Leaf(s)})
+
+def tree(entries: list[gdata.Node]) -> gdata.Node:
+    return gdata.Container({
+        q("service"): gdata.List([q("name")], entries, ns=TEST_NS),
+    })
+
+ON_CHANGE = gdata.SubscriptionSpec(None)
+
+def entry_spec(name: str) -> gdata.SubscriptionSpec:
+    return gdata.SubscriptionSpec(gdata.FNode(q("service"), children=[
+        gdata.FNode(q("name"), value_match=name),
+        gdata.FNode(q("status")),
+    ]))
+
+def prs(data: ?gdata.Node) -> str:
+    return data.prsrc(deterministic=True) if data is not None else "None"
+
+
+actor baseline_then_every_update_in_order(t: testing.AsyncT):
+    """Registration delivers what the producers hold; each push after that is
+    delivered as it comes."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if len(got) == 1:
+            hub.push("svc-a", status("second"))
+            hub.push("svc-a", status("third"))
+        elif len(got) == 3:
+            expected = [tree([entry("svc-a", "first")]), tree([entry("svc-a", "second")]), tree([entry("svc-a", "third")])]
+            for i in range(0, 3):
+                if got[i] != expected[i]:
+                    fail(ValueError("delivery {i}: expected {prs(expected[i])}, got {prs(got[i])}"))
+                    return
+            done = True
+            t.success()
+
+    def declare(_r: value):
+        hub.push("svc-a", status("first"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {ON_CHANGE})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor filtered_spec_sees_only_its_element(t: testing.AsyncT):
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if len(got) == 1:
+            hub.push("svc-a", status("a-changed"))          # outside the filter: nothing
+            hub.push("svc-b", status("b-changed"))
+        elif len(got) == 2:
+            expected = tree([entry("svc-b", "b-changed")])
+            if got[1] == expected:
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected {prs(expected)}, got {prs(got[1])}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {entry_spec("svc-b")})
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor two_owners_share_and_one_may_leave(t: testing.AsyncT):
+    hub = Hub()
+    layer = service_layer(hub)
+    var first: list[?gdata.Node] = []
+    var second: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def check():
+        if len(first) == 2 and len(second) == 2:
+            layer.remove_subscriptions("second")
+            hub.push("svc-a", status("third"))
+        elif len(first) == 3:
+            if len(second) != 2:
+                fail(ValueError("the removed owner kept receiving"))
+            elif first[2] == tree([entry("svc-a", "third")]):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("unexpected third delivery {prs(first[2])}"))
+
+    def on_first(data: ?gdata.Node, err: ?Exception):
+        first.append(data)
+        check()
+
+    def on_second(data: ?gdata.Node, err: ?Exception):
+        second.append(data)
+        if len(second) == 1:
+            hub.push("svc-a", status("second"))
+        check()
+
+    def declare(_r: value):
+        hub.push("svc-a", status("first"))
+        after 0.05: layer.declare_subscriptions("first", on_first, {ON_CHANGE})
+        after 0.1: layer.declare_subscriptions("second", on_second, {ON_CHANGE})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(first)} and {len(second)} deliveries"))
+
+
+actor element_created_after_subscribe_is_delivered(t: testing.AsyncT):
+    """A filtered subscription to an entry that does not exist yet is served
+    once the entry is created and pushes oper."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if len(got) == 1:
+            if data is not None:
+                fail(ValueError("baseline should be empty, got {prs(data)}"))
+                return
+            layer.edit_config(services(["svc-a", "svc-c"]), None, lambda _r: hub.push("svc-c", status("c")))
+        elif got[1] == tree([entry("svc-c", "c")]):
+            done = True
+            t.success()
+        else:
+            fail(ValueError("unexpected delivery {prs(got[1])}"))
+
+    def declare(_r: value):
+        layer.declare_subscriptions("test", on_update, {entry_spec("svc-c")})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor deleted_element_is_removed(t: testing.AsyncT):
+    """When an entry's config is deleted its actor clears the oper from its
+    shutdown: the tree loses the entry and the change reports it gone, with
+    what it held."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var deltas: list[(ttt.Path, ?gdata.Node, ?gdata.Node)] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_delta(path: ttt.Path, before: ?gdata.Node, now: ?gdata.Node):
+        deltas.append((path, before, now))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if len(got) == 1:
+            layer.edit_config(gdata.Container({
+                q("service"): gdata.List([q("name")], [gdata.Absent({q("name"): gdata.Leaf("svc-a")})]),
+            }))
+        elif len(got) == 2:
+            if data != tree([entry("svc-b", "b")]):
+                fail(ValueError("expected svc-b alone, got {prs(data)}"))
+                return
+            (path, before, now) = deltas[0]
+            if now is None and path.name == "svc-a" and before == entry("svc-a", "a"):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("unexpected change at {path}: {prs(before)} -> {prs(now)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {ON_CHANGE}, delta=on_delta)
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor owner_with_two_specs_gets_one_tree(t: testing.AsyncT):
+    """Several on-change specs from one owner are one Subscription with the
+    union of their filters."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if len(got) == 1:
+            hub.push("svc-b", status("b2"))
+        elif len(got) == 2:
+            expected = tree([entry("svc-a", "a"), entry("svc-b", "b2")])
+            if got[1] == expected:
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected {prs(expected)}, got {prs(got[1])}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        hub.push("svc-c", status("c"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {entry_spec("svc-a"), entry_spec("svc-b")})
+
+    layer.edit_config(services(["svc-a", "svc-b", "svc-c"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor change_carries_the_producer_path_and_slice(t: testing.AsyncT):
+    """The change alone is the producer's path with what it held before and
+    after; rendering it as a yang-patch is the northbound edge's business."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_delta(path: ttt.Path, before: ?gdata.Node, now: ?gdata.Node):
+        if path.name == "svc-a" and before is None and now == entry("svc-a", "a"):
+            done = True
+            t.success()
+        else:
+            fail(ValueError("unexpected change at {path}: {prs(before)} -> {prs(now)}"))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+
+    def declare(_r: value):
+        layer.declare_subscriptions("test", on_update, {ON_CHANGE}, delta=on_delta)
+        after 0.05: hub.push("svc-a", status("a"))
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out"))
+
+
+actor bad_filter_is_reported_once(t: testing.AsyncT):
+    hub = Hub()
+    layer = service_layer(hub)
+    var errors = 0
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            errors += 1
+
+    def finish():
+        if not done:
+            done = True
+            if errors == 1:
+                t.success()
+            else:
+                t.failure(ValueError("expected one error delivery, got {errors}"))
+
+    def declare(_r: value):
+        layer.declare_subscriptions("test", on_update, {gdata.SubscriptionSpec(gdata.FNode(children=[gdata.FNode(children=[])]))})
+        after 0.3: finish()
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+
+
+actor Relay(update_oper: action(?gdata.Node) -> None, lower: ?gdata.TreeProvider):
+    """An upper-layer transform actor: republishes, as its own oper, whatever
+    it sees in the layer below, through the ordinary gdata subscription API."""
+    _subs = gdata.SubscriptionManager(lower!, "relay")
+
+    def on_lower(tree: ?gdata.Node, err: ?Exception):
+        update_oper(tree)
+
+    def on_conf(conf: gdata.Node, memory: ?gdata.Node):
+        _subs.declare({gdata.Dst(on_lower).deliver({ON_CHANGE})})
+
+    def shutdown(memory: ?gdata.Node):
+        update_oper(None)
+
+
+def relay_ctor(params: ttt.TransformActorParams) -> ttt.TransformActor:
+    r = Relay(params.update_oper, params.lower_tree_provider)
+    return ttt.TransformActor(r.on_conf, r.shutdown)
+
+
+actor oper_crosses_layers_without_timers(t: testing.AsyncT):
+    """A push in the lower layer reaches a subscriber of the upper layer through
+    the upper transform's actor: lower Subscription, update_oper, upper Subscription. No
+    sampling anywhere; the only timers here are the test's own."""
+    hub = Hub()
+    lower = service_layer(hub, "lower")
+    upper = ttt.Layer("upper", ttt.Container({
+        q("relay"): ttt.Transform(Noop, relay_ctor, None, lower),
+    }), lower)
+    seen_x = tree([entry("svc-a", "x")])
+    seen_y = tree([entry("svc-a", "y")])
+    var pushed_y = False
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_top(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif data == gdata.Container({q("relay"): seen_x}) and not pushed_y:
+            pushed_y = True
+            hub.push("svc-a", status("y"))
+        elif data == gdata.Container({q("relay"): seen_y}) and pushed_y:
+            done = True
+            t.success()
+
+    def configured_upper(_r: value):
+        after 0.05: upper.declare_subscriptions("top", on_top, {ON_CHANGE})
+
+    def configured_lower(_r: value):
+        hub.push("svc-a", status("x"))
+        upper.edit_config(gdata.Container({q("relay"): gdata.Container({q("name"): gdata.Leaf("r")})}), None, configured_upper)
+
+    lower.edit_config(services(["svc-a"]), None, configured_lower)
+    after 2: fail(ValueError("timed out (pushed_y={pushed_y})"))
+
+
+actor subscribe_during_commit_is_delivered(t: testing.AsyncT):
+    """An entry that is still provisional when the subscription registers is
+    not in the baseline, and joins the subscription when it commits."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif data == tree([entry("svc-a", "a")]):
+            done = True
+            t.success()
+
+    layer.edit_config(services(["svc-a"]), None, lambda _r: hub.push("svc-a", status("a")))
+    layer.declare_subscriptions("test", on_update, {entry_spec("svc-a")})
+    after 2: fail(ValueError("timed out"))
+
+
+actor unchanged_slice_is_not_resent(t: testing.AsyncT):
+    """A change outside a route's filter does not reach that route's Subscription."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def finish():
+        if not done:
+            done = True
+            if len(got) == 1:
+                t.success()
+            else:
+                t.failure(ValueError("expected one delivery, got {len(got)}"))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if len(got) == 1:
+            hub.push("svc-a", gdata.Container({q("status"): gdata.Leaf("a"), q("rx"): gdata.Leaf(u64(7))}))
+            after 0.3: finish()
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {entry_spec("svc-a")})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+def entry_layer(hub: Hub) -> ttt.Layer:
+    """A list whose entries are containers holding a transform."""
+    return ttt.Layer("top", ttt.Container({
+        q("service"): ttt.List(ttt.Container({
+            q("probe"): ttt.Transform(Noop, pusher_ctor(hub)),
+        }), [q("name")], ns=TEST_NS, module="test-on-change"),
+    }), None)
+
+def probes(names: list[str]) -> gdata.Node:
+    """Config for entry_layer: each entry configures its probe transform."""
+    return gdata.Container({
+        q("service"): gdata.List([q("name")], [
+            gdata.Container({q("name"): gdata.Leaf(n), q("probe"): gdata.Container({q("enabled"): gdata.Leaf(True)})}) for n in names
+        ]),
+    })
+
+
+actor wildcard_key_over_container_entries_prunes(t: testing.AsyncT):
+    """A key predicate on a list of container entries is decided at the entry."""
+    hub = Hub()
+    layer = entry_layer(hub)
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif data is not None:
+            rendered = data.prsrc(deterministic=True)
+            if rendered.find("svc-b") != -1:
+                fail(ValueError("svc-b leaked through a svc-a* key filter: " + rendered))
+            elif rendered.find("up-svc-a") != -1:
+                done = True
+                t.success()
+
+    def declare(_r: value):
+        hub.push("svc-a", status("up-svc-a"))
+        hub.push("svc-b", status("up-svc-b"))
+        filt = gdata.FNode(q("service"), children=[gdata.FNode(q("name"), value_match=gdata.VWildcard("svc-a*"))])
+        after 0.05: layer.declare_subscriptions("test", on_update, {gdata.SubscriptionSpec(filt)})
+
+    layer.edit_config(probes(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out"))
+
+
+def counters(s: str) -> gdata.Node:
+    return gdata.Container({q("status"): gdata.Leaf(s), q("rx"): gdata.Leaf(u64(10)), q("tx"): gdata.Leaf(u64(20))})
+
+
+actor predicate_alternatives_stay_separate(t: testing.AsyncT):
+    """Two alternatives for one entry each keep their own predicate: the
+    producer serves the first that matches, and none when none does."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        n = len(got)
+        if n == 1:
+            hub.push("svc-a", counters("up"))
+        elif n == 2:
+            if data == tree([gdata.Container({q("name"): gdata.Leaf("svc-a"), q("rx"): gdata.Leaf(u64(10))})]):
+                hub.push("svc-a", counters("down"))
+            else:
+                fail(ValueError("up: expected rx alone, got {prs(data)}"))
+        elif n == 3:
+            if data == tree([gdata.Container({q("name"): gdata.Leaf("svc-a"), q("tx"): gdata.Leaf(u64(20))})]):
+                hub.push("svc-a", counters("unknown"))
+            else:
+                fail(ValueError("down: expected tx alone, got {prs(data)}"))
+        elif n == 4:
+            if data is None:
+                done = True
+                t.success()
+            else:
+                fail(ValueError("unknown: expected nothing, got {prs(data)}"))
+
+    def declare(_r: value):
+        filt = gdata.FNode(children=[
+            gdata.FNode(q("service"), children=[
+                gdata.FNode(q("name"), value_match="svc-a"),
+                gdata.FNode(q("status"), value_match="up"), gdata.FNode(q("rx")),
+            ]),
+            gdata.FNode(q("service"), children=[
+                gdata.FNode(q("name"), value_match="svc-a"),
+                gdata.FNode(q("status"), value_match="down"), gdata.FNode(q("tx")),
+            ]),
+        ])
+        layer.declare_subscriptions("alternatives", on_update, {gdata.SubscriptionSpec(filt)})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor selecting_only_keys_selects_no_oper(t: testing.AsyncT):
+    """A filter that names nothing but a list key selects no oper at all."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def finish():
+        if not done:
+            done = True
+            if len(got) == 1 and got[0] is None:
+                t.success()
+            else:
+                t.failure(ValueError("expected one empty delivery, got {len(got)}"))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        got.append(data)
+        if len(got) == 1:
+            hub.push("svc-a", status("must not leak"))
+            after 0.3: finish()
+
+    def declare(_r: value):
+        layer.declare_subscriptions("keys", on_update, {gdata.SubscriptionSpec(gdata.FNode(q("service"), children=[gdata.FNode(q("name"))]))})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+
+
+actor overlapping_specs_in_one_owner(t: testing.AsyncT):
+    """An unfiltered spec and a filtered one in the same owner fold into one
+    tree; a producer's push replaces its whole contribution."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        n = len(got)
+        if n == 1:
+            hub.push("svc-a", gdata.Container({q("status"): gdata.Leaf("first"), q("old"): gdata.Leaf("must disappear")}))
+        elif n == 2:
+            if data == tree([gdata.Container({q("name"): gdata.Leaf("svc-a"), q("status"): gdata.Leaf("first"), q("old"): gdata.Leaf("must disappear")})]):
+                hub.push("svc-a", status("second"))
+            else:
+                fail(ValueError("expected first with old, got {prs(data)}"))
+        elif n == 3:
+            if data == tree([entry("svc-a", "second")]):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected second alone, got {prs(data)}"))
+
+    def declare(_r: value):
+        layer.declare_subscriptions("overlap", on_update, {ON_CHANGE, entry_spec("svc-a")})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor owners_cancel_and_replace_their_declarations(t: testing.AsyncT):
+    """A removed owner hears nothing more; an owner that redeclares with a
+    new callback and filter is served the new way only."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var first: dict[str, int] = {"one": 0, "two": 0}
+    var replacing = False
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_tree(owner: str, data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif replacing:
+            fail(ValueError("cancelled or replaced callback was called for {owner}"))
+        elif data == tree([entry("svc-a", "first")]):
+            first[owner] += 1
+            if first["one"] == 1 and first["two"] == 1:
+                replacing = True
+                layer.remove_subscriptions("one")
+                layer.declare_subscriptions("two", replacement, {entry_spec("svc-b")})
+
+    def replacement(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif data is None:
+            hub.push("svc-a", status("must not arrive"))
+            hub.push("svc-b", status("second"))
+        elif data == tree([entry("svc-b", "second")]):
+            done = True
+            t.success()
+        else:
+            fail(ValueError("unexpected replacement delivery {prs(data)}"))
+
+    def declare(_r: value):
+        layer.declare_subscriptions("one", lambda data, err: self.on_tree("one", data, err), {ON_CHANGE})
+        layer.declare_subscriptions("two", lambda data, err: self.on_tree("two", data, err), {ON_CHANGE})
+        after 0.05: hub.push("svc-a", status("first"))
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out (replacing={replacing})"))
+
+
+actor entry_deleted_and_recreated_is_delivered_again(t: testing.AsyncT):
+    """An entry created anew after its deletion joins the subscription like
+    any entry committed after registration."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        n = len(got)
+        if n == 1:
+            layer.edit_config(gdata.Container({
+                q("service"): gdata.List([q("name")], [gdata.Absent({q("name"): gdata.Leaf("svc-a")})]),
+            }))
+        elif n == 2:
+            if data is None:
+                layer.edit_config(services(["svc-a"]), None, lambda _r: hub.push("svc-a", status("again")))
+            else:
+                fail(ValueError("expected the entry gone, got {prs(data)}"))
+        elif n == 3:
+            if data == tree([entry("svc-a", "again")]):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected the entry again, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("first"))
+        after 0.05: layer.declare_subscriptions("test", on_update, {ON_CHANGE})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+def probe_layer(hub: Hub) -> ttt.Layer:
+    """One container transform right below the root."""
+    return ttt.Layer("top", ttt.Container({
+        q("probe"): ttt.Transform(Noop, pusher_ctor(hub)),
+    }), None)
+
+def probe(enabled: bool) -> gdata.Node:
+    if enabled:
+        return gdata.Container({q("probe"): gdata.Container({q("enabled"): gdata.Leaf(True)})})
+    return gdata.Container({q("probe"): gdata.Absent()})
+
+
+actor owner_mixing_periodic_and_on_change_gets_one_tree(t: testing.AsyncT):
+    """An owner's periodic and on-change specs are served apart and merged
+    into the one tree it receives."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var pushed = False
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif not pushed and data == tree([entry("svc-a", "a"), entry("svc-b", "b")]):
+            pushed = True
+            hub.push("svc-a", status("a2"))
+        elif pushed and data == tree([entry("svc-a", "a2"), entry("svc-b", "b")]):
+            done = True
+            t.success()
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        sampled = gdata.SubscriptionSpec(entry_spec("svc-b").filt, period=0.02)
+        after 0.05: layer.declare_subscriptions("mixed", on_update, {entry_spec("svc-a"), sampled})
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out (pushed={pushed})"))
+
+
+actor matching_alternatives_are_unioned(t: testing.AsyncT):
+    """Two alternatives that both match one entry select the union of what
+    they name."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if not done:
+            done = True
+            if err is not None:
+                t.failure(err)
+            elif data == tree([gdata.Container({q("name"): gdata.Leaf("svc-a"), q("rx"): gdata.Leaf(u64(10)), q("tx"): gdata.Leaf(u64(20))})]):
+                t.success()
+            else:
+                t.failure(ValueError("expected rx and tx, got {prs(data)}"))
+
+    def declare(_r: value):
+        filt = gdata.FNode(children=[
+            gdata.FNode(q("service"), children=[gdata.FNode(q("name"), value_match="svc-a"), gdata.FNode(q("status"), value_match="up"), gdata.FNode(q("rx"))]),
+            gdata.FNode(q("service"), children=[gdata.FNode(q("name"), value_match="svc-a"), gdata.FNode(q("status"), value_match="up"), gdata.FNode(q("tx"))]),
+        ])
+        hub.push("svc-a", counters("up"))
+        after 0.05: layer.declare_subscriptions("union", on_update, {gdata.SubscriptionSpec(filt)})
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: on_update(None, ValueError("timed out"))
+
+
+actor selecting_a_subtree_keeps_an_empty_container(t: testing.AsyncT):
+    """An empty container is oper too: selecting its subtree delivers it,
+    as an unfiltered subscription does."""
+    hub = Hub()
+    layer = probe_layer(hub)
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if not done:
+            done = True
+            if err is not None:
+                t.failure(err)
+            elif data == gdata.Container({q("probe"): gdata.Container({})}):
+                t.success()
+            else:
+                t.failure(ValueError("expected the empty probe container, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("probe", gdata.Container({}))
+        after 0.05: layer.declare_subscriptions("presence", on_update, {gdata.SubscriptionSpec(gdata.FNode(q("probe")))})
+
+    layer.edit_config(probe(True), None, declare)
+    after 2: on_update(None, ValueError("timed out"))
+
+
+##################### Rooted at a node #####################
+
+ROOTED_AT_SERVICE = gdata.FNode(q("service"))
+
+def gone(name: str) -> gdata.Node:
+    """The spine of a service entry reported gone."""
+    return tree([gdata.Absent({q("name"): gdata.Leaf(name)})])
+
+def rendered(trees: list[?gdata.Node]) -> list[str]:
+    return sorted([prs(d) for d in trees])
+
+def probe_spine(c: gdata.Node) -> gdata.Node:
+    return gdata.Container({q("probe"): c})
+
+
+actor rooted_at_a_list_on_change(t: testing.AsyncT):
+    """Rooted at the service list: the walk delivers one entry at a time
+    then synced; a push delivers its entry alone; a deletion delivers an
+    Absent with the entry's key. Each delivery is a tree from the top."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var got: list[?gdata.Node] = []
+    var synced = False
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_synced(owner: str):
+        if synced or rendered(got) != rendered([tree([entry("svc-a", "a")]), tree([entry("svc-b", "b")])]):
+            fail(ValueError("synced after {len(got)} deliveries: {rendered(got)}"))
+            return
+        synced = True
+        hub.push("svc-a", status("a2"))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        n = len(got)
+        if n == 3:
+            if data == tree([entry("svc-a", "a2")]):
+                layer.edit_config(gdata.Container({
+                    q("service"): gdata.List([q("name")], [gdata.Absent({q("name"): gdata.Leaf("svc-b")})]),
+                }))
+            else:
+                fail(ValueError("expected svc-a alone, got {prs(data)}"))
+        elif n == 4:
+            if data == gone("svc-b"):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected svc-b gone, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("rooted", on_update, {gdata.SubscriptionSpec(None, root=ROOTED_AT_SERVICE)}, on_synced)
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries, synced={synced}"))
+
+
+actor rooted_at_a_container_on_change(t: testing.AsyncT):
+    """Rooted at a container: the container as it is, then the tree without
+    it when its config, and with it its oper, is gone."""
+    hub = Hub()
+    layer = probe_layer(hub)
+    var got: list[?gdata.Node] = []
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_synced(owner: str):
+        if len(got) == 1 and got[0] == probe_spine(status("up")):
+            layer.edit_config(probe(False))
+        else:
+            fail(ValueError("synced after {rendered(got)}"))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if len(got) == 2:
+            if data == gdata.Container():
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected the probe gone, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("probe", status("up"))
+        after 0.05: layer.declare_subscriptions("rooted", on_update, {gdata.SubscriptionSpec(None, root=gdata.FNode(q("probe")))}, on_synced)
+
+    layer.edit_config(probe(True), None, declare)
+    after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor two_consumers_rooted_alike_each_get_every_change(t: testing.AsyncT):
+    """Two consumers rooted at the same list each have a route of their
+    own: both get every entry, then synced, then a change."""
+    hub = Hub()
+    layer = service_layer(hub)
+    spec = gdata.SubscriptionSpec(None, root=ROOTED_AT_SERVICE)
+    var changed: dict[str, ?gdata.Node] = {}
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_data(who: str, data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif data == tree([entry("svc-a", "a2")]):
+            changed[who] = data
+            if len(changed) == 2:
+                done = True
+                t.success()
+
+    def first_synced(owner: str):
+        layer.declare_subscriptions("two", lambda d, e: self.on_data("two", d, e), {spec}, second_synced)
+
+    def second_synced(owner: str):
+        hub.push("svc-a", status("a2"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        after 0.05: layer.declare_subscriptions("one", lambda d, e: self.on_data("one", d, e), {spec}, first_synced)
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out; the change reached {list(changed.keys())}"))
+
+
+actor rooted_destination_is_served_one_way(t: testing.AsyncT):
+    """A rooted consumer is read on one period or served on-change: a
+    periodic filter cannot join an on-change one."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if not done:
+            done = True
+            if err is not None:
+                t.success()
+            else:
+                t.failure(ValueError("expected an error, got {prs(data)}"))
+
+    layer.declare_subscriptions("rooted", on_update, {
+        gdata.SubscriptionSpec(None, root=ROOTED_AT_SERVICE),
+        gdata.SubscriptionSpec(entry_spec("svc-a").filt, period=0.05, root=ROOTED_AT_SERVICE),
+    })
+    after 2: on_update(None, None)
+
+
+actor synced_follows_the_route_and_every_read(t: testing.AsyncT):
+    """A consumer with an on-change filter and a periodic one hears synced
+    once, after the walk and the first read, with the view holding both."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var latest: ?gdata.Node = None
+    var synced = 0
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        else:
+            latest = data
+
+    def on_synced(owner: str):
+        synced += 1
+        if latest == tree([entry("svc-a", "a"), entry("svc-b", "b")]):
+            after 0.2: finish()
+        else:
+            fail(ValueError("synced with {prs(latest)}"))
+
+    def finish():
+        if not done:
+            done = True
+            if synced == 1:
+                t.success()
+            else:
+                t.failure(ValueError("synced {synced} times"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("a"))
+        hub.push("svc-b", status("b"))
+        sampled = gdata.SubscriptionSpec(entry_spec("svc-b").filt, period=0.02)
+        after 0.05: layer.declare_subscriptions("mixed", on_update, {entry_spec("svc-a"), sampled}, on_synced)
+
+    layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
+    after 2: fail(ValueError("timed out (synced={synced})"))
+
+
+actor redeclaring_the_same_on_change_set_installs_the_callbacks_only(t: testing.AsyncT):
+    """A redeclaration of the same on-change set walks nothing again,
+    hears its synced at once, and hands later changes to the new callback."""
+    hub = Hub()
+    layer = service_layer(hub)
+    var second: list[?gdata.Node] = []
+    var synced = 0
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_first(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        elif data == tree([entry("svc-a", "second")]):
+            fail(ValueError("the replaced callback was called"))
+
+    def first_synced(owner: str):
+        layer.declare_subscriptions("owner", on_second, {ON_CHANGE}, second_synced)
+
+    def on_second(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+        else:
+            second.append(data)
+
+    def second_synced(owner: str):
+        synced += 1
+        if len(second) == 0:
+            hub.push("svc-a", status("second"))
+            after 0.3: finish()
+        else:
+            fail(ValueError("delivered again before synced: {rendered(second)}"))
+
+    def finish():
+        if not done:
+            done = True
+            if synced == 1 and len(second) == 1 and second[0] == tree([entry("svc-a", "second")]):
+                t.success()
+            else:
+                t.failure(ValueError("synced {synced} times, the new callback got {rendered(second)}"))
+
+    def declare(_r: value):
+        hub.push("svc-a", status("first"))
+        after 0.05: layer.declare_subscriptions("owner", on_first, {ON_CHANGE}, first_synced)
+
+    layer.edit_config(services(["svc-a"]), None, declare)
+    after 2: fail(ValueError("timed out"))
+
+
+def item(id: str, v: str) -> gdata.Node:
+    return gdata.Container({q("id"): gdata.Leaf(id), q("v"): gdata.Leaf(v)})
+
+def items(entries: list[gdata.Node]) -> gdata.Node:
+    return gdata.Container({q("items"): gdata.List([q("id")], entries)})
+
+def item_spine(i: gdata.Node) -> gdata.Node:
+    return probe_spine(items([i]))
+
+
+actor change_above_the_root_delivers_the_instances_that_differ(t: testing.AsyncT):
+    """A producer that holds several instances of the root's node delivers,
+    on a change, the instances that differ and those gone."""
+    hub = Hub()
+    layer = probe_layer(hub)
+    var got: list[?gdata.Node] = []
+    var stage = 0
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_synced(owner: str):
+        if rendered(got) == rendered([item_spine(item("one", "x")), item_spine(item("two", "y"))]):
+            stage = 1
+            got = []
+            hub.push("probe", items([item("one", "x2"), item("two", "y")]))
+        else:
+            fail(ValueError("synced after {rendered(got)}"))
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            fail(err)
+            return
+        got.append(data)
+        if stage == 1 and len(got) == 1:
+            if data == item_spine(item("one", "x2")):
+                stage = 2
+                got = []
+                hub.push("probe", items([item("one", "x2")]))
+            else:
+                fail(ValueError("expected item one changed alone, got {prs(data)}"))
+        elif stage == 2 and len(got) == 1:
+            if data == item_spine(gdata.Absent({q("id"): gdata.Leaf("two")})):
+                done = True
+                t.success()
+            else:
+                fail(ValueError("expected item two gone, got {prs(data)}"))
+
+    def declare(_r: value):
+        hub.push("probe", items([item("one", "x"), item("two", "y")]))
+        root = gdata.FNode(q("probe"), children=[gdata.FNode(q("items"))])
+        after 0.05: layer.declare_subscriptions("rooted", on_update, {gdata.SubscriptionSpec(None, root=root)}, on_synced)
+
+    layer.edit_config(probe(True), None, declare)
+    after 2: fail(ValueError("timed out at stage {stage} with {rendered(got)}"))
+
+
+actor failed_walk_still_ends_with_synced(t: testing.AsyncT):
+    """A walk that fails reports the error, then synced."""
+    hub = Hub()
+    layer = entry_layer(hub)
+    var failed = False
+    var done = False
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if err is not None:
+            failed = True
+        elif not done:
+            done = True
+            t.failure(ValueError("expected an error, got {prs(data)}"))
+
+    def on_synced(owner: str):
+        if not done:
+            done = True
+            if failed:
+                t.success()
+            else:
+                t.failure(ValueError("synced before the error"))
+
+    def declare(_r: value):
+        filt = gdata.FNode(q("service"), children=[gdata.FNode(q("probe"), value_match="x")])
+        layer.declare_subscriptions("test", on_update, {gdata.SubscriptionSpec(filt)}, on_synced)
+
+    layer.edit_config(probes(["svc-a"]), None, declare)
+    after 2: on_update(None, None)

--- a/src/test_ttt_subscriptions.act
+++ b/src/test_ttt_subscriptions.act
@@ -1,4 +1,4 @@
-"""Subscriptions on a TTT layer, served by a Subscription actor per spec.
+"""Periodic subscriptions on a TTT layer, served by a Subscription actor per consumer.
 
 A consumer's filters fold into one read per period, each read delivers
 the merged view when it differs from the last, and synced follows the
@@ -54,7 +54,7 @@ actor Pusher(hub: Hub, path: ttt.Path, update_oper: action(?gdata.Node) -> None)
     def on_conf(conf: gdata.Node, memory: ?gdata.Node):
         hub.register(entry_name(path), update_oper)
     def shutdown(memory: ?gdata.Node):
-        pass
+        update_oper(None)                       # the config is gone, and so is the oper
 
 
 def pusher_ctor(hub: Hub) -> proc(ttt.TransformActorParams) -> ttt.TransformActor:
@@ -165,24 +165,6 @@ actor every_read_that_differs_is_delivered(t: testing.AsyncT):
 
     layer.edit_config(services(["svc-a"]), None, declare)
     after 2: fail(ValueError("timed out with {len(got)} deliveries"))
-
-
-actor on_change_spec_is_refused(t: testing.AsyncT):
-    """A layer serves periodic specs; one without a period is an error."""
-    hub = Hub()
-    layer = service_layer(hub)
-    var done = False
-
-    def on_update(data: ?gdata.Node, err: ?Exception):
-        if not done:
-            done = True
-            if err is not None:
-                t.success()
-            else:
-                t.failure(ValueError("expected an error, got {prs(data)}"))
-
-    layer.declare_subscriptions("test", on_update, {gdata.SubscriptionSpec(None)})
-    after 2: on_update(None, None)
 
 
 actor filters_with_one_period_fold_into_one_read(t: testing.AsyncT):

--- a/src/test_yp_ttt.act
+++ b/src/test_yp_ttt.act
@@ -1,0 +1,409 @@
+"""Operational on-change delivery and replay over the northbound NETCONF pipe."""
+
+import logging
+import testing
+import std.xml as xml
+
+import netconf
+import netconf_server
+import ttt
+import yang
+import yang.gdata as gdata
+import yang.xml as yxml
+import yang.ypatch as ypatch
+import yp
+import yp_ttt
+
+
+NS = "urn:test-telemetry"
+MODEL = r"""module telemetry {
+  yang-version "1.1";
+  namespace "urn:test-telemetry";
+  prefix t;
+  list device {
+    key name;
+    leaf name { type string; }
+    leaf target { type string; }
+    container state {
+      config false;
+      leaf status { type string; }
+      leaf extra { type string; }
+    }
+  }
+  leaf-list labels { config false; type string; }
+}"""
+
+
+def q(name: str) -> gdata.Id:
+    return gdata.Id(NS, name)
+
+
+def _oper(status: str, extra: bool=False) -> gdata.Node:
+    children: dict[gdata.Id, gdata.Node] = {q("status"): gdata.Leaf(status)}
+    if extra:
+        children[q("extra")] = gdata.Leaf("old")
+    return gdata.Container({q("state"): gdata.Container(children)})
+
+
+def _entry(name: str, status: str, extra: bool=False) -> gdata.Node:
+    children = dict(_oper(status, extra).children.items())
+    children[q("name")] = gdata.Leaf(name)
+    return gdata.Container(children)
+
+
+def _test_change_edits_replace_keyed_subtree():
+    schema = yang.compile([MODEL])
+    path = ttt.PathKey("a/b,=", ttt.PathElem(q("device"), ttt.PathRoot("top")),
+                       {q("name"): gdata.Leaf("a/b,=")})
+    first = yp_ttt.change_edits(schema, path, None, _entry("a/b,=", "one", True))
+    testing.assertEqual(len(first), 1)
+    testing.assertEqual(first[0].target, "/telemetry:device=a%2Fb%2C%3D")
+    testing.assertEqual(first[0].operation, ypatch.OP_REPLACE)
+    current = gdata.patch(None, ypatch.edit_to_gdata(schema, first[0]))
+    second = yp_ttt.change_edits(schema, path, _entry("a/b,=", "one", True), _entry("a/b,=", "two"))
+    current = gdata.patch(current, ypatch.edit_to_gdata(schema, second[0]))
+    state = current!.get_list(q("device")).elements[0].children[q("state")]
+    testing.assertEqual(state.get_str(q("status")), "two")
+    testing.assertTrue(state.get_opt_str(q("extra")) is None)
+    removed = yp_ttt.change_edits(schema, path, _entry("a/b,=", "two"), None)
+    testing.assertEqual(removed[0].operation, ypatch.OP_REMOVE)
+    testing.assertTrue(removed[0].value is None)
+
+
+def _test_change_edits_root_list_instances():
+    schema = yang.compile([MODEL])
+    old = gdata.Container({q("device"): gdata.List([q("name")], [
+        _entry("a", "one"), _entry("b", "two"),
+    ])})
+    new = gdata.Container({q("device"): gdata.List([q("name")], [
+        _entry("b", "three"), _entry("c", "four"),
+    ])})
+    edits = yp_ttt.change_edits(schema, ttt.PathRoot("top"), old, new)
+    testing.assertEqual({e.target: e.operation for e in edits}, {
+        "/telemetry:device=a": ypatch.OP_REMOVE,
+        "/telemetry:device=b": ypatch.OP_REPLACE,
+        "/telemetry:device=c": ypatch.OP_REPLACE,
+    })
+
+
+def _test_oper_contents_snapshot_namespaces():
+    schema = yang.compile([MODEL])
+    tree = gdata.Container({q("device"): gdata.List([q("name")], [_entry("a", "up")])})
+    data = xml.Node("data", children=yp_ttt.oper_contents(tree))
+    parsed = yxml.from_xml(schema, xml.decode(data.encode()))
+    entry = parsed.get_list(q("device")).elements[0]
+    testing.assertEqual(entry.get_str(q("name")), "a")
+    testing.assertEqual(entry.children[q("state")].get_str(q("status")), "up")
+
+
+def _test_change_edits_root_leaf_list():
+    schema = yang.compile([MODEL])
+    old = gdata.Container({q("labels"): gdata.LeafList([
+        gdata.LeafListEntryMerge("a/b"), gdata.LeafListEntryMerge("b"),
+    ])})
+    new = gdata.Container({q("labels"): gdata.LeafList([
+        gdata.LeafListEntryMerge("b"), gdata.LeafListEntryMerge("c"),
+    ])})
+    edits = yp_ttt.change_edits(schema, ttt.PathRoot("top"), old, new)
+    current: ?gdata.Node = old
+    for edit in edits:
+        current = gdata.patch(current, ypatch.edit_to_gdata(schema, edit))
+    testing.assertEqual(set(current!.get_strs(q("labels"))), {"b", "c"})
+
+
+def _test_change_edits_preserve_user_order():
+    model = MODEL.replace("key name;", "key name; ordered-by user;").replace(
+        r"leaf-list labels { config false;", r"leaf-list labels { config false; ordered-by user;")
+    schema = yang.compile([model])
+    old = gdata.Container({
+        q("device"): gdata.List([q("name")], [_entry("a", "up"), _entry("b", "up")], user_order=True),
+        q("labels"): gdata.LeafList([gdata.LeafListEntryMerge("a"), gdata.LeafListEntryMerge("b")], user_order=True),
+    })
+    new = gdata.Container({
+        q("device"): gdata.List([q("name")], [_entry("b", "up"), _entry("a", "up")], user_order=True),
+        q("labels"): gdata.LeafList([gdata.LeafListEntryMerge("b"), gdata.LeafListEntryMerge("a")], user_order=True),
+    })
+    current: ?gdata.Node = old
+    for edit in yp_ttt.change_edits(schema, ttt.PathRoot("top"), old, new):
+        current = gdata.patch(current, ypatch.edit_to_gdata(schema, edit))
+    testing.assertEqual([e.get_str(q("name")) for e in current!.get_list(q("device")).elements], ["b", "a"])
+    testing.assertEqual(current!.get_strs(q("labels")), ["b", "a"])
+
+
+def _test_change_edits_reject_top_level_keyless_list():
+    schema = yang.compile([MODEL])
+    tree = gdata.Container({q("device"): gdata.List([], [_oper("one"), _oper("two")])})
+    try:
+        yp_ttt.change_edits(schema, ttt.PathRoot("top"), None, tree)
+    except ValueError:
+        return
+    testing.assertTrue(False)
+
+
+class _Transform(ttt.TransformFunction):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node,
+                          memory: ?gdata.Node, dynstate: ?gdata.Node):
+        return gdata.Container(), None
+
+
+actor _Source():
+    var publishers: dict[str, action(?gdata.Node) -> None] = {}
+
+    def attach(name: str, publish: action(?gdata.Node) -> None):
+        publishers[name] = publish
+
+    def publish(name: str, status: ?str, extra: bool=False):
+        publishers[name](_oper(status, extra) if status is not None else None)
+
+
+actor _Publisher(source: _Source, params: ttt.TransformActorParams):
+    def on_conf(cfg: gdata.Node, memory: ?gdata.Node):
+        source.attach(cfg.get_str(q("name")), params.update_oper)
+
+    def shutdown(memory: ?gdata.Node):
+        params.update_oper(None)
+
+
+def _publisher(source: _Source, params: ttt.TransformActorParams) -> ttt.TransformActor:
+    publisher = _Publisher(source, params)
+    return ttt.TransformActor(publisher.on_conf, publisher.shutdown)
+
+
+actor _test_rejected_on_change_requests_do_not_allocate_ids(t: testing.AsyncT):
+    schema = yang.compile([MODEL])
+    layer = ttt.Layer("top", ttt.Container({}), None)
+    pipes = netconf.actor_pipe_pair()
+    lh = logging.Handler("yp-ttt-test")
+    server = netconf_server.NetconfSession(pipes.server, lh, schema, layer)
+    requests = [
+        yp.build_establish_subscription(datastore="running", on_change=True),
+        yp.build_establish_subscription(on_change=True, dampening_period=1),
+    ]
+    for setting in [xml.Node("excluded-change", text="replace"), xml.Node("sync-on-start", text="bad"),
+                    xml.Node("dampening-period", text="-1"), xml.Node("dampening-period", text="soon")]:
+        requests.append(xml.Node("establish-subscription", nsdefs=[(None, yp.NS_SN)], children=[
+            xml.Node("datastore", nsdefs=[(None, yp.NS_YP), ("ds", yp.NS_DATASTORES)], text="ds:operational"),
+            xml.Node("on-change", nsdefs=[(None, yp.NS_YP)], children=[setting]),
+        ]))
+    requests.append(xml.Node("establish-subscription", nsdefs=[(None, yp.NS_SN)], children=[
+        xml.Node("datastore", nsdefs=[(None, yp.NS_YP), ("ds", yp.NS_DATASTORES)], text="ds:operational"),
+        xml.Node("periodic", nsdefs=[(None, yp.NS_YP)]),
+        xml.Node("on-change", nsdefs=[(None, yp.NS_YP)]),
+    ]))
+    var index = 0
+    var done = False
+
+    def fail(error: Exception):
+        if not done:
+            done = True
+            t.failure(error)
+
+    def _accepted(c: netconf.Client, sid: ?int, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+        elif sid != 1:
+            fail(ValueError("rejected requests allocated subscription ids"))
+        elif not done:
+            done = True
+            c.close(None)
+            t.success()
+
+    def _rejected(c: netconf.Client, reply: ?xml.Node, err: ?netconf.NetconfError):
+        if err is None:
+            fail(ValueError("unsupported on-change request was accepted"))
+        else:
+            index += 1
+            if index < len(requests):
+                c.rpc(requests[index], _rejected)
+            else:
+                c.establish_subscription(_accepted, on_change=True, sync_on_start=False)
+
+    def _connect(c: netconf.Client, err: ?Exception):
+        if err is not None:
+            fail(err)
+        else:
+            c.rpc(requests[0], _rejected)
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _connect,
+                            None, True, lh, pipe=pipes.client)
+    after 5.0: fail(ValueError("timed out waiting for policy rejection"))
+
+
+actor _test_on_change_routing_failure_terminates_subscription(t: testing.AsyncT):
+    schema = yang.compile([MODEL])
+    layer = ttt.Layer("top", ttt.Container({}), None)
+    pipes = netconf.actor_pipe_pair()
+    lh = logging.Handler("yp-ttt-test")
+    server = netconf_server.NetconfSession(pipes.server, lh, schema, layer)
+    var done = False
+    var subscription_id: ?int = None
+
+    def fail(error: Exception):
+        if not done:
+            done = True
+            t.failure(error)
+
+    def _deleted(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is None:
+            fail(ValueError("failed subscription was not released"))
+        elif not done:
+            done = True
+            c.close(None)
+            t.success()
+
+    def _notification(c: netconf.Client, notification: xml.Node):
+        try:
+            payload = yp.notification_payload(notification)!
+            testing.assertEqual(payload.tag, "subscription-terminated")
+            testing.assertTrue(subscription_id is not None)
+            testing.assertEqual(payload.one("id", None).text, str(subscription_id!))
+            testing.assertEqual(payload.one("reason", None).text, "yp:datastore-not-subscribable")
+            c.delete_subscription(_deleted, subscription_id!)
+        except Exception as error:
+            fail(error)
+
+    def _accepted(c: netconf.Client, sid: ?int, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+        else:
+            subscription_id = sid
+
+    def _connect(c: netconf.Client, err: ?Exception):
+        if err is not None:
+            fail(err)
+        else:
+            # Schema-valid selection whose content predicate cannot be routed
+            # across TTT actors; failure follows the accepted RPC asynchronously.
+            filt = xml.decode('<labels xmlns="urn:test-telemetry">a</labels>')
+            c.establish_subscription(_accepted, on_change=True, subtree_filter=[filt])
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _connect,
+                            _notification, True, lh, pipe=pipes.client)
+    after 5.0: fail(ValueError("timed out waiting for subscription termination"))
+
+
+actor _test_operational_on_change_replay(t: testing.AsyncT):
+    """Filtered subtree replacement, removals, cleanup, and sync disabled.
+
+    Every patch is replayed through the same YANG Patch decoder a client uses.
+    The second subtree omits a leaf to distinguish replacement from merging.
+    """
+    schema = yang.compile([MODEL])
+    source = _Source()
+    layer = ttt.Layer("top", ttt.Container({q("device"): ttt.List(
+        ttt.Transform(_Transform, lambda params: _publisher(source, params)), [q("name")]),
+    }), None)
+    pipes = netconf.actor_pipe_pair()
+    lh = logging.Handler("yp-ttt-test")
+    server = netconf_server.NetconfSession(pipes.server, lh, schema, layer)
+    var done = False
+    var accepted = False
+    var synced = False
+    var phase = 0
+    var subscription_id: ?int = None
+    var current: ?gdata.Node = None
+
+    def fail(error: Exception):
+        if not done:
+            done = True
+            t.failure(error)
+
+    def _on_delta_only(c: netconf.Client, sid: ?int, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+        else:
+            subscription_id = sid
+            # The existing value must not be sent with sync-on-start disabled.
+            after 0.05: source.publish("a", "delta-only")
+
+    def _subscribe_delta_only(c: netconf.Client):
+        phase = 4
+        c.establish_subscription(_on_delta_only, on_change=True, sync_on_start=False,
+            xpath_filter="/t:device[t:name='a']/t:state", xpath_nsdefs=[("t", NS)])
+
+    def _on_deleted(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+        else:
+            source.publish("a", "after-delete")
+            after 0.05: _subscribe_delta_only(c)
+
+    def _on_notif(c: netconf.Client, notification: xml.Node):
+        if done:
+            return
+        try:
+            pu = yp.parse_push_update(notification)
+            if pu is not None:
+                testing.assertTrue(accepted)
+                testing.assertEqual(phase, 0)
+                testing.assertFalse(synced)
+                testing.assertFalse(any(["target" in n.encode() for n in pu.contents]))
+                synced = True
+                source.publish("b", "unselected")
+                source.publish("a", "one", True)
+                return
+            pcu = yp.parse_push_change_update(notification)
+            testing.assertTrue(pcu is not None)
+            testing.assertTrue(synced)
+            testing.assertEqual(pcu!.sub_id, subscription_id)
+            patch = ypatch.Patch.from_xml(pcu!.yang_patch!)
+            testing.assertEqual(len(patch.edits), 1)
+            edit = patch.edits[0]
+            testing.assertEqual(edit.target, "/telemetry:device=a")
+            testing.assertEqual(patch.patch_id, "0" if phase == 4 else str(phase))
+            current = gdata.patch(current, ypatch.edit_to_gdata(schema, edit))
+            if phase == 0 or phase == 1 or phase == 4:
+                testing.assertEqual(edit.operation, ypatch.OP_REPLACE)
+                entry = current!.get_list(q("device")).elements[0]
+                testing.assertTrue(entry.get_opt_str(q("target")) is None)
+                state = entry.children[q("state")]
+                if phase == 0:
+                    testing.assertEqual(state.get_str(q("status")), "one")
+                    testing.assertEqual(state.get_opt_str(q("extra")), "old")
+                    phase = 1
+                    source.publish("a", "two")
+                elif phase == 1:
+                    testing.assertEqual(state.get_str(q("status")), "two")
+                    testing.assertTrue(state.get_opt_str(q("extra")) is None)
+                    phase = 2
+                    source.publish("a", None)
+                else:
+                    testing.assertEqual(state.get_str(q("status")), "delta-only")
+                    done = True
+                    c.close(None)
+                    t.success()
+            elif phase == 2:
+                testing.assertEqual(edit.operation, ypatch.OP_REMOVE)
+                phase = 3
+                c.delete_subscription(_on_deleted, subscription_id!)
+            else:
+                fail(ValueError("notification after deletion"))
+        except Exception as error:
+            fail(error)
+
+    def _on_sub(c: netconf.Client, sid: ?int, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+        else:
+            accepted = True
+            subscription_id = sid
+
+    def _on_seed(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+        else:
+            filt = xml.decode('<device xmlns="urn:test-telemetry"><name>a</name><state/></device>')
+            c.establish_subscription(_on_sub, on_change=True, subtree_filter=[filt])
+
+    def _on_connect(c: netconf.Client, err: ?Exception):
+        if err is not None:
+            fail(err)
+        else:
+            c.edit_config([
+                xml.decode('<device xmlns="urn:test-telemetry"><name>a</name><target>config</target></device>'),
+                xml.decode('<device xmlns="urn:test-telemetry"><name>b</name><target>config</target></device>'),
+            ], _on_seed)
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect,
+                            _on_notif, True, lh, pipe=pipes.client)
+    after 5.0: fail(ValueError("timed out waiting for operational changes"))

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -193,7 +193,7 @@ def CfgError(exception: Exception):
 
 class Path():
     name: str
-    namespace: () -> str
+    namespace: () -> ?str
 
     def __str__(self):
         parts = _format_path(self)
@@ -203,7 +203,7 @@ class PathRoot(Path):
     def __init__(self, name: str):
         self.name = name
     def namespace(self):
-        return ""
+        return None
 
 class PathElem(Path):
     def __init__(self, i: gdata.Id, parent: Path):
@@ -220,6 +220,14 @@ class PathKey(Path):
         self.keyvals = keyvals
     def namespace(self):
         return self.parent.namespace()
+
+def path_chain(p: Path) -> list[Path]:
+    """The path elements from the layer root down to p."""
+    if isinstance(p, PathElem):
+        return path_chain(p.parent) + [p]
+    elif isinstance(p, PathKey):
+        return path_chain(p.parent) + [p]
+    return [p]
 
 def _format_path(p: Path):
     if isinstance(p, PathElem):
@@ -272,6 +280,15 @@ def make_rooted(p: Path, tree: gdata.Node):
     else:
         return tree
 
+def spine(p: Path, tree: gdata.Node) -> gdata.Node:
+    """The tree from the top down to tree at p: make_rooted, with every node
+    on the way stamped as its node stamps it."""
+    if isinstance(p, PathKey):
+        return spine(p.parent, gdata.List(list(p.keyvals.keys()), [_with_path_keys(p, tree)], ns=p.parent.namespace()))
+    elif isinstance(p, PathElem):
+        return spine(p.parent, gdata.Container({gdata.Id(p.ns, p.name): tree}, ns=p.parent.namespace()))
+    return tree
+
 def _with_path_keys(p: Path, tree: gdata.Node) -> gdata.Node:
     if isinstance(p, PathKey) and isinstance(tree, gdata.Container):
         children = dict(tree.children.items())
@@ -294,6 +311,18 @@ def root_filter(filt: ?gdata.FNode) -> ?gdata.FNode:
     if filt is not None and filt.name is not None:
         return gdata.FNode(children=[filt])
     return filt
+
+def _keys_only(f: gdata.FNode, keys: dict[gdata.Id, gdata.Node]) -> bool:
+    """Whether a filter selects nothing but list keys. One that selects
+    nothing at all selects everything, so it is not that."""
+    sel = gdata.filter_selection_children(f)
+    for c in sel:
+        n = c.name
+        if n is not None:
+            if n in keys:
+                continue
+        return False
+    return len(sel) > 0
 
 def routed_filter(filt: ?gdata.FNode) -> ?gdata.FNode:
     """Adapt a routed child filter to the node that already matched it.
@@ -449,29 +478,35 @@ def exact_list_filter_branches(filters: list[gdata.FNode], key_names: list[gdata
 def _delay(period: u64) -> float:
     return float(period) / 1000000000.0
 
+def _union(specs: list[gdata.SubscriptionSpec]) -> ?gdata.FNode:
+    """One filter for the specs: the union of their filters, or None for
+    everything, which a filter that names nothing, or no filter, is."""
+    branches: list[gdata.FNode] = []
+    for spec in specs:
+        f = root_filter(spec.filt)
+        if f is not None and len(f.children) > 0:
+            branches.extend(f.children)
+        else:
+            return None
+    return gdata.FNode(children=gdata.filter_merge_list(branches))
+
 def fold(want: set[gdata.SubscriptionSpec]) -> dict[u64, ?gdata.FNode]:
     """One filter per period: the union of the filters a consumer declared
-    with that period, so one read serves them all. A filter that names
-    nothing, or no filter, is everything."""
-    branches: dict[u64, list[gdata.FNode]] = {}
-    whole: set[u64] = set()
+    with that period, so one read serves them all."""
+    by_period: dict[u64, list[gdata.SubscriptionSpec]] = {}
     for spec in want:
         period = spec.period
         if period is not None:
-            if period not in branches:
-                branches[period] = []
-            f = root_filter(spec.filt)
-            if f is not None and len(f.children) > 0:
-                branches[period].extend(f.children)
-            else:
-                whole.add(period)
-    folded: dict[u64, ?gdata.FNode] = {}
-    for period, bs in branches.items():
-        if period in whole:
-            folded[period] = None
-        else:
-            folded[period] = gdata.FNode(children=gdata.filter_merge_list(bs))
-    return folded
+            if period not in by_period:
+                by_period[period] = []
+            by_period[period].append(spec)
+    return {period: _union(specs) for period, specs in by_period.items()}
+
+def fold_on_change(want: set[gdata.SubscriptionSpec]) -> (bool, ?gdata.FNode):
+    """Whether the consumer declared a spec without a period, and the one
+    filter those specs fold into."""
+    specs = [spec for spec in want if spec.period is None]
+    return (len(specs) > 0, _union(specs))
 
 
 class Read(object):
@@ -492,34 +527,140 @@ class Read(object):
         self.active = True
 
 
+##################### Routes and shadows #####################
+
+class OperListSubscription():
+    """One subscription at a list: which elements it selects, by exact key
+    or by a filter over all of them."""
+    sub: Subscription
+    select: ?dict[str, list[gdata.FNode]]
+    scan: list[gdata.FNode]
+
+    def __init__(self, sub: Subscription, select: ?dict[str, list[gdata.FNode]], scan: list[gdata.FNode]):
+        self.sub = sub
+        self.select = select
+        self.scan = scan
+
+    def selects(self, k: str) -> ?list[gdata.FNode]:
+        """The filters for element k, or nothing when it is not selected."""
+        select = self.select
+        if select is not None:
+            return select.get(k)
+        return self.scan
+
+    def members(self, elems: dict[str, Node]) -> list[(str, list[gdata.FNode])]:
+        """The elements this subscription selects among elems, with their filters:
+        its exact keys when it has them, else all of them."""
+        select = self.select
+        if select is not None:
+            return [(k, filts) for k, filts in select.items() if k in elems]
+        return [(k, self.scan) for k in elems.keys()]
+
+
+class OperSubscription():
+    """One subscription at a producer: where to push, what to select, and
+    what was last sent so an unchanged slice is not resent. A new slice
+    is a new record."""
+    sub: Subscription
+    filts: list[gdata.FNode]
+    last: ?gdata.Node
+
+    def __init__(self, sub: Subscription, filts: list[gdata.FNode], last: ?gdata.Node):
+        self.sub = sub
+        self.filts = filts
+        self.last = last
+
+def _shadow_key(p: Path) -> str:
+    return "{p.ns}:{p.name}" if isinstance(p, PathElem) else p.name
+
+class Shadow(object):
+    """A node of the subscriber's shadow of the tree: a copy of the part of
+    the layer's tree the subscription asked for, built from the latest
+    slice each producer under it pushed on change, and kept in step with
+    the tree by those pushes. It is a cache. built holds a producer's
+    latest slice at a leaf, or the children joined at an inner node,
+    remembered until a push below it changes it, so a push rebuilds the
+    nodes on its own path and every other subtree is shared by reference.
+    It is mutable on purpose: a value would copy every child of every node
+    on the path per push.
+    """
+    path: Path
+    kids: dict[str, Shadow]
+    built: ?gdata.Node
+
+    def __init__(self, path: Path, built: ?gdata.Node=None):
+        self.path = path
+        self.kids = {}
+        self.built = built
+
+    def build(self) -> gdata.Node:
+        built = self.built
+        if built is not None:
+            return built
+        joined = self._join()
+        self.built = joined
+        return joined
+
+    def _join(self) -> gdata.Node:
+        p = self.path
+        ns = p.namespace()
+        for kid in self.kids.values():
+            kp = kid.path
+            if isinstance(kp, PathKey):             # the children are entries: this is a list
+                return gdata.List(list(kp.keyvals.keys()), [k.build() for k in self.kids.values()], ns=ns)
+        children = dict(p.keyvals.items()) if isinstance(p, PathKey) else {}
+        for kid in self.kids.values():
+            kp = kid.path
+            if isinstance(kp, PathElem):
+                children[gdata.Id(kp.ns, kp.name)] = kid.build()
+        return gdata.Container(children, ns=ns)
+
+
 actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) -> None, point: list[gdata.Id]):
     """One consumer's subscriptions, served outside the Layer actor.
 
-    The consumer's filters fold into one read per period. Each read runs
-    on its period, and every delivery is the reads' latest trees merged
-    into one view, sent straight to the consumer. synced is called once per
-    declaration, when every read has run once.
+    The consumer's periodic filters fold into one read per period, and its
+    on-change filters into one subscription in the tree. Each read runs on
+    its period. The subscription is laid by a walk from here: every node answers
+    with its path, its oper slice if it is a producer, and the children to
+    continue with, and the answers become a shadow of the subscribed part
+    of the tree. After the walk every producer under the subscription pushes its
+    slice here as it changes, and the shadow is rebuilt along the changed
+    path with everything else shared by reference. Every delivery is the
+    reads' latest trees and the shadow merged into one view, sent straight
+    to the consumer, and a consumer that asked for it gets each change alone
+    first, as the path of the node that changed with what it held before
+    and after. synced is called once per declaration, when every read has
+    run once and the subscription has been laid.
 
     Rooted at a point, a path of node names from the top, the consumer
     gets the instances of that node instead of one view: after each read,
     every instance that differs from the last read, as a tree from the top
     down to that one instance, and every instance gone, as that tree with
-    an Absent holding its keys where the entry was.
+    an Absent holding its keys where the entry was. On-change, a change
+    delivers the instances it touched the same way.
 
-    The reads and the waiting happen here, never in the Layer actor that
-    runs transactions.
+    The reads, the walk and the waiting happen here, never in the Layer
+    actor that runs transactions.
     """
     var reads: dict[u64, Read] = {}
+    var shadow: ?Shadow = None                  # what the subscription holds of the tree
+    var sub_id = ""                             # the subscription's name in the tree, "" when there is none
+    var change_filt: ?gdata.FNode = None        # the subscription's folded filter
+    var subs = 0
     var cb = cb0
+    var delta: ?proc(Path, ?gdata.Node, ?gdata.Node) -> None = None
     var synced: ?action(str) -> None = None
     var owed = False                            # a synced for the current declaration
     var active = True
 
-    def declare(want: set[gdata.SubscriptionSpec], cb1: proc(?gdata.Node, ?Exception) -> None, synced1: ?action(str) -> None):
+    def declare(want: set[gdata.SubscriptionSpec], cb1: proc(?gdata.Node, ?Exception) -> None, synced1: ?action(str) -> None, delta1: ?proc(Path, ?gdata.Node, ?gdata.Node) -> None):
         """Replace the want set: reads no longer wanted stop, changed ones
-        start over, unchanged ones keep their latest tree."""
+        start over, unchanged ones keep their latest tree. The subscription
+        is laid again only when its filter changed."""
         cb = cb1
         synced = synced1
+        delta = delta1
         folded = fold(want)
         dropped = False
         for period in list(reads.keys()):
@@ -541,6 +682,16 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
                     fresh.held = old.held       # so the next read reports only what changed
                 reads[period] = fresh
                 _read(fresh, period)
+        (on_change, cfilt) = fold_on_change(want)
+        if sub_id != "":
+            if not on_change:
+                _unsubscribe()
+                dropped = True
+            elif change_filt != cfilt:
+                _unsubscribe()
+                _subscribe(cfilt)
+        elif on_change:
+            _subscribe(cfilt)
         if dropped and len(point) == 0:
             _deliver(None)                      # the narrowed view
         owed = True
@@ -577,10 +728,10 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
         r.held = now
 
     def _deliver(err: ?Exception):
-        """The reads' latest trees as one view, by reference for one read."""
+        """The reads' latest trees and the shadow as one view, by reference
+        when there is one."""
         merged: ?gdata.Node = None
-        for period in sorted(reads.keys()):
-            t = reads[period].latest
+        for t in [reads[period].latest for period in sorted(reads.keys())] + [_tree()]:
             if t is not None:
                 m = merged
                 if m is not None:
@@ -601,7 +752,200 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
 
     def stop():
         active = False
+        _unsubscribe()
 
+    # The subscription in the tree
+
+    def _subscribe(f: ?gdata.FNode):
+        """Lay the subscription below node; the walk's result is the baseline."""
+        change_filt = f
+        sub_id = actorid() + ":" + str(subs)
+        subs += 1
+        filts: list[gdata.FNode] = []
+        if f is not None:
+            filts = [f]
+        try:
+            shadow = _walk(node, filts)
+        except Exception as e:
+            _failed(e)
+            return
+        if len(point) == 0:
+            _deliver(None)
+        else:
+            for i in gdata.instances(_tree(), point):
+                cb(i.1, None)
+
+    def _unsubscribe():
+        """Take the subscription out of the tree. The tree hears this after any
+        walk still in progress, so it undoes all that the walk laid."""
+        if sub_id != "":
+            node.unsubscribe_oper(sub_id)
+            shadow = None
+            sub_id = ""
+
+    def _failed(e: Exception):
+        """The subscription cannot be served: report it once and drop it."""
+        _unsubscribe()
+        if len(point) == 0:
+            _deliver(e)
+        else:
+            cb(None, e)
+
+    def fail(r: str, e: Exception):
+        """A producer could not serve the subscription."""
+        if active and r == sub_id:
+            _failed(e)
+
+    def update(r: str, path: Path, slice: ?gdata.Node):
+        """A producer under the subscription pushed its slice, or cleared it."""
+        if active and r == sub_id:
+            if slice is not None:
+                _graft(Shadow(path, slice))
+            else:
+                gone = _remove(path)
+                if gone is not None:
+                    _changed(gone.path, gone.build(), None)
+
+    def attach(r: str, at: Node, filts: list[gdata.FNode]):
+        """A list element committed after the walk joins the subscription."""
+        if active and r == sub_id:
+            try:
+                m = _walk(at, filts)
+                if m is not None:
+                    _graft(m)
+            except Exception as e:
+                _failed(e)
+
+    def _graft(m: Shadow):
+        """Put m at its path in place of what was there, and deliver the change."""
+        before = _built(_at(m.path))
+        _place(m)
+        _changed(m.path, before, m.build())
+
+    def _changed(path: Path, before: ?gdata.Node, now: ?gdata.Node):
+        """Deliver a change at path: the change alone to a consumer that
+        asked for it, then the view or, rooted, each instance of the point
+        that the change touched."""
+        if len(point) == 0:
+            d = delta
+            if d is not None:
+                d(path, before, now)
+            _deliver(None)
+        else:
+            try:
+                _changed_rooted(path, before)
+            except Exception as e:
+                cb(None, e)
+
+    def _changed_rooted(path: Path, before: ?gdata.Node):
+        """The instances of the point that a change at path left different,
+        and those it left gone: the change lies in one instance, or holds
+        several."""
+        ip = _instance_path(path)
+        was: dict[str, (gdata.Node, gdata.Node)] = {}
+        if before is not None:
+            for i in gdata.instances(spine(path, before), point):
+                was[i.0] = (i.1, i.2)
+        present: set[str] = set()
+        now = _built(_at(ip))
+        if now is not None:
+            for i in gdata.instances(spine(ip, now), point):
+                present.add(i.0)
+                if i.0 not in was or was[i.0].1 != i.2:
+                    cb(i.1, None)
+        for k, w in was.items():
+            if k not in present:
+                cb(gdata.gone(w.0, point), None)
+
+    def _instance_path(path: Path) -> Path:
+        """The path a change at path is delivered under: the instance of the
+        point it lies in, else path itself, at or above the point or outside."""
+        chain = path_chain(path)
+        i = 0
+        for j in range(1, len(chain)):
+            p = chain[j]
+            if i == len(point):                     # below the point's node
+                return p if isinstance(p, PathKey) else chain[j - 1]
+            if isinstance(p, PathElem):
+                if gdata.Id(p.ns, p.name) != point[i]:
+                    break
+                i += 1
+        return path
+
+    def _at(path: Path) -> ?Shadow:
+        """The shadow node at path, if there is one."""
+        down = _down(path, False)
+        if len(down) > 0:
+            return down[len(down) - 1]
+        return None
+
+    def _built(m: ?Shadow) -> ?gdata.Node:
+        if m is not None:
+            return m.build()
+        return None
+
+    def _tree() -> ?gdata.Node:
+        return _built(shadow)
+
+    def _walk(at: Node, filts: list[gdata.FNode]) -> ?Shadow:
+        (path, slice, below) = at.subscribe_oper(sub_id, self, filts)
+        m = Shadow(path, slice)
+        for hop in below:
+            kid = _walk(hop.0, hop.1)
+            if kid is not None:
+                m.kids[_shadow_key(kid.path)] = kid
+        return m if slice is not None or len(m.kids) > 0 else None
+
+    def _down(path: Path, create: bool) -> list[Shadow]:
+        """The shadow nodes from the root down to path, made on the way with
+        create, else empty when one is missing."""
+        chain = path_chain(path)
+        root = Shadow(chain[0])
+        s = shadow
+        if s is not None:
+            root = s
+        elif not create:
+            return []
+        shadow = root
+        down = [root]
+        for p in chain[1:]:
+            at = down[len(down) - 1]
+            k = _shadow_key(p)
+            if k not in at.kids:
+                if not create:
+                    return []
+                at.kids[k] = Shadow(p)
+            down.append(at.kids[k])
+        return down
+
+    def _place(m: Shadow):
+        """Put m at its path, making the way down to it, in place of what was there."""
+        chain = path_chain(m.path)
+        if len(chain) == 1:
+            shadow = m
+        else:
+            down = _down(chain[len(chain) - 2], True)
+            for a in down:
+                a.built = None
+            down[len(down) - 1].kids[_shadow_key(m.path)] = m
+
+    def _remove(path: Path) -> ?Shadow:
+        """Drop the node at path and every ancestor it leaves empty. Return the
+        topmost node dropped, still holding what it held, or nothing when there
+        was nothing at path."""
+        down = _down(path, False)
+        if len(down) == 0:
+            return None
+        i = len(down) - 1
+        while i > 0 and len(down[i - 1].kids) == 1:
+            i -= 1
+        if i == 0:
+            shadow = None
+        else:
+            del down[i - 1].kids[_shadow_key(down[i].path)]
+            for a in down[0:i]:
+                a.built = None
+        return down[i]
 
 def _db_path(path: Path) -> list[value]:
     if isinstance(path, PathElem):
@@ -652,6 +996,26 @@ actor Node(impl: _Node):
     def get_data(filt: ?gdata.FNode=None):
         return impl.get_data(filt)
 
+    def subscribe_oper(sub_id: str, sub: Subscription, filts: list[gdata.FNode]) -> (Path, ?gdata.Node, list[(Node, list[gdata.FNode])]):
+        """Subscribe `sub` to the oper below this node, one step of the way
+        down. This is telemetry, apart from the link subscriptions that carry
+        config between transforms: nothing here is transactional or waits.
+
+        `sub_id` names the subscription in the tree. The subscriber's actor
+        lays it with a walk that calls this on the root and then on each
+        child answered, the way a read carries a filter down with get_data. A
+        container or list transposes `filts` into one filter per child and
+        answers the children they select; a list also keeps the subscription,
+        so an entry that commits later joins it. A transform keeps it and
+        `sub`, so its later update_oper pushes reach the subscriber, and
+        answers its oper slice. The answer is this node's path, that slice,
+        and the children to continue with, each with its filters."""
+        return impl.subscribe_oper(sub_id, sub, filts)
+
+    def unsubscribe_oper(sub_id: str):
+        """Take an oper subscription out of this node and everything below it."""
+        impl.unsubscribe_oper(sub_id)
+
     def bind_db(db: ?swdb.Store):
         """Attach DB handle to this node (and its children)
 
@@ -673,6 +1037,12 @@ class _Node(object):
     get: proc() -> gdata.Node
     def get_data(self, filt: ?gdata.FNode=None) -> ?gdata.Node:
         return gdata.filter(self.get(), filt)
+    def subscribe_oper(self, sub_id: str, sub: Subscription, filts: list[gdata.FNode]) -> (Path, ?gdata.Node, list[(Node, list[gdata.FNode])]):
+        """A node with no producer and no children below it: nothing to
+        answer, nothing to continue with."""
+        return (self.path, None, [])
+    def unsubscribe_oper(self, sub_id: str) -> None:
+        pass
     def bind_db(self, db: ?swdb.Store) -> None:
         pass
     restore_from_db: proc(swdb.Reader, swdb.KeyCodec, RestoreWindow, action(?Exception) -> None) -> None
@@ -709,6 +1079,12 @@ actor Transaction(impl: _Transaction):
     def get_data(filt: ?gdata.FNode=None):
         return impl.get_data(filt)
 
+    def subscribe_oper(sub_id: str, sub: Subscription, filts: list[gdata.FNode]) -> (Path, ?gdata.Node, list[(Node, list[gdata.FNode])]):
+        return impl.subscribe_oper(sub_id, sub, filts)
+
+    def unsubscribe_oper(sub_id: str):
+        impl.unsubscribe_oper(sub_id)
+
     def bind_db(db: ?swdb.Store):
         impl.bind_db(db)
 
@@ -740,6 +1116,12 @@ class _Transaction(object):
     get: proc() -> gdata.Node
     def get_data(self, filt: ?gdata.FNode=None) -> ?gdata.Node:
         return gdata.filter(self.get(), filt)
+
+    proc def subscribe_oper(self, sub_id: str, sub: Subscription, filts: list[gdata.FNode]) -> (Path, ?gdata.Node, list[(Node, list[gdata.FNode])]):
+        return (self.path, None, [])
+
+    proc def unsubscribe_oper(self, sub_id: str) -> None:
+        pass
 
     def bind_db(self, db: ?swdb.Store) -> None:
         pass
@@ -884,39 +1266,46 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
     def tree_provider() -> gdata.TreeProvider:
         return LayerTreeProvider(self)
 
-    def declare_subscriptions(owner_id: str, cb: proc(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec], synced: ?action(str) -> None=None):
+    def declare_subscriptions(owner_id: str, cb: proc(?gdata.Node, ?Exception) -> None, want: set[gdata.SubscriptionSpec], synced: ?action(str) -> None=None, delta: ?proc(Path, ?gdata.Node, ?gdata.Node) -> None=None):
         """Replace one consumer's want set. A Subscription actor of the
         consumer's own serves it and calls `synced` with the owner id once
-        every read of the declaration has run. A layer serves periodic
-        specs. Specs rooted at a node share one root, and one period."""
+        every read of the declaration has run. A spec with a period is
+        read on that period. A spec without one is served on-change: the
+        operational state under its filter reaches the consumer as the
+        transforms publish it with update_oper, and a consumer that gives
+        `delta` also gets each change alone, as the path of the node that
+        changed with what it held before and after. Specs rooted at a node
+        share one root, and are read on one period or served on-change."""
         point: list[gdata.Id] = []
         root_of: ?gdata.FNode = None
         first = True
         try:
             for spec in want:
-                if spec.period is None:
-                    raise ValueError("TTT layer TreeProvider only supports periodic subscriptions")
                 if first:
                     root_of = spec.root
                     first = False
                 elif root_of != spec.root:
                     raise ValueError("a consumer's filters share one root")
             point = gdata.root_names(root_of)
-            if len(point) > 0 and len(fold(want)) > 1:
-                raise ValueError("a rooted destination is read on one period")
+            if len(point) > 0:
+                ways = len(fold(want))
+                if fold_on_change(want).0:
+                    ways += 1
+                if ways > 1:
+                    raise ValueError("a rooted destination is read on one period or served on-change")
         except Exception as e:
             cb(None, e)
             return
         sub = subscribers.get(owner_id)
         if sub is not None:
             if roots[owner_id] == root_of:
-                sub.declare(want, cb, synced)
+                sub.declare(want, cb, synced, delta)
                 return
             sub.stop()                              # a new root is a new actor
         fresh = Subscription(owner_id, root, cb, point)
         subscribers[owner_id] = fresh
         roots[owner_id] = root_of
-        fresh.declare(want, cb, synced)
+        fresh.declare(want, cb, synced, delta)
 
     def remove_subscriptions(owner_id: str):
         """Drop a consumer and stop its reads."""
@@ -1217,6 +1606,49 @@ class _Container(_Node):
             return None
         return gdata.Container(res, ns=self.ns, module=self.module)
 
+    def subscribe_oper(self, sub_id: str, sub: Subscription, filts: list[gdata.FNode]) -> (Path, ?gdata.Node, list[(Node, list[gdata.FNode])]):
+        """Transpose the filters into one per child and answer the children
+        they select. A predicate on one of this entry's keys is decided here;
+        any other predicate at this level would span producers, so it is
+        refused."""
+        path = self.path
+        keys = path_key_data(path)
+        branches: dict[gdata.Id, list[gdata.FNode]] = {}
+        whole = len(filts) == 0
+        for f in filts:
+            preds: list[gdata.FNode] = []
+            rest: list[gdata.FNode] = []
+            for c in f.children:
+                n = c.name
+                if n is not None and n in keys.children and c.value_match is not None:
+                    preds.append(c)
+                elif c.value_match is not None:
+                    raise ValueError("a content predicate at {_format_path(path)} would span producers; put it under one transform")
+                else:
+                    rest.append(c)
+            if len(preds) > 0 and gdata.filter(keys, gdata.FNode(children=preds)) is None:
+                continue                                    # this alternative does not select this entry
+            b = filter_transpose(gdata.FNode(children=rest))
+            if b is not None:
+                for tag, cf in b.items():
+                    if tag in branches:
+                        branches[tag].append(cf)
+                    else:
+                        branches[tag] = [cf]
+            else:
+                whole = True
+        below: list[(Node, list[gdata.FNode])] = []
+        for tag, node in self.elems.items():
+            if whole:
+                below.append((node, []))
+            elif tag in branches:
+                below.append((node, branches[tag]))
+        return (self.path, None, below)
+
+    def unsubscribe_oper(self, sub_id: str) -> None:
+        for node in self.elems.values():
+            node.unsubscribe_oper(sub_id)
+
     def bind_db(self, db: ?swdb.Store) -> None:
         for node in self.elems.values():
             node.bind_db(db)
@@ -1466,6 +1898,20 @@ class _List(_Node):
             return None
         return gdata.List(self.key_names, res, ns=self.ns, module=self.module)
 
+    def subscribe_oper(self, sub_id: str, sub: Subscription, filts: list[gdata.FNode]) -> (Path, ?gdata.Node, list[(Node, list[gdata.FNode])]):
+        """Select the entries by exact key when every filter names one, else
+        every entry with the filters over all of them, and hand the
+        subscription to the list state, so an entry that commits later joins it."""
+        alts: list[gdata.FNode] = []
+        for f in filts:
+            alts += list_filters(f)
+        select = exact_list_filter_branches(alts, self.key_names)
+        scan = list_element_filters(alts)
+        return (self.path, None, self.liststate.subscribe_oper(sub_id, sub, select, scan))
+
+    def unsubscribe_oper(self, sub_id: str) -> None:
+        self.liststate.unsubscribe_oper(sub_id)
+
     def bind_db(self, db: ?swdb.Store) -> None:
         self.liststate.bind_db(db)
 
@@ -1557,11 +2003,33 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
     var active = {}
     var provisional = set()
     var db = None
+    var oper_subscriptions: dict[str, OperListSubscription] = {}
 
     def bind_db(db1: ?swdb.Store) -> None:
         db = db1
         for node in elems.values():
             node.bind_db(db1)
+
+    def subscribe_oper(sub_id: str, sub: Subscription, select: ?dict[str, list[gdata.FNode]], scan: list[gdata.FNode]) -> list[(Node, list[gdata.FNode])]:
+        """Remember an oper subscription so that elements committed later join
+        it, and answer the committed elements it selects now."""
+        o = OperListSubscription(sub, select, scan)
+        oper_subscriptions[sub_id] = o
+        return [(elems[m.0], m.1) for m in o.members(elems) if m.0 not in provisional]
+
+    def unsubscribe_oper(sub_id: str):
+        if sub_id in oper_subscriptions:
+            o = oper_subscriptions[sub_id]
+            del oper_subscriptions[sub_id]
+            for m in o.members(elems):
+                elems[m.0].unsubscribe_oper(sub_id)
+
+    def _attach(k: str):
+        """Subscribe a committed element to every oper subscription that selects it."""
+        for sid, o in oper_subscriptions.items():
+            filts = o.selects(k)
+            if filts is not None:
+                o.sub.attach(sid, elems[k], filts)
 
     def acquire(tid: str, keys: ?dict[str, dict[gdata.Id, gdata.Leaf]], full: ?set[str]) -> dict[str, Node]:
         if keys is not None:
@@ -1593,6 +2061,10 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
     def release(tid: str, ok: bool, deletes: set[str]):
         #print('====', tid, path, 'release', ok, 'deletes:', deletes, 'provisional:', provisional, err=True)
         if ok:
+            # An element joins the oper subscriptions when it is committed, not
+            # when it is created: a provisional element is not part of running.
+            for k in active[tid] & provisional:
+                _attach(k)
             provisional -= active[tid]
             provisional |= deletes
         del active[tid]
@@ -1641,6 +2113,7 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
         node = template(PathKey(key, path, leaves), lower)
         node.bind_db(db)
         elems[key] = node
+        _attach(key)
         return node
 
 class _ListTransaction(_Transaction):
@@ -1979,6 +2452,12 @@ class _TransformBase(_Node):
     def get_data(self, filt: ?gdata.FNode=None):
         return self.transaction.get_data(filt)
 
+    def subscribe_oper(self, sub_id: str, sub: Subscription, filts: list[gdata.FNode]) -> (Path, ?gdata.Node, list[(Node, list[gdata.FNode])]):
+        return self.transaction.subscribe_oper(sub_id, sub, filts)
+
+    def unsubscribe_oper(self, sub_id: str) -> None:
+        self.transaction.unsubscribe_oper(sub_id)
+
     def bind_db(self, db: ?swdb.Store) -> None:
         self.transaction.bind_db(db)
 
@@ -2016,6 +2495,7 @@ class _TransformTransactionBase(_Transaction):
 
     me: str
     db: ?swdb.Store
+    oper_subscriptions: dict[str, OperSubscription]          # Telemetry: on-change subscribers served with this node's oper
 
     compute : proc(tid: str, merged: gdata.Node, linked: gdata.Node, out: ?Session) -> (gdata.Node, ?gdata.Node)
     clear : proc(tid: str, out: ?Session) -> None
@@ -2035,6 +2515,7 @@ class _TransformTransactionBase(_Transaction):
         self.oper = None
         self.locker = None
         self.pending = []
+        self.oper_subscriptions = {}
         self.linked = gdata.Container()
         self.candidate_link_updates = {}
         self.subscriptions = []
@@ -2305,8 +2786,62 @@ class _TransformTransactionBase(_Transaction):
             return _with_path_keys(self.path, filtered)
         return None
 
+    def _slice(self, filts: list[gdata.FNode]) -> ?gdata.Node:
+        """This node's oper with its keys, narrowed to the union of the
+        filters that match, or all of it when there is no filter. A filter
+        that selects nothing but keys selects no oper."""
+        oper = self.oper
+        if oper is not None:
+            path = self.path
+            keyed = _with_path_keys(path, oper)
+            if len(filts) == 0:
+                return keyed
+            out: ?gdata.Node = None
+            for f in filts:
+                if not _keys_only(f, path_key_data(path).children):
+                    r = gdata.filter(keyed, f)
+                    if r is not None:
+                        o = out
+                        if o is not None:
+                            out = gdata.merge(o, r)
+                        else:
+                            out = r
+            if out is not None:
+                return _with_path_keys(path, out)
+        return None
+
+    proc def subscribe_oper(self, sub_id: str, sub: Subscription, filts: list[gdata.FNode]) -> (Path, ?gdata.Node, list[(Node, list[gdata.FNode])]):
+        """Keep the subscription and its filters, so every later update_oper
+        pushes the subscriber the slice they select, and answer that slice
+        now. An oper subscription is telemetry, apart from the link
+        subscriptions that carry config between transforms."""
+        fs = [routed_filter(f)! for f in filts]
+        o = OperSubscription(sub, fs, self._slice(fs))
+        self.oper_subscriptions[sub_id] = o
+        return (self.path, o.last, [])
+
+    proc def unsubscribe_oper(self, sub_id: str) -> None:
+        if sub_id in self.oper_subscriptions:
+            del self.oper_subscriptions[sub_id]
+
     proc def update_oper(self, oper):
+        """Replace this node's oper and push each oper subscription the slice it selects,
+        when that changed. TTT never clears the oper by itself: a transform
+        actor whose config went away does that from its shutdown, with None."""
         self.oper = oper
+        sent: list[(str, OperSubscription)] = []
+        for sid, o in self.oper_subscriptions.items():
+            s: ?gdata.Node = None
+            try:
+                s = self._slice(o.filts)
+            except Exception as e:
+                o.sub.fail(sid, e)
+                continue
+            if s != o.last:
+                sent.append((sid, OperSubscription(o.sub, o.filts, s)))
+                o.sub.update(sid, self.path, s)
+        for sid, o in sent:
+            self.oper_subscriptions[sid] = o
 
 class TransformActorParams:
     def __init__(self, path: Path, update_dynstate: action(?gdata.Node) -> None, update_oper: action(?gdata.Node) -> None, dev: ?swdev.DeviceMgr, lower: ?Layer=None):

--- a/src/yp.act
+++ b/src/yp.act
@@ -329,7 +329,7 @@ def parse_establish_subscription(op: xml.Node) -> EstablishParams:
     if on_change:
         sync_on_start = True
         if sync_node is not None:
-            if sync_node.text == "false":
+            if sync_node.text == "false" or sync_node.text == "0":
                 sync_on_start = False
     sf = _child_by_tag(op, "datastore-subtree-filter")
     subtree_filter = sf.children if sf is not None else None

--- a/src/yp_ttt.act
+++ b/src/yp_ttt.act
@@ -1,24 +1,38 @@
-"""TTT-backed YANG-push for the northbound NETCONF server (periodic).
+"""TTT-backed YANG-push for the northbound NETCONF server.
 
 TttSubscriptionService is the NETCONF binding that serves dynamic YANG-push
 (RFC 8641) subscriptions straight from a ttt.Layer datastore via TTT's native
-subscription mechanism (declare_subscriptions). On establish-subscription it
-declares a TTT subscription; TTT samples the datastore on the spec period and
-pushes the current merged tree to our callback, which we frame as a NETCONF
-push-update notification carrying the datastore-contents.
+subscription mechanism (declare_subscriptions) and frames what TTT delivers as
+NETCONF notifications:
 
-Supported v1 subset, enforced before a subscription is accepted (anything outside
+  - a periodic subscription samples the datastore on the spec period, and each
+    delivery becomes a push-update carrying the datastore-contents;
+  - an on-change subscription is served from the layer's route to the
+    operational state its transforms publish. The first delivery is the
+    complete baseline, sent as a push-update when sync-on-start is asked for;
+    every change after that arrives as the path of the node that changed with
+    what it held before and after, and is sent as a push-change-update whose
+    yang-patch replaces that subtree (so omitted descendants disappear) or
+    removes it. No tree is diffed. Config is not part of an on-change
+    subscription: it carries operational state only, with the keys of the
+    list entries it sits under, and it is served from the operational
+    datastore only. An entry whose config is removed is removed from the
+    subscription. A failure while serving ends the subscription with a
+    subscription-terminated notification.
+
+Supported subset, enforced before a subscription is accepted (anything outside
 it gets an rpc-error rather than being silently served as something else):
 
-  - periodic subscriptions only; on-change is not supported;
   - the running or operational datastore;
   - no filter, a datastore-subtree-filter (RFC 6241 subtree filtering), or a
     datastore-xpath-filter in the subset supported by acton-yang. Filters are
     parsed against the served schema into a gdata filter and handed to TTT,
-    which samples only the selected subtree, so each push carries just the
-    filtered data.
+    which serves only the selected subtree, so each push carries just the
+    filtered data;
+  - no dampening-period and no excluded-change on an on-change subscription:
+    changes are sent as they happen.
 
-Known deviation, still under discussion: TTT subscriptions are
+Known deviation, still under discussion: TTT periodic subscriptions are
 periodic-with-change-suppression, so a subscription only pushes when the datastore
 actually changes (at most once per period), not unconditionally every period.
 
@@ -28,12 +42,14 @@ the transport-only netconf.yp binding so it stays TTT-free.
 
 import logging
 import std.xml as xml
+import uri
 
 import ttt
 import yang.filter_xpath as filter_xpath
 import yang.gdata as gdata
 import yang.schema as yschema
 import yang.xml as yxml
+import yang.ypatch as ypatch
 
 from netconf import Server
 import yp
@@ -50,6 +66,121 @@ def parse_subtree_filter(schema: yschema.DRoot, nodes: list[xml.Node]) -> gdata.
     return yxml.from_filter_xml(schema, wrapper)
 
 
+def _change_target(schema: yschema.DRoot, path: ttt.Path) -> str:
+    """Render a TTT path as an RFC 8040 data-resource path, module-qualified
+    where the namespace changes and the schema knows the module."""
+    if isinstance(path, ttt.PathElem):
+        name = path.name
+        if path.ns != path.parent.namespace():
+            if path.ns not in schema.module_metadata:
+                raise ValueError("no module in the schema for {path.ns} at {name}")
+            name = schema.module_metadata[path.ns].module + ":" + name
+        return _change_target(schema, path.parent) + "/" + name
+    elif isinstance(path, ttt.PathKey):
+        keys = [uri.quote(gdata.yang_str(v.val), safe="")
+                for v in path.keyvals.values() if isinstance(v, gdata.Leaf)]
+        return _change_target(schema, path.parent) + "=" + ",".join(keys)
+    return ""
+
+
+def oper_contents(tree: ?gdata.Node, parent_ns: ?str=None,
+                  keys: list[gdata.Id]=[]) -> list[xml.Node]:
+    """Serialize an oper tree with namespaces taken from its child ids, so a
+    tree assembled from shared TTT nodes renders qualified without being
+    changed. List keys come first."""
+    result: list[xml.Node] = []
+    if tree is not None:
+        for name in keys + [k for k in tree.children if k not in keys]:
+            node = tree.children[name]
+            ns = name.q if name.q else parent_ns
+            decl = ns if ns != parent_ns else None
+            if isinstance(node, gdata.Leaf):
+                result.append(gdata.leaf_xml(name.name, decl, node.val))
+            elif isinstance(node, gdata.LeafList):
+                for entry in node.entries:
+                    result.append(gdata.leaf_xml(name.name, decl, entry.val))
+            else:
+                entries = node.elements if isinstance(node, gdata.List) else [node]
+                for entry in entries:
+                    children = oper_contents(entry, ns, node.keys if isinstance(node, gdata.List) else [])
+                    if children or isinstance(node, gdata.List) or (isinstance(entry, gdata.Container) and entry.presence):
+                        result.append(xml.Node(name.name, nsdefs=[(None, decl)] if decl is not None else [], children=children))
+    return result
+
+
+def change_edits(schema: yschema.DRoot, path: ttt.Path,
+                 before: ?gdata.Node, current: ?gdata.Node) -> list[ypatch.Edit]:
+    """The yang-patch edits for one changed node: replace its subtree, or
+    remove it. Only the layer root and lists are split into their instances,
+    since an edit addresses one data instance; an instance that did not
+    change is left alone. No leaf is ever diffed."""
+    edits: list[ypatch.Edit] = []
+
+    def add(p: ttt.Path, old: ?gdata.Node, new: ?gdata.Node):
+        if isinstance(p, ttt.PathRoot):
+            old_children = old.children if old is not None else {}
+            new_children = new.children if new is not None else {}
+            for name in set(old_children.keys()) | set(new_children.keys()):
+                add(ttt.PathElem(name, p), old_children.get(name), new_children.get(name))
+        elif isinstance(new, gdata.List) or isinstance(old, gdata.List):
+            keys = new.keys if isinstance(new, gdata.List) else old.keys if isinstance(old, gdata.List) else []
+            if not keys:
+                raise ValueError("A top-level keyless list cannot be addressed by YANG Patch")
+            old_entries = {n.key_str(keys): n for n in old.elements} if isinstance(old, gdata.List) else {}
+            new_entries = {n.key_str(keys): n for n in new.elements} if isinstance(new, gdata.List) else {}
+            ordered = (new.user_order if isinstance(new, gdata.List) else False) or (old.user_order if isinstance(old, gdata.List) else False)
+            for key, entry in old_entries.items():
+                if ordered or key not in new_entries:
+                    add(ttt.PathKey(key, p, {k: entry.get_leaf(k) for k in keys}), entry, None)
+            for key, entry in new_entries.items():
+                if not ordered and key in old_entries and old_entries[key] == entry:
+                    continue
+                add(ttt.PathKey(key, p, {k: entry.get_leaf(k) for k in keys}), old_entries.get(key), entry)
+        elif isinstance(new, gdata.LeafList) or isinstance(old, gdata.LeafList):
+            target = _change_target(schema, p)
+            old_values = {gdata.yang_str(e.val): e.val for e in old.entries} if isinstance(old, gdata.LeafList) else {}
+            new_values = {gdata.yang_str(e.val): e.val for e in new.entries} if isinstance(new, gdata.LeafList) else {}
+            ordered = (new.user_order if isinstance(new, gdata.LeafList) else False) or (old.user_order if isinstance(old, gdata.LeafList) else False)
+            for key in old_values:
+                if ordered or key not in new_values:
+                    edits.append(ypatch.Edit(str(len(edits)), ypatch.OP_REMOVE,
+                        target + "=" + uri.quote(key, safe="")))
+            for key, value in new_values.items():
+                edits.append(ypatch.Edit(str(len(edits)), ypatch.OP_REPLACE,
+                    target + "=" + uri.quote(key, safe=""), gdata.leaf_xml(p.name, p.namespace(), value)))
+        else:
+            target = _change_target(schema, p)
+            value: ?xml.Node = None
+            if new is not None:
+                name = p.parent.name if isinstance(p, ttt.PathKey) else p.name
+                if isinstance(new, gdata.Leaf):
+                    value = gdata.leaf_xml(name, p.namespace(), new.val)
+                else:
+                    value = xml.Node(name, nsdefs=[(None, p.namespace()!)],
+                                     children=oper_contents(new, p.namespace(),
+                                         list(p.keyvals.keys()) if isinstance(p, ttt.PathKey) else []))
+            operation = ypatch.OP_REPLACE if new is not None else ypatch.OP_REMOVE
+            edits.append(ypatch.Edit(str(len(edits)), operation, target, value))
+
+    add(path, before, current)
+    return edits
+
+
+class SubState():
+    """How one accepted subscription is framed: a periodic one pushes the
+    whole tree every time; an on-change one sends its baseline once, if
+    asked for, and then a patch per change. A change of state is a new
+    record."""
+    on_change: bool
+    sync: bool                  # a baseline push is still owed
+    seq: int
+
+    def __init__(self, on_change: bool, sync: bool, seq: int=0):
+        self.on_change = on_change
+        self.sync = sync
+        self.seq = seq
+
+
 actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRoot,
                              owner_prefix: str="yp",
                              log_handler: ?logging.Handler=None):
@@ -57,13 +188,13 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRo
 
     Route establish-subscription / delete-subscription here from the server's
     on_rpc (gate with yp.is_subscription_rpc); call shutdown when the session
-    closes so TTT stops sampling for it. schema is the served top-level schema;
+    closes so TTT stops serving it. schema is the served top-level schema;
     subtree and XPath filters are parsed against it. owner_prefix must be unique
     per session: TTT keys subscriptions by owner id, so two sessions sharing one
     cfs must not collide."""
 
     _log = logging.Logger(log_handler)
-    var active: set[int] = set()
+    var subs: dict[int, SubState] = {}
     var next_id: int = 1
 
     def _owner_id(sub_id: int) -> str:
@@ -77,33 +208,69 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRo
             return local == "running" or local == "operational"
         return False
 
-    def _has_on_change(op: xml.Node) -> bool:
-        for c in op.children:
-            if c.tag == "on-change":
-                return True
-        return False
-
-    def _contents(tree: ?gdata.Node) -> list[xml.Node]:
+    def _contents(st: SubState, tree: ?gdata.Node) -> list[xml.Node]:
+        if st.on_change:
+            return oper_contents(tree)
         if tree is not None:
             return tree.to_xml(deterministic=True)
         return []
 
-    def _on_tree(sub_id: int, tree: ?gdata.Node, err: ?Exception) -> None:
-        """TTT subscription callback: a fresh merged tree (or an error).
-        Frame it as a push-update, unless the subscription is already gone."""
-        if sub_id in active:
-            if err is not None:
-                _log.error("subscription sample error id={sub_id} error={err}")
-            else:
-                server.send_notification(yp.build_notification(
-                    yp.event_time_now(), yp.build_push_update(sub_id, _contents(tree))))
+    def _push_update(sub_id: int, st: SubState, tree: ?gdata.Node) -> None:
+        server.send_notification(yp.build_notification(
+            yp.event_time_now(), yp.build_push_update(sub_id, _contents(st, tree))))
 
-    def _establish(message_id: str, pp: int, subtree_filter: ?list[xml.Node],
-                   xpath_filter: ?str) -> None:
-        """Declare a periodic TTT subscription and reply with its id.
+    def _fail(sub_id: int, error: Exception) -> None:
+        """End a subscription the layer cannot serve, and say so."""
+        if sub_id in subs:
+            _log.error("subscription failed id={sub_id} error={error}")
+            del subs[sub_id]
+            cfs.remove_subscriptions(_owner_id(sub_id))
+            server.send_notification(yp.build_notification(yp.event_time_now(),
+                xml.Node("subscription-terminated", nsdefs=[(None, yp.NS_SN)], children=[
+                    xml.Node("id", text=str(sub_id)),
+                    xml.Node("reason", nsdefs=[("yp", yp.NS_YP)], text="yp:datastore-not-subscribable"),
+                ])))
+
+    def _on_tree(sub_id: int, tree: ?gdata.Node, err: ?Exception) -> None:
+        """TTT delivered a tree: a periodic sample, or the on-change baseline."""
+        st = subs.get(sub_id)
+        if st is not None:
+            if err is not None:
+                if st.on_change:
+                    _fail(sub_id, err)
+                else:
+                    _log.error("subscription sample error id={sub_id} error={err}")
+            elif not st.on_change:
+                _push_update(sub_id, st, tree)
+            elif st.sync:
+                subs[sub_id] = SubState(st.on_change, False, st.seq)
+                try:
+                    _push_update(sub_id, st, tree)
+                except Exception as error:
+                    _fail(sub_id, error)
+
+    def _on_change(sub_id: int, path: ttt.Path, before: ?gdata.Node, now: ?gdata.Node) -> None:
+        """TTT delivered one change: frame it as a patch."""
+        st = subs.get(sub_id)
+        if st is not None:
+            try:
+                edits = change_edits(schema, path, before, now)
+                if len(edits) > 0:
+                    patch = ypatch.Patch(str(st.seq), edits)
+                    subs[sub_id] = SubState(st.on_change, st.sync, (st.seq + 1) % 4294967296)
+                    server.send_notification(yp.build_notification(
+                        yp.event_time_now(), yp.build_push_change_update(sub_id, patch.to_xml())))
+            except Exception as error:
+                _fail(sub_id, error)
+
+    def _establish(message_id: str, st: SubState, period_s: ?float,
+                   subtree_filter: ?list[xml.Node], xpath_filter: ?str) -> None:
+        """Accept a subscription: allocate an id, answer, then declare it.
 
         A filter that does not parse against the schema fails the RPC with
-        invalid-value, and no id is allocated."""
+        invalid-value, and no id is allocated. The reply carries the id the
+        notifications will reference, so it is sent before the subscription
+        is declared and can push (ordering)."""
         filt: ?gdata.FNode = None
         if subtree_filter is not None and xpath_filter is not None:
             server.send_error(message_id, "invalid-value",
@@ -125,26 +292,72 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRo
                 return
         sub_id = next_id
         next_id += 1
-        active.add(sub_id)
-        period_s = float(pp) / 100.0
+        subs[sub_id] = st
         scope = "filtered" if filt is not None else "full"
-        _log.info("establish-subscription id={sub_id} mode=periodic period={period_s}s scope={scope}")
-        # Reply with the id BEFORE the subscription can push (ordering).
+        mode = "on-change" if period_s is None else "periodic period={period_s}s"
+        _log.info("establish-subscription id={sub_id} mode={mode} scope={scope}")
         server.send_reply(message_id, [yp.build_subscription_id_reply(sub_id)])
-        spec = gdata.SubscriptionSpec(filt, period=period_s)
         cfs.declare_subscriptions(_owner_id(sub_id),
-            (lambda tree, err: _on_tree(sub_id, tree, err)), {spec})
+            (lambda tree, err: _on_tree(sub_id, tree, err)),
+            {gdata.SubscriptionSpec(filt, period=period_s)},
+            delta=(lambda path, before, now: _on_change(sub_id, path, before, now)))
+
+    def _operational(ds: ?str) -> bool:
+        if ds is not None:
+            return ds.split(":")[-1] == "operational"
+        return False
+
+    def _has_child(op: xml.Node, tag: str) -> bool:
+        for child in op.children:
+            if child.tag == tag:
+                return True
+        return False
+
+    def _invalid_dampening(op: xml.Node, dp: ?int) -> bool:
+        """A dampening-period given that is not a non-negative number."""
+        if _on_change_setting(op, "dampening-period") is not None:
+            if dp is not None:
+                return dp < 0
+            return True
+        return False
+
+    def _on_change_setting(op: xml.Node, tag: str) -> ?str:
+        """The text of one <on-change> child, or None when absent."""
+        for child in op.children:
+            if child.tag == "on-change":
+                for setting in child.children:
+                    if setting.tag == tag:
+                        return setting.text if setting.text is not None else ""
+        return None
 
     def handle_rpc(message_id: str, op: xml.Node) -> None:
         """Handle a subscription RPC. Route here when is_subscription_rpc."""
         if op.tag == "establish-subscription":
             params = yp.parse_establish_subscription(op)
             pp = params.periodic_period
-            # Enforce the v1 subset before allocating an id, so unsupported request
-            # shapes fail closed instead of being served as full-tree periodic.
-            if _has_on_change(op):
-                server.send_error(message_id, "operation-not-supported",
-                    "on-change subscriptions are not supported; use a periodic subscription")
+            dp = params.dampening_period
+            # Enforce the supported subset before allocating an id, so unsupported
+            # request shapes fail closed instead of being served as something else.
+            if params.on_change:
+                ds = params.datastore
+                if _has_child(op, "periodic"):
+                    server.send_error(message_id, "invalid-value", "choose periodic or on-change")
+                elif not _operational(ds):
+                    server.send_error(message_id, "operation-not-supported",
+                        "on-change subscriptions serve the operational datastore only")
+                elif _invalid_dampening(op, dp):
+                    server.send_error(message_id, "invalid-value", "invalid dampening-period")
+                elif dp is not None and dp > 0:
+                    server.send_error(message_id, "operation-not-supported",
+                        "<dampening-period> is not supported; changes are sent as they happen")
+                elif _on_change_setting(op, "excluded-change") is not None:
+                    server.send_error(message_id, "operation-not-supported",
+                        "excluded change types are not supported")
+                elif _on_change_setting(op, "sync-on-start") not in [None, "true", "false", "1", "0"]:
+                    server.send_error(message_id, "invalid-value", "invalid sync-on-start boolean")
+                else:
+                    _establish(message_id, SubState(True, params.sync_on_start), None,
+                               params.subtree_filter, params.xpath_filter)
             elif pp is not None:
                 if pp <= 0:
                     server.send_error(message_id, "invalid-value",
@@ -153,18 +366,19 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRo
                     server.send_error(message_id, "invalid-value",
                         "unsupported datastore; this server serves running and operational")
                 else:
-                    _establish(message_id, pp, params.subtree_filter,
-                               params.xpath_filter)
+                    period_s = float(pp) / 100.0
+                    _establish(message_id, SubState(False, False), period_s,
+                               params.subtree_filter, params.xpath_filter)
             else:
                 server.send_error(message_id, "missing-element",
-                    "a periodic <period> is required")
+                    "a periodic <period> or an <on-change> is required")
         elif op.tag == "delete-subscription":
             did = yp.parse_delete_subscription(op)
             ok = False
             if did is not None:
-                if did in active:
+                if did in subs:
                     cfs.remove_subscriptions(_owner_id(did))
-                    active.discard(did)
+                    del subs[did]
                     _log.info("delete-subscription id={did}")
                     ok = True
             if ok:
@@ -176,10 +390,10 @@ actor TttSubscriptionService(server: Server, cfs: ttt.Layer, schema: yschema.DRo
 
     def shutdown() -> None:
         """Release every subscription for this session (call on disconnect) so
-        TTT stops sampling on our behalf."""
-        n = len(active)
-        for sid in active:
+        TTT stops serving on our behalf."""
+        n = len(subs)
+        for sid in subs.keys():
             cfs.remove_subscriptions(_owner_id(sid))
-        active = set()
+        subs = {}
         if n > 0:
             _log.info("stopping all subscriptions (count={n})")


### PR DESCRIPTION
A layer now serves a subscription without a period on change. The operational state its transforms publish with update_oper reaches the subscriber as it changes, and nothing samples. The first delivery is the baseline. After that each change is delivered as it happens: the tree is rebuilt along the changed path and everything else is shared by reference. A consumer's periodic and on-change filters arrive as one view. An instance-rooted consumer gets the instances a change touched, so a subscriber to a large list is called with one entry. TTT does not clear a transform's oper when its config goes; the transform actor does that from its shutdown with update_oper(None).

The northbound NETCONF server serves on-change YANG-Push from the operational datastore on top of this: a push-update with the baseline when sync-on-start is asked for, then one push-change-update per change, as a replace of the changed subtree or a remove of the node that emptied. No tree is diffed.