### PR TITLE
Restore DeviceMgr.rpc_xml

### DIFF
--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -303,7 +303,17 @@ class DeviceAdapter(object):
 
     get_config: proc() -> ?ygdata.Node
 
+    ## Send a RPC to the device (gdata)
+    ##
+    ## This action works with gdata - the request as well as the reply are gdata
+    ## nodes. Processing the reply therefore needs the schema.
     rpc: proc(cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None
+
+    ## Send a raw RPC, bypassing the device schema.
+    ##
+    ## The schemaless counterpart of rpc() - the request and as well as the
+    ## reply are XML nodes.
+    rpc_xml: proc(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None
 
     ## Read device data once, narrowed by `filt`.
     ##
@@ -349,6 +359,9 @@ class NoAdapter(DeviceAdapter):
         pass
 
     def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
+        cb(None, NotConnectedError())
+
+    def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
         cb(None, NotConnectedError())
 
     def get(self, cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
@@ -403,6 +416,9 @@ class MockAdapter(DeviceAdapter):
     def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
         return self._driver.rpc(cb, gdata_rpc)
 
+    def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
+        return self._driver.rpc_xml(cb, xml_rpc)
+
     def get(self, cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
         return self._driver.get(cb, filt)
 
@@ -425,6 +441,8 @@ actor MockDriver(on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_sc
 
     var conn_state: int = DISCONNECTED
     var running_conf: ?ygdata.Node = None
+
+    NS_NC_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
 
     # The bundled schema is the device's baseline module inventory; advertise it
     # so enabling mock connects without listing modules by hand. The mock/module
@@ -481,6 +499,10 @@ actor MockDriver(on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_sc
 
     def rpc(cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
         cb(ygdata.Container({}), None)
+
+    def rpc_xml(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
+        # The same answer rpc() gives, written as XML: accepted, nothing returned.
+        cb(xml.Node("rpc-reply", [(None, NS_NC_1_0)], children=[xml.Node("ok")]), None)
 
     def get(cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
         # The mock driver keeps no device data.

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -34,6 +34,7 @@ MODULE_SUBSCRIBED_NOTIFICATIONS = "ietf-subscribed-notifications"
 MODULE_EVENT_NOTIFICATIONS = "ietf-event-notifications"
 MODULE_PREFIX_IOSXR = "Cisco-IOS-XR-"
 RUNTIME_SCHEMA_MODULE_SETS = ["no-openconfig"]
+NS_NC_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
 
 # TODO: Delete this table and read module prefixes from the compiled YANG
 # schema instead. XML namespace prefixes are supposed to be aliases, but IOS XE's
@@ -318,7 +319,6 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
     # YANG-push: the last operational tree pushed, to diff against for on-change.
     var _yp_last: ?ygdata.Node = None
     var yp_service: ?nyp.NetconfSubscriptionService = None
-    NS_NC_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
 
     def _merged_schema(schemas: list[yschema.DRoot]) -> yschema.DRoot:
         children = []
@@ -665,8 +665,6 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
     var yp_subid_spec: dict[int, ygdata.SubscriptionSpec] = {}
     var yp_spec_subid: dict[ygdata.SubscriptionSpec, int] = {}
     var yp_pending: set[ygdata.SubscriptionSpec] = set()
-
-    NS_NC_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
 
     def _modset_from_capabilities(capabilities: list[str]) -> dict[str, ModCap]:
         new_modset = {}
@@ -1598,6 +1596,24 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         else:
             cb(None, NotConnectedError())
 
+    def rpc_xml(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
+        def rpc_reply(c, r: ?xml.Node, error: ?netconf.NetconfError):
+            if _is_stale(c):
+                cb(None, NotConnectedError())
+                return
+            _log.debug("Device.rpc_xml.rpc_reply", {"r": r, "error": error})
+            if r is None and error is None:
+                # The client dropped the request, on close or restart.
+                cb(None, NotConnectedError())
+                return
+            cb(r, error)
+
+        _log.debug("Device.rpc_xml", {"xml_rpc": xml_rpc})
+        if client is not None:
+            client.rpc(xml_rpc, rpc_reply)
+        else:
+            cb(None, NotConnectedError())
+
     def rpc(cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
         if len(gdata_rpc.children) != 1:
             cb(None, ValueError("gdata_rpc container must have exactly one child"))
@@ -1621,15 +1637,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         if rpc_def!.output is not None:
             out_path = ["{rpc_def!.module}:{rpc_def!.name}", "output"]
 
-        def rpc_reply(c, r: ?xml.Node, error: ?netconf.NetconfError):
-            if _is_stale(c):
-                cb(None, NotConnectedError())
-                return
-            _log.debug("Device.rpc.rpc_reply", {"r": r, "error": error})
-            if r is None and error is None:
-                # The session went away before a reply. Not an <ok/>.
-                cb(None, NotConnectedError())
-                return
+        def on_reply(r: ?xml.Node, error: ?Exception):
             if r is not None and error is None:
                 if netconf.is_ok_reply(r):
                     cb(ygdata.Container({}), None)
@@ -1650,16 +1658,11 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         # containers, but the RPC operation element must always be present.
         # So fix by moving this to an RPC-aware XML serializer.
         rpc_input = gdata_rpc.children[rpc_id]
-        xml_rpc = xml.Node(
+        rpc_xml(on_reply, xml.Node(
             rpc_id.name,
             nsdefs=[(None, rpc_id.q)],
             children=rpc_input.to_xml(),
-        )
-        _log.debug("Device.rpc", {"xml_rpc": xml_rpc})
-        if client is not None:
-            client.rpc(xml_rpc, rpc_reply)
-        else:
-            cb(None, NotConnectedError())
+        ))
 
     def _owner_publish(owner_id: str, err: ?Exception=None):
         if owner_id not in sub_owners:
@@ -1971,6 +1974,9 @@ class NetconfAdapter(DeviceAdapter):
 
     def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node) -> None:
         self._driver.rpc(cb, gdata_rpc)
+
+    def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
+        self._driver.rpc_xml(cb, xml_rpc)
 
     def get(self, cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None) -> None:
         self._driver.get(cb, filt)

--- a/src/device.act
+++ b/src/device.act
@@ -1321,6 +1321,9 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
     def rpc(cb: action(?ygdata.Node, ?Exception) -> None, gdata_rpc: ygdata.Node):
         adapter.rpc(cb, gdata_rpc)
 
+    def rpc_xml(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
+        adapter.rpc_xml(cb, xml_rpc)
+
     def get(cb: action(?ygdata.Node, ?Exception) -> None, filt: ?ygdata.FNode=None):
         """Read device data once, narrowed by `filt`. The result may contain
         configuration, operational state, or both. Subscribe instead when the


### PR DESCRIPTION
DeviceMgr.rpc() works with gdata nodes, both for the input as well as output. Encoding the input gdata as XML is not a problem, but decoding the output XML as gdata requires a schema. That may not be always available, for example with ncurl we may want to have an option to send a raw XML RPC.