### PR TITLE
Upgrade acton-yang

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -28,8 +28,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/d5524ee8c3c60dd0240ddb8437cb51b2ae01898f.zip",
-        hash="N-V-__8AAMWGKADdIkyQiSDHVV8K-KOaLLOL8vtj7rxuZ4Sr"
+        url="https://github.com/stratoweave/acton-yang/archive/a388d7599b5b1fdbd419c8b92a2b58a3ff5084f4.zip",
+        hash="N-V-__8AALCPKAB1mL--ZBrVkl0r--9vyuQCZ25yjD-pBBDY"
     )
 }
 zig_dependencies = {}

--- a/gen_adata/Build.act
+++ b/gen_adata/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x7d1c1e932a731ef0
 dependencies = {
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/d5524ee8c3c60dd0240ddb8437cb51b2ae01898f.zip",
-        hash="N-V-__8AAMWGKADdIkyQiSDHVV8K-KOaLLOL8vtj7rxuZ4Sr"
+        url="https://github.com/stratoweave/acton-yang/archive/a388d7599b5b1fdbd419c8b92a2b58a3ff5084f4.zip",
+        hash="N-V-__8AALCPKAB1mL--ZBrVkl0r--9vyuQCZ25yjD-pBBDY"
     )
 }
 zig_dependencies = {}

--- a/minisys/Build.act
+++ b/minisys/Build.act
@@ -11,8 +11,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/d5524ee8c3c60dd0240ddb8437cb51b2ae01898f.zip",
-        hash="N-V-__8AAMWGKADdIkyQiSDHVV8K-KOaLLOL8vtj7rxuZ4Sr"
+        url="https://github.com/stratoweave/acton-yang/archive/a388d7599b5b1fdbd419c8b92a2b58a3ff5084f4.zip",
+        hash="N-V-__8AALCPKAB1mL--ZBrVkl0r--9vyuQCZ25yjD-pBBDY"
     )
 }
 zig_dependencies = {}

--- a/minisys/gen/Build.act
+++ b/minisys/gen/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/d5524ee8c3c60dd0240ddb8437cb51b2ae01898f.zip",
-        hash="N-V-__8AAMWGKADdIkyQiSDHVV8K-KOaLLOL8vtj7rxuZ4Sr"
+        url="https://github.com/stratoweave/acton-yang/archive/a388d7599b5b1fdbd419c8b92a2b58a3ff5084f4.zip",
+        hash="N-V-__8AALCPKAB1mL--ZBrVkl0r--9vyuQCZ25yjD-pBBDY"
     )
 }
 zig_dependencies = {}


### PR DESCRIPTION
acton-yang now decodes a yang-patch value without its mandatory leaves, since RFC 8072 validates the datastore after the edits rather than each value on its own. A client of on-change YANG-Push needs that, because a replace can carry part of a list entry. The pin also brings a simpler root-path expression and Hashable on LeafListEntry. Nothing in stratoweave changes.
