### PR TITLE
Load ncurl schemas from a directory

### DIFF
--- a/docs/reference/subscriptions.md
+++ b/docs/reference/subscriptions.md
@@ -3,6 +3,45 @@
 Subscriptions are declared as a `set[yang.gdata.SubscriptionSpec]` and
 reconciled by `yang.gdata.SubscriptionManager`.
 
+## Monitoring With Local YANG Files
+
+`ncurl monitor --yang-dir DIR` loads a schema from local `.yang` files
+when the server does not serve its schemas, or when you want to supply
+them yourself. It scans the directory and its subdirectories, compiles
+the schema before connecting, and disables schema downloads. The local
+schema is used both to parse updates and to resolve `--filter-subtree`.
+It works with periodic monitoring and with `--on-change`.
+
+For example, from the repository root, monitor a minisys server using
+its CFS models:
+
+```sh
+out/bin/ncurl --port 8830 monitor --yang-dir minisys/gen/yang/cfs
+```
+
+All local modules are selected by default. To select particular roots,
+use `--module` or the existing named `--module-set` groups. Their
+transitive imports and includes are added automatically:
+
+```sh
+out/bin/ncurl --host router monitor --yang-dir schemas --module ietf-system
+```
+
+Explicit modules and module sets are combined. These monitor options
+require `--yang-dir`; they select the schema, while `--filter-subtree`
+selects the data to monitor. The bundled `stratoweave`, `ietf-inet-types`,
+and `ietf-yang-types` modules supply missing imports only. A module found
+on disk takes precedence over its bundled copy.
+
+Repeated identical files are deduplicated. When several revisions are
+available, select `--module name@YYYY-MM-DD`, or let an import/include's
+`revision-date` select the revision. Ambiguous sources, conflicting
+revision requests, missing modules, and unreadable or malformed files
+are errors. Loading errors stop the command before it connects. Parsed
+YANG sources are cached under `~/.cache/ayang`.
+
+## Declaring Subscriptions
+
 `SubscriptionManager` is the owner-scoped declarative API. It binds:
 
 - one `TreeProvider`

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -24,6 +24,7 @@ import yang.xml as yxml
 import device as swdev
 import adapters.netconf as swna
 import schema_filter
+import yang_dir as local_yang
 
 from device_meta_config import \
     stratoweave_rfs__device_entry as DeviceMetaConfig, \
@@ -1023,6 +1024,7 @@ actor CmdMonitor(env, args, log_handler):
     filter_subtree = args.get_str("filter-subtree")
     format = args.get_str("format")
     on_change = args.get_bool("on-change")
+    yang_dir = args.get_str("yang-dir")
 
     owner_id = "ncurl-monitor"
     var dev: ?swdev.DeviceMgr = None
@@ -1030,6 +1032,8 @@ actor CmdMonitor(env, args, log_handler):
     var subscribed = False
     var done = False
     var status_str = "connecting"
+    # Local schemas serve both data parsing and subtree filter resolution.
+    var local_schema: ?yschema.DRoot = None
 
     pstr = args.get_str("period")
     var period: ?float = None
@@ -1084,7 +1088,8 @@ actor CmdMonitor(env, args, log_handler):
             filt: ?ygdata.FNode = None
             fnode = filter_node
             if fnode is not None:
-                schema = d.get_fetched_schema()
+                ls = local_schema
+                schema = ls if ls is not None else d.get_fetched_schema()
                 if schema is not None:
                     try:
                         filt = yxml.from_filter_xml(schema, fnode)
@@ -1109,23 +1114,32 @@ actor CmdMonitor(env, args, log_handler):
     elif filter_error is not None:
         print("Error: invalid --filter-subtree XML: {filter_error}", err=True)
         env.exit(1)
+    elif yang_dir == "" and (len(args.get_strlist("module")) > 0 or len(args.get_strlist("module-set")) > 0):
+        print("Error: monitor --module and --module-set require --yang-dir", err=True)
+        env.exit(1)
     else:
-        # Build a stratoweave DeviceAdapter pointed at the target device and
-        # start connecting. An empty bundled schema + runtime_schema_fetch lets
-        # it work against arbitrary devices: the schema is fetched from the
-        # device at connect. Connection is asynchronous; _on_connect fires once
-        # the device is ready.
-        cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth)))
-        schema_registry = swdev.SchemaRegistry()
-        dev_types = {
-            "netconf": swdev.DeviceType(name="netconf", adapter_type=swna.NetconfAdapter, src_dnode=yschema.DRoot())
-        }
-        dmc = DeviceMetaConfig(name="ncurl-target", credentials=Credentials(username, password), type="netconf")
-        dmc.address.create("primary", host, u64(port))
-        dmc.feature_flags.runtime_schema_fetch = True
-        device = swdev.DeviceMgr(dev_types, cap, "ncurl-target", log_handler, _on_connect, schema_registry)
-        device.set_dmc(dmc)
-        dev = device
+        # Finish local compilation before connecting. A load failure must not
+        # fall back to fetching a different schema from the device.
+        try:
+            if yang_dir != "":
+                local_schema = local_yang.load(file.FileCap(env.cap), yang_dir, args.get_strlist("module"), args.get_strlist("module-set"))
+        except Exception as e:
+            print("Error: cannot load --yang-dir {yang_dir}: {e}", err=True)
+            env.exit(1)
+        else:
+            sch = local_schema
+            bundled = sch if sch is not None else yschema.DRoot()
+            cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth)))
+            schema_registry = swdev.SchemaRegistry()
+            dev_types = {
+                "netconf": swdev.DeviceType(name="netconf", adapter_type=swna.NetconfAdapter, src_dnode=bundled)
+            }
+            dmc = DeviceMetaConfig(name="ncurl-target", credentials=Credentials(username, password), type="netconf")
+            dmc.address.create("primary", host, u64(port))
+            dmc.feature_flags.runtime_schema_fetch = sch is None
+            device = swdev.DeviceMgr(dev_types, cap, "ncurl-target", log_handler, _on_connect, schema_registry)
+            device.set_dmc(dmc)
+            dev = device
 
 
 actor main(env):
@@ -1265,6 +1279,10 @@ actor main(env):
         p_monitor.add_option("filter-subtree", "str", "?", "", "XML subtree filter (limits what is monitored)")
         p_monitor.add_option("format", "str", "?", "tree", "Output format: tree (live view) or raw (xml)")
         p_monitor.add_bool("on-change", "Subscribe on-change instead of periodic (RFC 8641); the device must support yang-push")
+        p_monitor.add_option("yang-dir", "str", "?", "", "Load the device schema from .yang files in this directory and its subdirectories, without downloading schemas")
+        monitor_module_sets_help = "Module set(s) to compile from --yang-dir ({schema_filter.get_module_set_names()})"
+        p_monitor.add_option("module-set", "strlist", "+", [], monitor_module_sets_help)
+        p_monitor.add_option("module", "strlist", "+", [], "Module(s) to compile from --yang-dir, optionally module@revision, with import/include dependencies")
 
         return p.parse(env.argv)
 

--- a/src/test_yang_dir.act
+++ b/src/test_yang_dir.act
@@ -1,0 +1,204 @@
+import file
+import testing
+import std.xml as xml
+import yang
+import yang.gdata as gdata
+import yang.xml as yxml
+
+import swyang
+import yang_dir
+
+
+ROOT = r"""/* module fake { import absent { prefix a; } } */
+module demo { namespace "urn:demo"; prefix d;
+  description "import not-a-dependency; http://example.com";
+  import
+    'demo-types' { prefix t; }
+  include "demo-state";
+}"""
+
+TYPES = r"""module demo-types { namespace "urn:types"; prefix t;
+  revision 2026-01-01;
+  typedef counter { type uint32; }
+}"""
+
+STATE = r"""submodule demo-state { belongs-to demo { prefix d; }
+  import demo-types { prefix t; }
+  container state { config false; leaf count { type t:counter; } }
+}"""
+
+OTHER = r"""module other { namespace "urn:other"; prefix o;
+  leaf ignored { type string; }
+}"""
+
+
+def _expect_error(sources: dict[str, str], message: str, modules: list[str]=[], module_sets: list[str]=[]):
+    try:
+        yang_dir.select_sources(sources, modules, module_sets)
+    except ValueError as e:
+        testing.assertIn(message, str(e))
+        return
+    testing.error("Expected an error containing: {message}")
+
+
+def _test_yang_dir_import_include_closure():
+    sources = {"demo.yang": ROOT, "types.yang": TYPES, "state.yang": STATE, "other.yang": OTHER}
+    selected = yang_dir.select_sources(sources, ["demo"])
+    testing.assertEqual(set(selected), {ROOT, TYPES, STATE})
+    schema = yang.compile(selected)
+    # The included submodule's imported typedef must reach the compiled schema.
+    data = yxml.from_xml(schema, xml.decode('<data><state xmlns="urn:demo"><count>42</count></state></data>'))
+    testing.assertIn("42", data.to_xmlstr())
+
+
+def _test_yang_dir_module_set_union():
+    ietf = OTHER.replace("module other", "module ietf-example")
+    sources = {"demo.yang": ROOT, "types.yang": TYPES, "state.yang": STATE, "ietf.yang": ietf, "other.yang": OTHER}
+    selected = yang_dir.select_sources(sources, ["demo"], ["ietf"])
+    testing.assertEqual(set(selected), {ROOT, TYPES, STATE, ietf})
+    _expect_error(sources, "Unknown module set", ["demo"], ["ietff"])
+    _expect_error({"other.yang": OTHER}, "No YANG modules selected", module_sets=["ietf"])
+
+
+def _test_yang_dir_missing_and_invalid_sources():
+    _expect_error({"demo.yang": ROOT}, "missing module demo-types", ["demo"])
+    _expect_error({"demo.yang": ROOT, "types.yang": TYPES}, "missing submodule demo-state", ["demo"])
+    _expect_error({"other.yang": OTHER}, "Requested module missing", ["other", "missing"])
+    _expect_error({"broken.yang": r"module broken {"}, "Cannot parse broken.yang")
+    _expect_error({"container.yang": "container wrong;"}, "Expected a YANG module")
+    _expect_error({}, "No YANG modules selected")
+    _expect_error({"other.yang": OTHER}, "Invalid module selection", ["other@"])
+    wrong_owner = STATE.replace("belongs-to demo", "belongs-to other")
+    _expect_error({"demo.yang": ROOT, "types.yang": TYPES, "state.yang": wrong_owner}, "does not belong to demo", ["demo"])
+
+
+def _test_yang_dir_revisions_and_duplicates():
+    newer = TYPES.replace("2026-01-01", "2026-02-01")
+    sources = {"types-old.yang": TYPES, "types-new.yang": newer, "copy.yang": TYPES}
+    testing.assertEqual(yang_dir.select_sources(sources, ["demo-types@2026-01-01"]), [TYPES])
+    _expect_error(sources, "Ambiguous module demo-types", ["demo-types"])
+    _expect_error(sources, "missing module demo-types@2025-01-01", ["demo-types@2025-01-01"])
+    # Different contents claiming the same revision must not depend on file order.
+    _expect_error({"a.yang": TYPES, "b.yang": TYPES.replace("uint32", "uint64")}, "Ambiguous module demo-types")
+    pinned_root = ROOT.replace("prefix t;", "prefix t; revision-date 2026-01-01;")
+    sources["demo.yang"] = pinned_root
+    sources["state.yang"] = STATE
+    testing.assertEqual(set(yang_dir.select_sources(sources, ["demo"])), {pinned_root, TYPES, STATE})
+    _expect_error(sources, "but --module selects", ["demo", "demo-types@2026-02-01"])
+
+
+def _test_yang_dir_conflicting_import_revisions():
+    old_root = r"""module a { namespace "urn:a"; prefix a;
+      import demo-types { prefix t; revision-date 2026-01-01; }
+    }"""
+    new_root = old_root.replace("module a", "module b").replace("2026-01-01", "2026-02-01")
+    sources = {"a.yang": old_root, "b.yang": new_root, "old.yang": TYPES,
+               "new.yang": TYPES.replace("2026-01-01", "2026-02-01")}
+    _expect_error(sources, "conflicting with old.yang", ["a", "b"])
+
+
+def _test_yang_dir_revision_resolution_order():
+    unpinned = r"""module a { namespace "urn:a"; prefix a;
+      import demo-types { prefix t; }
+    }"""
+    pinned = r"""module z { namespace "urn:z"; prefix z;
+      import demo-types { prefix t; revision-date 2026-01-01; }
+    }"""
+    sources = {"a.yang": unpinned, "z.yang": pinned, "old.yang": TYPES,
+               "new.yang": TYPES.replace("2026-01-01", "2026-02-01")}
+    # Both the unpinned import and the types root precede the pinned import.
+    selected = yang_dir.select_sources(sources)
+    testing.assertEqual(set(selected), {unpinned, pinned, TYPES})
+    yang.compile(selected)
+
+
+def _test_yang_dir_bundled_imports():
+    root = r"""module demo { namespace "urn:demo"; prefix d;
+      import stratoweave { prefix sw; }
+      import ietf-inet-types { prefix inet; }
+      leaf address { type inet:ip-address; }
+    }"""
+    selected = yang_dir.select_sources({"demo.yang": root})
+    testing.assertEqual(set(selected), {root, swyang.stratoweave, swyang.ietf_inet_types})
+    yang.compile(selected)
+    testing.assertEqual(yang_dir.select_sources({"other.yang": OTHER}), [OTHER])
+    _expect_error({"other.yang": OTHER}, "Requested module stratoweave", ["stratoweave"])
+
+
+def _test_yang_dir_local_import_precedence():
+    root = r"""module demo { namespace "urn:demo"; prefix d;
+      import ietf-inet-types { prefix inet; }
+      leaf address { type inet:address; }
+    }"""
+    local_types = TYPES.replace("demo-types", "ietf-inet-types").replace("counter", "address")
+    sources = {"demo.yang": root, "inet.yang": local_types}
+    selected = yang_dir.select_sources(sources, ["demo"])
+    testing.assertEqual(set(selected), {root, local_types})
+    yang.compile(selected)
+    sources["demo.yang"] = root.replace("prefix inet;", "prefix inet; revision-date 2013-07-15;")
+    _expect_error(sources, "missing module ietf-inet-types@2013-07-15", ["demo"])
+
+
+def _check_load_and_filter(fc: file.FileCap):
+    fs = file.FS(fc)
+    directory = fs.mktmpdir("test_yang_dir_")
+    try:
+        await async fs.mkdir(directory + "/deps")
+        for name, text in {"demo.yang": ROOT, "deps/types.yang": TYPES, "deps/state.yang": STATE,
+                           "ignored.txt": "not YANG"}.items():
+            f = file.WriteFile(file.WriteFileCap(fc), directory + "/" + name)
+            await async f.write(text.encode())
+            await async f.close()
+        schema = yang_dir.load(fc, directory, ["demo"])
+        filt = yxml.from_filter_xml(schema, xml.decode('<filter type="subtree"><state xmlns="urn:demo"><count/></state></filter>'))
+        expected = gdata.FNode(None, children=[
+            gdata.FNode(gdata.Id("urn:demo", "state"), children=[gdata.FNode(gdata.Id("urn:demo", "count"))])
+        ])
+        testing.assertEqual(filt, expected)
+    finally:
+        await async fs.rmtree(directory)
+        await async fs.rmdir(directory)
+
+
+def _check_directory_errors(fc: file.FileCap):
+    fs = file.FS(fc)
+    directory = fs.mktmpdir("test_yang_dir_errors_")
+    try:
+        try:
+            yang_dir.load(fc, directory + "/missing")
+        except ValueError as e:
+            testing.assertIn("Cannot read directory", str(e))
+        else:
+            testing.error("Missing directory must fail")
+        f = file.WriteFile(file.WriteFileCap(fc), directory + "/broken.yang")
+        await async f.write(b"module broken {")
+        await async f.close()
+        try:
+            yang_dir.load(fc, directory)
+        except ValueError as e:
+            testing.assertIn("broken.yang", str(e))
+        else:
+            testing.error("Malformed YANG must fail")
+        f = file.WriteFile(file.WriteFileCap(fc), directory + "/broken.yang")
+        await async f.write(b"\xff")
+        await async f.close()
+        try:
+            yang_dir.load(fc, directory)
+        except ValueError as e:
+            testing.assertIn("Cannot read", str(e))
+            testing.assertIn("broken.yang", str(e))
+        else:
+            testing.error("Undecodable YANG must fail with its filename")
+    finally:
+        await async fs.rmtree(directory)
+        await async fs.rmdir(directory)
+
+
+actor _test_yang_dir_load_and_filter(t: testing.EnvT):
+    _check_load_and_filter(file.FileCap(t.env.cap))
+    t.success()
+
+
+actor _test_yang_dir_directory_errors(t: testing.EnvT):
+    _check_directory_errors(file.FileCap(t.env.cap))
+    t.success()

--- a/src/yang_dir.act
+++ b/src/yang_dir.act
@@ -1,0 +1,199 @@
+"""Load a local YANG module set and its import/include dependencies."""
+
+import file
+import yang
+import yang.parser as yparser
+import yang.schema as yschema
+
+import schema_filter
+import swyang
+
+
+_FALLBACKS = {
+    "stratoweave": swyang.stratoweave,
+    "ietf-inet-types": swyang.ietf_inet_types,
+    "ietf-yang-types": swyang.ietf_yang_types,
+}
+
+
+class _Source(object):
+    path: str
+    text: str
+    kind: str
+    name: str
+    revision: ?str
+    belongs_to: ?str
+    deps: list[(kind: str, name: str, revision: ?str)]
+
+    def __init__(self, path: str, text: str):
+        self.path = path
+        self.text = text
+        try:
+            stmt = yparser.parse(text)
+        except Exception as e:
+            raise ValueError("Cannot parse {path}: {e}")
+        if stmt.prefix is not None or stmt.kw not in {"module", "submodule"}:
+            raise ValueError("Expected a YANG module or submodule in {path}")
+        self.kind = stmt.kw
+        name = stmt.arg
+        if name is not None:
+            self.name = name
+        else:
+            raise ValueError("Missing module name in {path}")
+        self.revision = None
+        self.belongs_to = None
+        self.deps = []
+        for child in stmt.substatements:
+            arg = child.arg
+            if child.prefix is not None:
+                continue
+            if arg is not None:
+                if child.kw == "revision":
+                    rev = self.revision
+                    if rev is not None:
+                        if arg > rev:
+                            self.revision = arg
+                    else:
+                        self.revision = arg
+                elif child.kw == "belongs-to":
+                    self.belongs_to = arg
+                elif child.kw in {"import", "include"}:
+                    revision: ?str = None
+                    for sub in child.substatements:
+                        if sub.prefix is None and sub.kw == "revision-date":
+                            revision = sub.arg
+                    kind = "module" if child.kw == "import" else "submodule"
+                    self.deps.append((kind=kind, name=arg, revision=revision))
+
+
+def select_sources(sources: dict[str, str], modules: list[str]=[], module_sets: list[str]=[]) -> list[str]:
+    """Select local module roots, then resolve their dependencies.
+
+    Keys in sources are filenames used in diagnostics. Explicit module names
+    may include @revision. Multiple revisions require an explicit selection or
+    an import/include revision-date; incompatible requests fail. Bundled sources
+    supply missing imports only, and never replace a local module.
+    """
+    for name in module_sets:
+        if name not in schema_filter.MODULE_SETS:
+            raise ValueError("Unknown module set: {name}")
+
+    available: dict[(str, str), list[_Source]] = {}
+    for path in sorted(sources.keys()):
+        source = _Source(path, sources[path])
+        key = (source.kind, source.name)
+        copies = available.get_def(key, [])
+        if not any([s.text == source.text for s in copies]):
+            copies.append(source)
+        available[key] = copies
+
+    pins: dict[str, str] = {}
+    roots: list[str] = []
+    for spec in modules:
+        parts = spec.split("@")
+        if parts[0] == "" or len(parts) > 2 or (len(parts) == 2 and parts[1] == ""):
+            raise ValueError("Invalid module selection: {spec}; expected module or module@revision")
+        name = parts[0]
+        if ("module", name) not in available:
+            raise ValueError("Requested module {spec} not found in --yang-dir")
+        if len(parts) == 2:
+            previous = pins.get(name)
+            if previous is not None and previous != parts[1]:
+                raise ValueError("Conflicting revisions requested for module {name}")
+            pins[name] = parts[1]
+        roots.append(name)
+    for kind, name in sorted(available.keys()):
+        if kind == "module" and (len(modules) == 0 and len(module_sets) == 0 or
+                                 len(module_sets) > 0 and schema_filter.should_include_module(name, module_sets)):
+            roots.append(name)
+    if len(roots) == 0:
+        raise ValueError("No YANG modules selected from --yang-dir")
+
+    selected: dict[(str, str), _Source] = {}
+    pending: list[(kind: str, name: str, revision: ?str, required_by: str, owner: ?str, error: str)] = []
+
+    def visit(kind: str, name: str, revision: ?str, required_by: str, owner: ?str=None):
+        pin = pins.get(name) if kind == "module" else None
+        if pin is not None:
+            if revision is not None and revision != pin:
+                raise ValueError("{required_by} requires {name}@{revision}, but --module selects {name}@{pin}")
+            revision = pin
+        key = (kind, name)
+        source = selected.get(key)
+        if source is not None:
+            if revision is not None and source.revision != revision:
+                raise ValueError("{required_by} requires {name}@{revision}, conflicting with {source.path}")
+            if owner is not None and source.belongs_to != owner:
+                raise ValueError("Submodule {name} in {source.path} does not belong to {owner}")
+            return
+
+        candidates = available.get_def(key, [])
+        if len(candidates) == 0 and kind == "module":
+            fallback = _FALLBACKS.get(name)
+            if fallback is not None:
+                candidates = [_Source("bundled {name}", fallback)]
+        if revision is not None:
+            candidates = [s for s in candidates if s.revision == revision]
+        label = name if revision is None else "{name}@{revision}"
+        if len(candidates) == 0:
+            raise ValueError("{required_by} requires missing {kind} {label}")
+        if len(candidates) > 1:
+            paths = ", ".join([s.path for s in candidates])
+            error = "Ambiguous {kind} {label}: {paths}. Select one revision or remove conflicting copies"
+            pending.append((kind=kind, name=name, revision=revision, required_by=required_by, owner=owner, error=error))
+            return
+        chosen = candidates[0]
+        if owner is not None and chosen.belongs_to != owner:
+            raise ValueError("Submodule {name} in {chosen.path} does not belong to {owner}")
+        selected[key] = chosen
+        for dep in chosen.deps:
+            parent = chosen.name if chosen.kind == "module" else chosen.belongs_to
+            visit(dep.kind, dep.name, dep.revision, chosen.path, parent if dep.kind == "submodule" else None)
+
+    for name in sorted(set(roots)):
+        visit("module", name, pins.get(name), "--yang-dir")
+    # A later import may select the revision of an earlier, unpinned root.
+    # Retry ambiguous requests after traversing the other selected modules.
+    while len(pending) > 0:
+        before = len(selected)
+        for _ in range(len(pending)):
+            request = pending.pop(0)
+            visit(request.kind, request.name, request.revision, request.required_by, request.owner)
+        if len(selected) == before and len(pending) > 0:
+            raise ValueError(pending[0].error)
+    return [selected[key].text for key in sorted(selected.keys())]
+
+
+def load(fc: file.FileCap, directory: str, modules: list[str]=[], module_sets: list[str]=[]) -> yschema.DRoot:
+    """Recursively read .yang files and compile the selected schema with caching."""
+    fs = file.FS(fc)
+    rfc = file.ReadFileCap(fc)
+    sources: dict[str, str] = {}
+
+    def read_dir(dirname: str):
+        # FS.walk suppresses filesystem errors; an incomplete schema is an error.
+        entries: list[str] = []
+        try:
+            entries = sorted(fs.listdir(dirname))
+        except OSError as e:
+            raise ValueError("Cannot read directory {dirname}: {e}")
+        for entry in entries:
+            path = file.join_path([dirname, entry])
+            try:
+                stat = fs.lstat(path)
+                if stat.is_dir():
+                    read_dir(path)
+                elif entry.endswith(".yang"):
+                    if not fs.stat(path).is_file():
+                        raise ValueError("Not a regular YANG file: {path}")
+                    rf = file.ReadFile(rfc, path)
+                    try:
+                        sources[path] = rf.read().decode()
+                    finally:
+                        await async rf.close()
+            except Exception as e:
+                raise ValueError("Cannot read {path}: {e}")
+
+    read_dir(directory)
+    texts = select_sources(sources, modules, module_sets)
+    return yang.compile_with_cache(texts, fc=fc)


### PR DESCRIPTION
ncurl monitor can now load YANG modules from a local directory with --yang-dir, so it can parse updates from servers that do not provide schemas. The local schema also resolves subtree filters.

Module selection follows imports and includes, supports explicit revisions, and reports missing or ambiguous sources. Bundled StratoWeave and IETF types supply missing imports.
