### PR TITLE
Deliver every periodic subscription sample

### DIFF
--- a/docs/reference/subscriptions.md
+++ b/docs/reference/subscriptions.md
@@ -228,13 +228,12 @@ a destination at `devices.device.interfaces.interface` hands its
 callback `keys.device_name`, `keys.interface_name` and the interface.
 
 The first pass delivers every instance the filter selects, one call each,
-and then calls `synced`. After that each read delivers the instances that
-changed since the last one, and on-change each change delivers the
-instances it touched, whatever the size of the list, so a subscriber to a
-hundred thousand devices is called with one device. The filters handed to
-a rooted destination must lead to its node, and they are read on one
-period or served on-change, not both. A destination rooted at a container
-receives that container, or `None` when it is gone.
+and then calls `synced`. Every periodic read delivers all selected instances
+and reports instances removed since the last read.
+On-change, each change delivers the instances it touched, one per callback.
+The filters handed to a rooted destination must lead to its node, and they
+are read on one period or served on-change, not both. A destination rooted
+at a container receives that container, or `None` when it is gone.
 
 `synced` belongs to the declaration, not to one destination: it is
 called once, when every delivery in that `declare` has had its first
@@ -296,6 +295,19 @@ The delivery contract:
 TTT decides on-change from `period` alone; the `on_change` flag on
 `SubscriptionSpec` exists for device subscriptions and is ignored here. The
 `NetconfDriver` accepts on-change only against a device that pushes natively.
+
+### Periodic Subscriptions
+
+Every successful periodic read delivers the subscribed data tree to the
+callback. Device subscriptions deliver each periodic YANG-Push snapshot.
+A transform actor can use these callbacks to track when a sample was
+received.
+
+With several periods, each completed read delivers its tree merged with
+the latest trees from the other reads and any on-change subscription.
+Only the completed read has been refreshed; the other parts keep their
+previous samples. A read error is reported through the callback's error
+argument, so it can be distinguished from a fresh sample.
 
 ## `SubscriptionSpec`
 
@@ -371,10 +383,10 @@ non-zero dampening-period and excluded change types are rejected.
 layer serves each consumer from a `Subscription` actor of the consumer's
 own, outside the Layer actor. The consumer's filters fold into one read
 per period: the union of the filters declared with that period, read in
-one pass. Each read runs on its period, and every delivery is the reads'
-latest trees merged into one view, sent straight to the consumer, by
-reference when there is one read. The Layer keeps only which actor serves
-which consumer.
+one pass. Each read runs on its period and delivers the subscribed view.
+Every delivery is the reads' latest trees merged into one view, sent
+straight to the consumer, by reference when there is one read. The Layer
+keeps only which actor serves which consumer.
 
 The consumer's on-change filters fold into one subscription in the tree.
 This is telemetry, apart from the link subscriptions that carry config
@@ -404,7 +416,7 @@ changed ones over, keeps the rest with their latest trees, and calls
 has been laid.
 
 A consumer rooted at a node has one read, or one subscription in the
-tree, and instead of one view gets, after each read, every instance that
-differs from the last read and every instance gone, and after each
-change the instances it touched, each as a tree from the top down to
-that one instance.
+tree. Each read delivers every selected instance and reports instances
+removed since the last read. Each on-change update delivers the instances
+it touched. Every instance is delivered as a tree from the top down to
+that instance.

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -851,9 +851,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                 if spec in subs and subs[spec].active:
                     # A push with no contents, or one we can't parse against the
                     # device schema, must not overwrite the last good value with
-                    # nothing (which _owner_publish would then silently swallow,
-                    # leaving the subscriber hanging). Surface an error instead and
-                    # keep the previous value.
+                    # nothing. Surface an error instead and keep the previous value.
                     parsed: ?ygdata.Node = None
                     if len(pu.contents) > 0:
                         try:
@@ -865,7 +863,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                         st.latest = parsed
                         subs[spec] = st
                         for owner_id in st.owners:
-                            _owner_publish(owner_id)
+                            _owner_publish(owner_id, sample=not spec.on_change)
                     else:
                         err = ValueError("unparseable push-update for subscription id={sid} (no usable device schema?)")
                         for owner_id in st.owners:
@@ -1661,12 +1659,13 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         else:
             cb(None, NotConnectedError())
 
-    def _owner_publish(owner_id: str, err: ?Exception=None):
+    def _owner_publish(owner_id: str, err: ?Exception=None, sample: bool=False):
+        """Deliver periodic samples, on-change updates, and errors to the consumer."""
         if owner_id not in sub_owners:
             return
         owner = sub_owners[owner_id]
         merged = merge_subscription_tree(owner.want, subs)
-        if err is not None or merged != owner.last_merged:
+        if sample or err is not None or merged != owner.last_merged:
             owner.last_merged = merged
             sub_owners[owner_id] = owner
             owner.cb(merged, err)
@@ -1862,7 +1861,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                     st2.latest = parsed
                     subs[spec] = st2
                     for owner_id in st2.owners:
-                        _owner_publish(owner_id)
+                        _owner_publish(owner_id, sample=True)
             _sub_schedule_next(spec)
 
         filt_xml = None

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -714,8 +714,8 @@ actor _test_subscribe_periodic(t: testing.EnvT):
     1. Create DeviceMgr in NETCONF mock-server mode with IETF system schema.
     2. Seed the mock server oper datastore with system-state/clock (both datetimes).
     3. Start a periodic subtree subscription that selects only system-state/clock/current-datetime.
-    4. On the first update, validate current-datetime (and absence of boot-datetime), then mutate the mock oper datastore once.
-    5. On the second update, validate the new current-datetime and remove the owner declaration.
+    4. Validate three samples of the seeded datastore, including the absence of boot-datetime, then update the mock oper datastore.
+    5. Validate the new current-datetime and remove the owner declaration.
     6. Fail fast via a short timeout if updates never arrive.
     """
     mock_current_datetime_1 = "2026-02-21T10:11:12Z"
@@ -757,23 +757,22 @@ actor _test_subscribe_periodic(t: testing.EnvT):
             return
 
         updates += 1
-        if updates == 1:
+        if updates <= 3:
             if dt != mock_current_datetime_1:
-                fail("Unexpected first datetime: {dt}")
+                fail("Unexpected datetime on poll {updates}: {dt}")
+                return
+            if updates < 3:
                 return
             if mock_server is not None:
                 mock_server.set_oper_ds(_mock_oper_ds(mock_current_datetime_2, mock_boot_datetime))
             else:
                 fail("Missing mock server for subscription update")
                 return
-        elif updates == 2:
-            if dt != mock_current_datetime_2:
-                fail("Unexpected second datetime: {dt}")
-                return
+        elif dt == mock_current_datetime_2:
             dev.remove_subscriptions("test-subscribe-periodic")
             succeed()
-        else:
-            fail("Unexpected extra subscription update: {updates}")
+        elif dt != mock_current_datetime_1:
+            fail("Unexpected datetime: {dt}")
 
     def start():
         adapter = dev.get_adapter()
@@ -900,10 +899,9 @@ actor _test_subscribe_on_change(t: testing.EnvT):
 
 
 actor _test_subscribe_periodic_yang_push(t: testing.EnvT):
-    """Periodic subscription that rides real yang-push (not poll emulation) because
-    the mock advertises ietf-yang-push: exercises the adapter's push-update path with
-    a device that pushes natively, the counterpart to _test_subscribe_periodic's poll
-    emulation."""
+    """Periodic YANG-Push through the NETCONF adapter. The mock advertises
+    ietf-yang-push and sends a snapshot on each period. The callback receives
+    three samples of the seeded datastore, then a sample of the updated datastore."""
     mock_current_datetime_1 = "2026-02-21T10:11:12Z"
     mock_current_datetime_2 = "2026-02-21T10:11:13Z"
     mock_boot_datetime = "2025-12-31T00:00:00Z"
@@ -940,9 +938,11 @@ actor _test_subscribe_periodic_yang_push(t: testing.EnvT):
             return
 
         updates += 1
-        if updates == 1:
+        if updates <= 3:
             if dt != mock_current_datetime_1:
-                fail("Unexpected first datetime: {dt}")
+                fail("Unexpected datetime on push {updates}: {dt}")
+                return
+            if updates < 3:
                 return
             ms = mock_server
             if ms is not None:
@@ -950,14 +950,11 @@ actor _test_subscribe_periodic_yang_push(t: testing.EnvT):
             else:
                 fail("Missing mock server for subscription update")
                 return
-        elif updates == 2:
-            if dt != mock_current_datetime_2:
-                fail("Unexpected second datetime: {dt}")
-                return
+        elif dt == mock_current_datetime_2:
             dev.remove_subscriptions("test-periodic-push")
             succeed()
-        else:
-            fail("Unexpected extra subscription update: {updates}")
+        elif dt != mock_current_datetime_1:
+            fail("Unexpected datetime: {dt}")
 
     def start():
         adapter = dev.get_adapter()
@@ -1076,7 +1073,7 @@ actor _test_subscription_manager_declare(t: testing.EnvT):
 
 
 actor _test_subscription_manager_idempotent(t: testing.EnvT):
-    """Redeclaring the same subscriptions is a no-op."""
+    """Redeclaring the same subscriptions delivers nothing before the next poll."""
     mock_current_datetime = "2026-02-21T10:11:12Z"
     mock_boot_datetime = "2025-12-31T00:00:00Z"
 
@@ -1134,7 +1131,7 @@ actor _test_subscription_manager_idempotent(t: testing.EnvT):
     def declare_current_only():
         want = {
             dst!.deliver({
-                ygdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)
+                ygdata.SubscriptionSpec(_current_datetime_filter(), period=0.5)
             })
         }
         subs!.declare(want)

--- a/src/test_netconf_server.act
+++ b/src/test_netconf_server.act
@@ -743,9 +743,8 @@ def _first_error_tag(err: netconf.NetconfError) -> ?str:
 
 
 actor _test_subscription_subtree_filter_narrows_push(t: testing.AsyncT):
-    """A datastore-subtree-filter narrows what a periodic subscription pushes:
-    with hostname and location configured, a filter that selects hostname
-    yields a push-update that carries hostname and not location."""
+    """Each periodic push carries the filtered data: with hostname and location
+    configured, a filter selecting hostname yields snapshots containing only hostname."""
     lh = logging.Handler("nctest")
     schema = _demo_schema()
     layer = _demo_layer()
@@ -755,6 +754,7 @@ actor _test_subscription_subtree_filter_narrows_push(t: testing.AsyncT):
     server = swnetconf.NetconfSession(pipes.server, lh, schema, layer, caps)
 
     var done = False
+    var updates = 0
     def fail(e: Exception):
         if not done:
             done = True
@@ -773,8 +773,10 @@ actor _test_subscription_subtree_filter_narrows_push(t: testing.AsyncT):
             elif payload.find("location") != -1:
                 fail(ValueError("filtered push leaked location: " + payload))
             else:
-                done = True
-                t.success()
+                updates += 1
+                if updates == 3:
+                    done = True
+                    t.success()
         else:
             fail(ValueError("unexpected notification: " + n.encode()))
 

--- a/src/test_ttt_subscriptions.act
+++ b/src/test_ttt_subscriptions.act
@@ -1,11 +1,10 @@
 """Periodic subscriptions on a TTT layer, served by a Subscription actor per consumer.
 
-A consumer's filters fold into one read per period, each read delivers
-the merged view when it differs from the last, and synced follows the
-first run of every read of a declaration. A consumer rooted at a node
-gets the instances of that node instead, each as a tree from the top
-down to it. These tests push oper into transforms through a Hub and
-watch what the consumer receives.
+A consumer's filters fold into one read per period. Each read delivers
+the merged view, and synced follows the first run of every read in a
+declaration. A consumer rooted at a node receives one tree per instance,
+from the top down to that instance. These tests push oper into transforms
+through a Hub and watch what the consumer receives.
 """
 
 import testing
@@ -128,9 +127,8 @@ def rendered(trees: list[?gdata.Node]) -> list[str]:
     return sorted([prs(d) for d in trees])
 
 
-actor every_read_that_differs_is_delivered(t: testing.AsyncT):
-    """The first read is delivered, then every read that differs from the
-    last, as the whole subscribed tree."""
+actor every_read_is_delivered(t: testing.AsyncT):
+    """Each periodic read delivers the whole subscribed tree."""
     hub = Hub()
     layer = service_layer(hub)
     var got: list[?gdata.Node] = []
@@ -142,22 +140,24 @@ actor every_read_that_differs_is_delivered(t: testing.AsyncT):
             t.failure(e)
 
     def on_update(data: ?gdata.Node, err: ?Exception):
+        if done:
+            return
         if err is not None:
             fail(err)
             return
         got.append(data)
         n = len(got)
-        if n == 1:
-            if data == tree([entry("svc-a", "first")]):
+        if n <= 3:
+            if data != tree([entry("svc-a", "first")]):
+                fail(ValueError("expected first on read {n}, got {prs(data)}"))
+            elif n == 3:
                 hub.push("svc-a", status("second"))
-            else:
-                fail(ValueError("expected first, got {prs(data)}"))
-        elif n == 2:
-            if data == tree([entry("svc-a", "second")]):
-                done = True
-                t.success()
-            else:
-                fail(ValueError("expected second, got {prs(data)}"))
+        elif data == tree([entry("svc-a", "second")]):
+            done = True
+            layer.remove_subscriptions("test")
+            t.success()
+        elif data != tree([entry("svc-a", "first")]):
+            fail(ValueError("unexpected read {prs(data)}"))
 
     def declare(_r: value):
         hub.push("svc-a", status("first"))
@@ -165,6 +165,41 @@ actor every_read_that_differs_is_delivered(t: testing.AsyncT):
 
     layer.edit_config(services(["svc-a"]), None, declare)
     after 2: fail(ValueError("timed out with {len(got)} deliveries"))
+
+
+actor empty_reads_are_delivered(t: testing.AsyncT):
+    """A read with no matching data delivers None."""
+    layer = service_layer(Hub())
+    var updates = 0
+    var synced = False
+    var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def on_update(data: ?gdata.Node, err: ?Exception):
+        if done:
+            return
+        if err is not None:
+            fail(err)
+        elif data is not None:
+            fail(ValueError("expected no matching data, got {prs(data)}"))
+        else:
+            updates += 1
+            if updates >= 3 and synced:
+                done = True
+                layer.remove_subscriptions("empty")
+                t.success()
+
+    def on_synced(owner: str):
+        if updates != 1 or synced:
+            fail(ValueError("synced after {updates} empty reads"))
+        synced = True
+
+    layer.declare_subscriptions("empty", on_update, {entry_spec("missing")}, on_synced)
+    after 2: fail(ValueError("timed out with {updates} empty reads"))
 
 
 actor filters_with_one_period_fold_into_one_read(t: testing.AsyncT):
@@ -309,8 +344,8 @@ actor synced_waits_for_a_read_added_by_a_redeclaration(t: testing.AsyncT):
 
 
 actor redeclaring_the_same_set_installs_the_callbacks_only(t: testing.AsyncT):
-    """A redeclaration of the same set delivers nothing again, hears its
-    synced at once, and hands later deliveries to the new callback."""
+    """A redeclaration does not trigger a read, hears its synced at once,
+    and hands later periodic deliveries to the new callback."""
     hub = Hub()
     layer = service_layer(hub)
     var second: list[?gdata.Node] = []
@@ -348,7 +383,7 @@ actor redeclaring_the_same_set_installs_the_callbacks_only(t: testing.AsyncT):
     def finish():
         if not done:
             done = True
-            if synced == 1 and len(second) == 1 and second[0] == tree([entry("svc-a", "second")]):
+            if synced == 1 and len(second) >= 2 and second[-1] == tree([entry("svc-a", "second")]):
                 t.success()
             else:
                 t.failure(ValueError("synced {synced} times, the new callback got {rendered(second)}"))
@@ -429,44 +464,53 @@ actor failed_first_read_still_ends_with_synced(t: testing.AsyncT):
     after 2: on_update(None, None)
 
 
-actor read_error_keeps_the_last_good_view(t: testing.AsyncT):
-    """A read that fails reports the error with the last good view."""
+actor read_error_keeps_the_view_and_delivers_recovery(t: testing.AsyncT):
+    """A failed read reports the last good view with the error. The callback
+    receives the current view when a subsequent read succeeds."""
     hub = Hub()
     layer = service_layer(hub)
     good = tree([gdata.Container({q("name"): gdata.Leaf("svc-a"), q("detail"): gdata.Container({q("x"): gdata.Leaf("1")})})])
+    good_oper = gdata.Container({q("detail"): gdata.Container({q("x"): gdata.Leaf("1")})})
+    var injected = False
+    var failed = False
     var done = False
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
 
     def on_update(data: ?gdata.Node, err: ?Exception):
         if done:
             return
-        if err is not None:
+        if data != good:
+            fail(ValueError("expected the last good view, got {prs(data)}"))
+        elif err is not None:
+            failed = True
+            hub.push("svc-a", good_oper)
+        elif failed:
             done = True
-            if data == good:
-                t.success()
-            else:
-                t.failure(ValueError("expected the last good view with the error, got {prs(data)}"))
-        elif data == good:
+            layer.remove_subscriptions("first")
+            t.success()
+        elif not injected:
+            injected = True
             hub.push("svc-a", gdata.Container({q("detail"): gdata.Leaf("now a leaf")}))     # the filter no longer applies
-        else:
-            done = True
-            t.failure(ValueError("unexpected delivery {prs(data)}"))
 
     def declare(_r: value):
-        hub.push("svc-a", gdata.Container({q("detail"): gdata.Container({q("x"): gdata.Leaf("1")})}))
+        hub.push("svc-a", good_oper)
         after 0.05: layer.declare_subscriptions("first", on_update, {detail_spec()})
 
     layer.edit_config(services(["svc-a"]), None, declare)
-    after 2: on_update(None, ValueError("timed out"))
+    after 2: fail(ValueError("timed out waiting for recovery (failed={failed})"))
 
 
 actor rooted_at_a_list(t: testing.AsyncT):
-    """Rooted at the service list: the first read is one delivery per entry
-    then synced; a change delivers its entry alone; a deletion delivers an
-    Absent with the entry's key. Each delivery is a tree from the top."""
+    """Each read delivers one tree per selected service entry. The first read
+    is followed by synced. A deletion reports an Absent with the entry's key once."""
     hub = Hub()
     layer = service_layer(hub)
     var got: list[?gdata.Node] = []
-    var synced = False
+    var stage = 0
     var done = False
 
     def fail(e: Exception):
@@ -475,31 +519,48 @@ actor rooted_at_a_list(t: testing.AsyncT):
             t.failure(e)
 
     def on_synced(owner: str):
-        if synced or rendered(got) != rendered([tree([entry("svc-a", "a")]), tree([entry("svc-b", "b")])]):
+        if stage != 0 or rendered(got) != rendered([tree([entry("svc-a", "a")]), tree([entry("svc-b", "b")])]):
             fail(ValueError("synced after {len(got)} deliveries: {rendered(got)}"))
             return
-        synced = True
-        hub.push("svc-a", status("a2"))
+        stage = 1
+        got = []
 
     def on_update(data: ?gdata.Node, err: ?Exception):
+        if done:
+            return
         if err is not None:
             fail(err)
             return
         got.append(data)
-        n = len(got)
-        if n == 3:
-            if data == tree([entry("svc-a", "a2")]):
+        if stage == 1 and len(got) == 2:
+            if rendered(got) == rendered([tree([entry("svc-a", "a")]), tree([entry("svc-b", "b")])]):
+                stage = 2
+                hub.push("svc-a", status("a2"))
+            else:
+                fail(ValueError("expected both service entries, got {rendered(got)}"))
+            got = []
+        elif stage == 2 and len(got) == 2:
+            if rendered(got) == rendered([tree([entry("svc-a", "a2")]), tree([entry("svc-b", "b")])]):
+                stage = 3
                 layer.edit_config(gdata.Container({
                     q("service"): gdata.List([q("name")], [gdata.Absent({q("name"): gdata.Leaf("svc-b")})]),
                 }))
-            else:
-                fail(ValueError("expected svc-a alone, got {prs(data)}"))
-        elif n == 4:
-            if data == gone("svc-b"):
+            elif rendered(got) != rendered([tree([entry("svc-a", "a")]), tree([entry("svc-b", "b")])]):
+                fail(ValueError("unexpected entries after change: {rendered(got)}"))
+            got = []
+        elif stage == 3 and len(got) == 2:
+            if rendered(got) == rendered([tree([entry("svc-a", "a2")]), gone("svc-b")]):
+                stage = 4
+            elif rendered(got) != rendered([tree([entry("svc-a", "a2")]), tree([entry("svc-b", "b")])]):
+                fail(ValueError("unexpected entries after deletion: {rendered(got)}"))
+            got = []
+        elif stage == 4:
+            if data != tree([entry("svc-a", "a2")]):
+                fail(ValueError("expected the surviving entry, got {prs(data)}"))
+            elif len(got) == 2:
                 done = True
+                layer.remove_subscriptions("rooted")
                 t.success()
-            else:
-                fail(ValueError("expected svc-b gone, got {prs(data)}"))
 
     def declare(_r: value):
         hub.push("svc-a", status("a"))
@@ -507,7 +568,7 @@ actor rooted_at_a_list(t: testing.AsyncT):
         after 0.05: layer.declare_subscriptions("rooted", on_update, {whole(root=ROOTED_AT_SERVICE)}, on_synced)
 
     layer.edit_config(services(["svc-a", "svc-b"]), None, declare)
-    after 2: fail(ValueError("timed out with {len(got)} deliveries, synced={synced}"))
+    after 2: fail(ValueError("timed out at stage {stage} with {rendered(got)}"))
 
 
 actor rooted_at_a_container(t: testing.AsyncT):
@@ -530,16 +591,19 @@ actor rooted_at_a_container(t: testing.AsyncT):
             fail(ValueError("synced after {rendered(got)}"))
 
     def on_update(data: ?gdata.Node, err: ?Exception):
+        if done:
+            return
         if err is not None:
             fail(err)
             return
         got.append(data)
-        if len(got) == 2:
+        if len(got) > 1:
             if data == probe_spine(gdata.Container()):
                 done = True
+                layer.remove_subscriptions("rooted")
                 t.success()
-            else:
-                fail(ValueError("expected the probe empty, got {prs(data)}"))
+            elif data != got[0]:
+                fail(ValueError("unexpected probe while awaiting deletion: {prs(data)}"))
 
     def declare(_r: value):
         hub.push("probe", status("up"))
@@ -624,9 +688,9 @@ def item_spine(i: gdata.Node) -> gdata.Node:
     return probe_spine(items([i]))
 
 
-actor change_above_the_root_delivers_the_instances_that_differ(t: testing.AsyncT):
+actor read_above_the_root_delivers_all_instances(t: testing.AsyncT):
     """A producer that holds several instances of the root's node delivers,
-    on a read, the instances that differ and those gone."""
+    on every read, all instances and reports those gone."""
     hub = Hub()
     layer = probe_layer(hub)
     var got: list[?gdata.Node] = []
@@ -651,19 +715,21 @@ actor change_above_the_root_delivers_the_instances_that_differ(t: testing.AsyncT
             fail(err)
             return
         got.append(data)
-        if stage == 1 and len(got) == 1:
-            if data == item_spine(item("one", "x2")):
+        if stage == 1 and len(got) == 2:
+            if rendered(got) == rendered([item_spine(item("one", "x2")), item_spine(item("two", "y"))]):
                 stage = 2
-                got = []
                 hub.push("probe", items([item("one", "x2")]))
-            else:
-                fail(ValueError("expected item one changed alone, got {prs(data)}"))
-        elif stage == 2 and len(got) == 1:
-            if data == item_spine(gdata.Absent({q("id"): gdata.Leaf("two")})):
+            elif rendered(got) != rendered([item_spine(item("one", "x")), item_spine(item("two", "y"))]):
+                fail(ValueError("expected both items, got {rendered(got)}"))
+            got = []
+        elif stage == 2 and len(got) == 2:
+            if rendered(got) == rendered([item_spine(item("one", "x2")), item_spine(gdata.Absent({q("id"): gdata.Leaf("two")}))]):
                 done = True
+                layer.remove_subscriptions("rooted")
                 t.success()
-            else:
-                fail(ValueError("expected item two gone, got {prs(data)}"))
+            elif rendered(got) != rendered([item_spine(item("one", "x2")), item_spine(item("two", "y"))]):
+                fail(ValueError("expected item one and item two gone, got {rendered(got)}"))
+            got = []
 
     def declare(_r: value):
         hub.push("probe", items([item("one", "x"), item("two", "y")]))

--- a/src/ttt.act
+++ b/src/ttt.act
@@ -511,11 +511,11 @@ def fold_on_change(want: set[gdata.SubscriptionSpec]) -> (bool, ?gdata.FNode):
 
 class Read(object):
     """One read of a consumer's actor: a folded filter, read on its period,
-    and what it gave last: the tree, or rooted, the instances by key, each
-    with its spine."""
+    and what it gave last: the tree, or rooted, the instances' spines by key
+    so the next read can report removals."""
     filt: ?gdata.FNode
     latest: ?gdata.Node
-    held: dict[str, (gdata.Node, gdata.Node)]
+    held: dict[str, gdata.Node]
     done: bool                  # has run at least once
     active: bool                # False once replaced or dropped, so its timer ends
 
@@ -621,12 +621,13 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
 
     The consumer's periodic filters fold into one read per period, and its
     on-change filters into one subscription in the tree. Each read runs on
-    its period. The subscription is laid by a walk from here: every node answers
-    with its path, its oper slice if it is a producer, and the children to
-    continue with, and the answers become a shadow of the subscribed part
-    of the tree. After the walk every producer under the subscription pushes its
-    slice here as it changes, and the shadow is rebuilt along the changed
-    path with everything else shared by reference. Every delivery is the
+    its period and delivers the subscribed view. The subscription is laid by
+    a walk from here: every node answers with its path, its oper slice if it
+    is a producer, and the children to continue with, and the answers become
+    a shadow of the subscribed part of the tree. After the walk every producer
+    under the subscription pushes its slice here as it changes, and the shadow
+    is rebuilt along the changed path with everything else shared by reference.
+    Every delivery is the
     reads' latest trees and the shadow merged into one view, sent straight
     to the consumer, and a consumer that asked for it gets each change alone
     first, as the path of the node that changed with what it held before
@@ -634,11 +635,10 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
     run once and the subscription has been laid.
 
     Rooted at a point, a path of node names from the top, the consumer
-    gets the instances of that node instead of one view: after each read,
-    every instance that differs from the last read, as a tree from the top
-    down to that one instance, and every instance gone, as that tree with
-    an Absent holding its keys where the entry was. On-change, a change
-    delivers the instances it touched the same way.
+    receives one tree per selected instance after each read. Each tree runs
+    from the top down to that instance. An instance removed since the last
+    read is reported as that tree with an Absent holding its keys where the
+    entry was. On-change, a change delivers the instances it touched.
 
     The reads, the walk and the waiting happen here, never in the Layer
     actor that runs transactions.
@@ -679,7 +679,7 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
             if replace:
                 fresh = Read(filt)
                 if old is not None:
-                    fresh.held = old.held       # so the next read reports only what changed
+                    fresh.held = old.held       # so the next read reports instances no longer selected
                 reads[period] = fresh
                 _read(fresh, period)
         (on_change, cfilt) = fold_on_change(want)
@@ -703,7 +703,7 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
                 tree = node.get_data(r.filt)
                 if len(point) > 0:
                     _read_rooted(r, tree)
-                elif tree != r.latest:
+                else:
                     r.latest = tree
                     _deliver(None)
             except Exception as e:
@@ -716,15 +716,14 @@ actor Subscription(owner: str, node: Node, cb0: proc(?gdata.Node, ?Exception) ->
             after _delay(period): _read(r, period)
 
     def _read_rooted(r: Read, tree: ?gdata.Node):
-        """Deliver the instances that differ from the last read, and those gone."""
-        now: dict[str, (gdata.Node, gdata.Node)] = {}
+        """Deliver every selected instance, and report those gone since the last read."""
+        now: dict[str, gdata.Node] = {}
         for i in gdata.instances(tree, point):
-            now[i.0] = (i.1, i.2)
-            if i.0 not in r.held or r.held[i.0].1 != i.2:
-                cb(i.1, None)
+            now[i.0] = i.1
+            cb(i.1, None)
         for k, h in r.held.items():
             if k not in now:
-                cb(gdata.gone(h.0, point), None)
+                cb(gdata.gone(h, point), None)
         r.held = now
 
     def _deliver(err: ?Exception):

--- a/src/yp_ttt.act
+++ b/src/yp_ttt.act
@@ -5,8 +5,8 @@ TttSubscriptionService is the NETCONF binding that serves dynamic YANG-push
 subscription mechanism (declare_subscriptions) and frames what TTT delivers as
 NETCONF notifications:
 
-  - a periodic subscription samples the datastore on the spec period, and each
-    delivery becomes a push-update carrying the datastore-contents;
+  - a periodic subscription samples the datastore on the spec period, and every
+    sample becomes a push-update carrying the datastore-contents;
   - an on-change subscription is served from the layer's route to the
     operational state its transforms publish. The first delivery is the
     complete baseline, sent as a push-update when sync-on-start is asked for;
@@ -31,10 +31,6 @@ it gets an rpc-error rather than being silently served as something else):
     filtered data;
   - no dampening-period and no excluded-change on an on-change subscription:
     changes are sent as they happen.
-
-Known deviation, still under discussion: TTT periodic subscriptions are
-periodic-with-change-suppression, so a subscription only pushes when the datastore
-actually changes (at most once per period), not unconditionally every period.
 
 This belongs at the app layer (it couples netconf to ttt); the mock server keeps
 the transport-only netconf.yp binding so it stays TTT-free.


### PR DESCRIPTION
Periodic subscriptions deliver the subscribed data tree to transform callbacks on each successful read or received YANG-Push snapshot. Rooted subscriptions deliver one tree per selected instance and report removals.
