### PR TITLE
Acquire only the list keys a transaction names

### DIFF
--- a/src/ttt.act
+++ b/src/ttt.act
@@ -2034,7 +2034,7 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
     def acquire(tid: str, keys: ?dict[str, dict[gdata.Id, gdata.Leaf]], full: ?set[str]) -> dict[str, Node]:
         if keys is not None:
             keys1 = set(keys.keys())
-            new = keys1 - set(elems.keys())
+            new = {k for k in keys1 if k not in elems}
             for k in new:
                 node = template(PathKey(k, path, keys[k]), lower)
                 node.bind_db(db)


### PR DESCRIPTION
ListState.acquire built a set of every key in the list to find which of the requested keys were new, so every transaction against a list paid the length of the list however few entries it touched. A layer holding 100000 devices built a 100000 key set to add one.

The requested keys are looked up in the element dict instead, which is the same answer for the cost of the request.

test_ttt_perf.list_touch_one touches entries of a loaded list one at a time, so it pays that cost once per transaction:

    2000 entries, 100 touches:   665 ms -> 459 ms,  233 MB -> 134 MB
    6000 entries, 300 touches:  3597 ms -> 1265 ms, 1344 MB -> 404 MB