### PR TITLE
Use new iosxe mocking capabilities in fleetmgr

### DIFF
--- a/fleetmgr/Build.act
+++ b/fleetmgr/Build.act
@@ -11,8 +11,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
-        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
+        url="https://github.com/stratoweave/acton-yang/archive/a388d7599b5b1fdbd419c8b92a2b58a3ff5084f4.zip",
+        hash="N-V-__8AALCPKAB1mL--ZBrVkl0r--9vyuQCZ25yjD-pBBDY"
     )
 }
 zig_dependencies = {}

--- a/fleetmgr/Justfile
+++ b/fleetmgr/Justfile
@@ -16,7 +16,7 @@ flotilla:
 demo:
 	out/bin/fleetmgr --http.port 18200 --netconf.port 12900 demo.xml
 
-# Submit the two-device IOS XE demo campaign.
+# Submit the three-device IOS XE demo campaign.
 upgrade:
 	@curl -fsS -X PATCH -H "Content-Type: application/yang-data+xml" --data-binary @upgrade.xml "{{fleetmgr_api}}/restconf/data"
 	@echo "Submitted xe-upgrade"

--- a/fleetmgr/README.md
+++ b/fleetmgr/README.md
@@ -49,6 +49,19 @@ processes use these ports:
 For bottom-node development, `just flotilla` still starts one standalone
 instance on the first flotilla's ports. Do not run it alongside `just demo`.
 
+Mock devices take three leaves under `mock/software`. `upgrade-duration` is how many
+seconds a whole software upgrade takes; the mock spreads it over the
+operations as measured on a lab c8000v (the numbers are in
+`docs/reference/software-upgrade.md`), and absent or 0 completes each
+operation at once. `failure`
+names one IOS XE failure to reproduce: `download-failed`, `add-failed`,
+`activate-refused`, `commit-failed` or `reverts`. `running-release` is the
+release the device runs before any upgrade. In the demo, `cpe-02` takes 40 s
+and fails its commit, so the campaign aborts it and it ends `rolled-back`;
+`cpe-03` already runs the target and ends `up-to-date`. The leaves are read
+when the device is created; change them by deleting and re-creating the
+device.
+
 Inspect the top CFS and the bottom RFS independently:
 
     curl -H "Accept: application/yang-data+json" \
@@ -114,7 +127,7 @@ the implicit device layer beneath it.
 
 The focused tests cover node creation, per-device sharding, precise campaign
 links, campaign aggregation, the parent RFS-to-flotilla render, direct
-`/device` configuration at the RFS-only bottom, and a complete mock IOS XE
-software upgrade. The root tests also cover IOS XE adapter behavior and ensure
+`/device` configuration at the RFS-only bottom, the mock leaves reaching the
+flotilla, and a complete mock IOS XE software upgrade. The root tests also cover IOS XE adapter behavior and ensure
 that a software-intent change preserves the existing NETCONF adapter and
 session.

--- a/fleetmgr/demo.xml
+++ b/fleetmgr/demo.xml
@@ -52,8 +52,8 @@
             <credentials><username>admin</username><password>admin</password></credentials>
         </node>
         <device><name>cpe-01</name><type>iosxe</type><shard>flotilla-1</shard><credentials><username>admin</username><password>admin</password></credentials><mock><enabled>true</enabled></mock></device>
-        <device><name>cpe-02</name><type>iosxe</type><shard>flotilla-2</shard><credentials><username>admin</username><password>admin</password></credentials><mock><enabled>true</enabled></mock></device>
-        <device><name>cpe-03</name><type>iosxe</type><shard>flotilla-3</shard><credentials><username>admin</username><password>admin</password></credentials><mock><enabled>true</enabled></mock></device>
+        <device><name>cpe-02</name><type>iosxe</type><shard>flotilla-2</shard><credentials><username>admin</username><password>admin</password></credentials><mock><enabled>true</enabled><software><upgrade-duration>40</upgrade-duration><failure>commit-failed</failure></software></mock></device>
+        <device><name>cpe-03</name><type>iosxe</type><shard>flotilla-3</shard><credentials><username>admin</username><password>admin</password></credentials><mock><enabled>true</enabled><software><running-release>17.18.03a</running-release></software></mock></device>
         <device><name>cpe-04</name><type>iosxe</type><shard>flotilla-4</shard><credentials><username>admin</username><password>admin</password></credentials><mock><enabled>true</enabled></mock></device>
         <device><name>cpe-05</name><type>iosxe</type><shard>flotilla-5</shard><credentials><username>admin</username><password>admin</password></credentials><mock><enabled>true</enabled></mock></device>
         <device><name>cpe-06</name><type>iosxe</type><shard>flotilla-6</shard><credentials><username>admin</username><password>admin</password></credentials><mock><enabled>true</enabled></mock></device>

--- a/fleetmgr/spec/Build.act
+++ b/fleetmgr/spec/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/20c744c934dd7d76d501aec0b4d1cf2582a87476.zip",
-        hash="N-V-__8AAGDKJwBBv9yrhaAupRZabnJIMPIuB8MoKTPlARfR"
+        url="https://github.com/stratoweave/acton-yang/archive/a388d7599b5b1fdbd419c8b92a2b58a3ff5084f4.zip",
+        hash="N-V-__8AALCPKAB1mL--ZBrVkl0r--9vyuQCZ25yjD-pBBDY"
     )
 }
 zig_dependencies = {}

--- a/fleetmgr/spec/yang/common/fleetmgr-types.yang
+++ b/fleetmgr/spec/yang/common/fleetmgr-types.yang
@@ -92,6 +92,46 @@ module fleetmgr-types {
         type boolean;
         default "false";
       }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
+      }
       list module {
         key "name";
         leaf name {

--- a/fleetmgr/src/fleetmgr/cfs.act
+++ b/fleetmgr/src/fleetmgr/cfs.act
@@ -55,6 +55,9 @@ class Node(base.Node):
         dev.ssh.minimum_rsa_bits = i.ssh.minimum_rsa_bits
 
         dev.mock.enabled = i.mock.enabled
+        dev.mock.software.upgrade_duration = i.mock.software.upgrade_duration
+        dev.mock.software.failure = i.mock.software.failure
+        dev.mock.software.running_release = i.mock.software.running_release
         for module in i.mock.module:
             out_module = dev.mock.module.create(
                 module.name,
@@ -118,6 +121,9 @@ class Device(base.Device):
         dev.ssh.minimum_rsa_bits = i.ssh.minimum_rsa_bits
 
         dev.mock.enabled = i.mock.enabled
+        dev.mock.software.upgrade_duration = i.mock.software.upgrade_duration
+        dev.mock.software.failure = i.mock.software.failure
+        dev.mock.software.running_release = i.mock.software.running_release
         for module in i.mock.module:
             out_module = dev.mock.module.create(
                 module.name,

--- a/fleetmgr/src/fleetmgr/cfs.act
+++ b/fleetmgr/src/fleetmgr/cfs.act
@@ -201,6 +201,10 @@ actor UpgradeCampaignTransform(path: ttt.Path,
             latest = root
         publish()
 
+    def shutdown() -> None:
+        # Releasing the subscriptions here is a separate change.
+        pass
+
     def on_conf(conf: y_0.software__software__upgrade_campaign_entry) -> None:
         ms = []
         for member in conf.device:

--- a/fleetmgr/src/fleetmgr/devices/flotilla.act
+++ b/fleetmgr/src/fleetmgr/devices/flotilla.act
@@ -312,6 +312,31 @@ class stratoweave_rfs__device__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class stratoweave_rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'running-release')))
+        return stratoweave_rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -335,7 +360,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -370,13 +395,15 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: ?bool
+    software: stratoweave_rfs__device__mock__software
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?stratoweave_rfs__device__mock__software=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else stratoweave_rfs__device__mock__software()
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -385,7 +412,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), software=stratoweave_rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_stratoweave_rfs, 'software'))), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:
@@ -393,7 +420,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class stratoweave_rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -414,7 +441,7 @@ class stratoweave_rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class stratoweave_rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -435,7 +462,7 @@ class stratoweave_rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -455,7 +482,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -488,7 +515,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
         return stratoweave_rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class stratoweave_rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -517,7 +544,7 @@ class stratoweave_rfs__device__software(yadata.MNode):
         return stratoweave_rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker19: None = None
+_breaker20: None = None
 class stratoweave_rfs__device_entry(yadata.MNode):
     name: str
     description: ?str
@@ -557,7 +584,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker20: None = None
+_breaker21: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -594,7 +621,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
         return stratoweave_rfs__device(elements=copied_elements)
 
 
-_breaker21: None = None
+_breaker22: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
 
@@ -612,7 +639,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker22: None = None
+_breaker23: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -643,7 +670,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker23: None = None
+_breaker24: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs

--- a/fleetmgr/src/fleetmgr/devices/flotilla_oper.act
+++ b/fleetmgr/src/fleetmgr/devices/flotilla_oper.act
@@ -76,6 +76,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -335,6 +340,46 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -2257,6 +2302,31 @@ class stratoweave_rfs__device__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class stratoweave_rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'running-release')))
+        return stratoweave_rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -2280,7 +2350,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2315,13 +2385,15 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: ?bool
+    software: stratoweave_rfs__device__mock__software
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?stratoweave_rfs__device__mock__software=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else stratoweave_rfs__device__mock__software()
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2330,7 +2402,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), software=stratoweave_rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_stratoweave_rfs, 'software'))), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:
@@ -2338,7 +2410,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class stratoweave_rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -2359,7 +2431,7 @@ class stratoweave_rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class stratoweave_rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -2380,7 +2452,7 @@ class stratoweave_rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -2400,7 +2472,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -2433,7 +2505,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
         return stratoweave_rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class stratoweave_rfs__device__software__state__job_entry(yadata.MNode):
     name: str
     state: ?str
@@ -2461,7 +2533,7 @@ class stratoweave_rfs__device__software__state__job_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__state__job_entry.from_gdata(self.to_gdata())
 
-_breaker19: None = None
+_breaker20: None = None
 class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, stratoweave_rfs__device__software__state__job_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__state__job_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2502,7 +2574,7 @@ class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, strat
         return stratoweave_rfs__device__software__state__job(elements=copied_elements)
 
 
-_breaker20: None = None
+_breaker21: None = None
 class stratoweave_rfs__device__software__state__precheck(yadata.MNode):
     verdict: ?str
     detail: ?str
@@ -2527,7 +2599,7 @@ class stratoweave_rfs__device__software__state__precheck(yadata.MNode):
         return stratoweave_rfs__device__software__state__precheck.from_gdata(self.to_gdata())
 
 
-_breaker21: None = None
+_breaker22: None = None
 class stratoweave_rfs__device__software__state__postcheck(yadata.MNode):
     verdict: ?str
     detail: ?str
@@ -2552,7 +2624,7 @@ class stratoweave_rfs__device__software__state__postcheck(yadata.MNode):
         return stratoweave_rfs__device__software__state__postcheck.from_gdata(self.to_gdata())
 
 
-_breaker22: None = None
+_breaker23: None = None
 class stratoweave_rfs__device__software__state(yadata.MNode):
     status: ?str
     running_release: ?str
@@ -2581,7 +2653,7 @@ class stratoweave_rfs__device__software__state(yadata.MNode):
         return stratoweave_rfs__device__software__state.from_gdata(self.to_gdata())
 
 
-_breaker23: None = None
+_breaker24: None = None
 class stratoweave_rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -2612,7 +2684,7 @@ class stratoweave_rfs__device__software(yadata.MNode):
         return stratoweave_rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker24: None = None
+_breaker25: None = None
 class stratoweave_rfs__device__state(yadata.MNode):
 
     mut def __init__(self) -> None:
@@ -2632,7 +2704,7 @@ class stratoweave_rfs__device__state(yadata.MNode):
         return stratoweave_rfs__device__state.from_gdata(self.to_gdata())
 
 
-_breaker25: None = None
+_breaker26: None = None
 class stratoweave_rfs__device_entry(yadata.MNode):
     name: str
     description: ?str
@@ -2674,7 +2746,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker26: None = None
+_breaker27: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2711,7 +2783,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
         return stratoweave_rfs__device(elements=copied_elements)
 
 
-_breaker27: None = None
+_breaker28: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
 
@@ -2729,7 +2801,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker28: None = None
+_breaker29: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2760,7 +2832,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker29: None = None
+_breaker30: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
@@ -2788,7 +2860,27 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
-_breaker30: None = None
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
+_breaker31: None = None
 class stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2804,7 +2896,24 @@ class stratoweave_rfs__device__address__initial_credentials_entry_subs(Subscript
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker31: None = None
+_breaker32: None = None
+proc def stratoweave_rfs__device__address__initial_credentials_deliver(cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__device__address__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'address')), 'address')
+            e3 = _one(_at(e2, ygdata.Id(NS_stratoweave_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), address_name=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), initial_credentials_username=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'username')), initial_credentials_password=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'password')), initial_credentials_key=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2824,11 +2933,17 @@ class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNod
         base_path = self._path!.parent
         return stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__address__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__address__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker32: None = None
+_breaker33: None = None
 class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2846,7 +2961,23 @@ class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker33: None = None
+_breaker34: None = None
+proc def stratoweave_rfs__device__address_deliver(cb: action(?(device_name: str, address_name: str), ?stratoweave_rfs__device__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str) = None
+    inst: ?stratoweave_rfs__device__address_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'address')), 'address')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), address_name=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__device__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2866,11 +2997,17 @@ class stratoweave_rfs__device__address_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__address_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'address'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, address_name: str), ?stratoweave_rfs__device__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__address_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker34: None = None
+_breaker35: None = None
 class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2884,7 +3021,24 @@ class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker35: None = None
+_breaker36: None = None
+proc def stratoweave_rfs__device__credentials__key_deliver(cb: action(?(device_name: str, key_key: str), ?stratoweave_rfs__device__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, key_key: str) = None
+    inst: ?stratoweave_rfs__device__credentials__key_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'credentials'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'key')), 'key')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), key_key=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__credentials__key_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2900,11 +3054,33 @@ class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'key'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, key_key: str), ?stratoweave_rfs__device__credentials__key_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__credentials__key_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker36: None = None
+_breaker37: None = None
+proc def stratoweave_rfs__device__credentials_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__credentials = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'credentials'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__credentials.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2920,7 +3096,13 @@ class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker37: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__credentials, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__credentials_deliver(cb, n, err), root=self.filt())
+
+_breaker38: None = None
 class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2936,7 +3118,23 @@ class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker38: None = None
+_breaker39: None = None
+proc def stratoweave_rfs__device__initial_credentials_deliver(cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__device__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), initial_credentials_username=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'username')), initial_credentials_password=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'password')), initial_credentials_key=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__device__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2956,11 +3154,33 @@ class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker39: None = None
+_breaker40: None = None
+proc def stratoweave_rfs__device__ssh_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__ssh = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'ssh'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__ssh.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
     cipher: SubscriptionNode
     mac: SubscriptionNode
@@ -2990,7 +3210,52 @@ class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
         return direct
 
-_breaker40: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__ssh, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__ssh_deliver(cb, n, err), root=self.filt())
+
+_breaker41: None = None
+proc def stratoweave_rfs__device__mock__software_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__mock__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__mock__software = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
+class stratoweave_rfs__device__mock__software_subs(SubscriptionNode):
+    upgrade_duration: SubscriptionNode
+    failure: SubscriptionNode
+    running_release: SubscriptionNode
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.upgrade_duration = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration'), parent=path))
+        self.failure = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'failure'), parent=path))
+        self.running_release = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'running-release'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.upgrade_duration, self.failure, self.running_release]
+        return direct
+
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__mock__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock__software_deliver(cb, n, err), root=self.filt())
+
+_breaker42: None = None
 class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -3008,7 +3273,24 @@ class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker41: None = None
+_breaker43: None = None
+proc def stratoweave_rfs__device__mock__module_deliver(cb: action(?(device_name: str, module_name: str), ?stratoweave_rfs__device__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, module_name: str) = None
+    inst: ?stratoweave_rfs__device__mock__module_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'module')), 'module')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), module_name=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock__module_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -3028,25 +3310,71 @@ class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__mock__module_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'module'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, module_name: str), ?stratoweave_rfs__device__mock__module_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock__module_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker42: None = None
+_breaker44: None = None
+proc def stratoweave_rfs__device__mock_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__mock = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
+    software: stratoweave_rfs__device__mock__software_subs
     module: stratoweave_rfs__device__mock__module_subs
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'enabled'), parent=path))
+        self.software = stratoweave_rfs__device__mock__software_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'software'), parent=path))
         self.module = stratoweave_rfs__device__mock__module_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'module'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.enabled, self.module]
+        direct: list[SubscriptionNode] = [self.enabled, self.software, self.module]
         return direct
 
-_breaker43: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__mock, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock_deliver(cb, n, err), root=self.filt())
+
+_breaker45: None = None
+proc def stratoweave_rfs__device__debug_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__debug = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'debug'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__debug.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -3058,7 +3386,29 @@ class stratoweave_rfs__device__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
-_breaker44: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__debug, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__debug_deliver(cb, n, err), root=self.filt())
+
+_breaker46: None = None
+proc def stratoweave_rfs__device__feature_flags_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__feature_flags = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'feature-flags'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__feature_flags.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -3070,7 +3420,13 @@ class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
 
-_breaker45: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__feature_flags, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__feature_flags_deliver(cb, n, err), root=self.filt())
+
+_breaker47: None = None
 class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -3084,7 +3440,24 @@ class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker46: None = None
+_breaker48: None = None
+proc def stratoweave_rfs__device__software__veto_deliver(cb: action(?(device_name: str, veto_holder: str), ?stratoweave_rfs__device__software__veto_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, veto_holder: str) = None
+    inst: ?stratoweave_rfs__device__software__veto_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'veto')), 'veto')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), veto_holder=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'holder')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__veto_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -3100,11 +3473,17 @@ class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__software__veto_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'veto'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, veto_holder: str), ?stratoweave_rfs__device__software__veto_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__veto_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker47: None = None
+_breaker49: None = None
 class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -3126,7 +3505,25 @@ class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker48: None = None
+_breaker50: None = None
+proc def stratoweave_rfs__device__software__state__job_deliver(cb: action(?(device_name: str, job_name: str), ?stratoweave_rfs__device__software__state__job_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, job_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__job_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            e4 = _one(_at(c3, ygdata.Id(NS_stratoweave_rfs, 'job')), 'job')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), job_name=e4.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__job_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -3150,11 +3547,35 @@ class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'job'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, job_name: str), ?stratoweave_rfs__device__software__state__job_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__job_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker49: None = None
+_breaker51: None = None
+proc def stratoweave_rfs__device__software__state__precheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__precheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__precheck = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            c4 = _at(c3, ygdata.Id(NS_stratoweave_rfs, 'precheck'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__precheck.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -3170,7 +3591,31 @@ class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
-_breaker50: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__precheck, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__precheck_deliver(cb, n, err), root=self.filt())
+
+_breaker52: None = None
+proc def stratoweave_rfs__device__software__state__postcheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__postcheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__postcheck = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            c4 = _at(c3, ygdata.Id(NS_stratoweave_rfs, 'postcheck'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__postcheck.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -3186,7 +3631,30 @@ class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
-_breaker51: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__postcheck, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__postcheck_deliver(cb, n, err), root=self.filt())
+
+_breaker53: None = None
+proc def stratoweave_rfs__device__software__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
     status: SubscriptionNode
     running_release: SubscriptionNode
@@ -3206,7 +3674,29 @@ class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.status, self.running_release, self.job, self.precheck, self.postcheck]
         return direct
 
-_breaker52: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state_deliver(cb, n, err), root=self.filt())
+
+_breaker54: None = None
+proc def stratoweave_rfs__device__software_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software_subs(SubscriptionNode):
     upgrade_campaign: SubscriptionNode
     target_release: SubscriptionNode
@@ -3228,7 +3718,29 @@ class stratoweave_rfs__device__software_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.upgrade_campaign, self.target_release, self.image_url, self.allow_staging, self.veto, self.state]
         return direct
 
-_breaker53: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software_deliver(cb, n, err), root=self.filt())
+
+_breaker55: None = None
+proc def stratoweave_rfs__device__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__state_subs(SubscriptionNode):
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -3238,7 +3750,13 @@ class stratoweave_rfs__device__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = []
         return direct
 
-_breaker54: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__state_deliver(cb, n, err), root=self.filt())
+
+_breaker56: None = None
 class stratoweave_rfs__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -3274,7 +3792,22 @@ class stratoweave_rfs__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker55: None = None
+_breaker57: None = None
+proc def stratoweave_rfs__device_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e1)
+            if here is not None:
+                inst = stratoweave_rfs__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -3312,11 +3845,17 @@ class stratoweave_rfs__device_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker56: None = None
+_breaker58: None = None
 class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
     name: SubscriptionNode
 
@@ -3328,7 +3867,22 @@ class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name]
         return direct
 
-_breaker57: None = None
+_breaker59: None = None
+proc def stratoweave_rfs__rfs_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str) = None
+    inst: ?stratoweave_rfs__rfs_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e1)
+            if here is not None:
+                inst = stratoweave_rfs__rfs_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs_subs(SubscriptionNode):
     name: SubscriptionNode
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -3342,11 +3896,17 @@ class stratoweave_rfs__rfs_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'rfs'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name]
         return direct
 
-_breaker58: None = None
+_breaker60: None = None
 class root_subs(SubscriptionNode):
     device: stratoweave_rfs__device_subs
     rfs: stratoweave_rfs__rfs_subs
@@ -3362,17 +3922,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/fleetmgr/src/fleetmgr/devices/flotilla_schema.act
+++ b/fleetmgr/src/fleetmgr/devices/flotilla_schema.act
@@ -68,6 +68,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -298,6 +303,46 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";

--- a/fleetmgr/src/fleetmgr/layers/t_0.act
+++ b/fleetmgr/src/fleetmgr/layers/t_0.act
@@ -31,4 +31,5 @@ def UpgradeCampaignTransformCtor(params: ttt.TransformActorParams) -> ttt.Transf
     def update_oper_type_wrapper(oper: ?y_0_oper.software__software__upgrade_campaign_entry):
         params.update_oper(oper.to_gdata() if oper is not None else None)
     act = cfs.UpgradeCampaignTransform(params.path, update_oper_type_wrapper, params.lower_tree_provider)
-    return ttt.TransformActor(lambda c, m: act.on_conf(software__software__upgrade_campaign_entry.from_gdata(c)))
+    return ttt.TransformActor(lambda c, m: act.on_conf(software__software__upgrade_campaign_entry.from_gdata(c)),
+                              lambda m: act.shutdown())

--- a/fleetmgr/src/fleetmgr/layers/t_1.act
+++ b/fleetmgr/src/fleetmgr/layers/t_1.act
@@ -21,4 +21,5 @@ def FlotillaStatusTransformCtor(params: ttt.TransformActorParams) -> ttt.Transfo
     def update_oper_type_wrapper(oper: ?y_1_oper.stratoweave_rfs__rfs__flotilla_status):
         params.update_oper(oper.to_gdata() if oper is not None else None)
     act = rfs.FlotillaStatusTransform(params.path, update_oper_type_wrapper, params.dev!)
-    return ttt.TransformActor(lambda c, m: act.on_conf(stratoweave_rfs__rfs__flotilla_status.from_gdata(c)))
+    return ttt.TransformActor(lambda c, m: act.on_conf(stratoweave_rfs__rfs__flotilla_status.from_gdata(c)),
+                              lambda m: act.shutdown())

--- a/fleetmgr/src/fleetmgr/layers/y_0.act
+++ b/fleetmgr/src/fleetmgr/layers/y_0.act
@@ -73,6 +73,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:flee
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -152,6 +157,11 @@ SRC_DNODE_CHILD_21: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fle
 
 SRC_DNODE_CHILD_22: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -430,6 +440,46 @@ SRC_YANG_2: str = r"""module fleetmgr-types {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -1530,6 +1580,31 @@ class fleetmgr__fleet__node__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class fleetmgr__fleet__node__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str=None, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure if failure is not None else "none"
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['fleetmgr:fleet', 'node', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__node__mock__software:
+        if n is not None:
+            return fleetmgr__fleet__node__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'running-release')))
+        return fleetmgr__fleet__node__mock__software()
+
+    mut def copy(self) -> fleetmgr__fleet__node__mock__software:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__node__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
     name: str
     namespace: str
@@ -1553,7 +1628,7 @@ class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__node__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -1587,13 +1662,15 @@ class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet
         return fleetmgr__fleet__node__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class fleetmgr__fleet__node__mock(yadata.MNode):
     enabled: bool
+    software: fleetmgr__fleet__node__mock__software
     module: fleetmgr__fleet__node__mock__module
 
-    mut def __init__(self, enabled: ?bool=None, module: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool=None, software: ?fleetmgr__fleet__node__mock__software=None, module: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
         self.enabled = enabled if enabled is not None else False
+        self.software = software if software is not None else fleetmgr__fleet__node__mock__software()
         self.module = fleetmgr__fleet__node__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -1602,7 +1679,7 @@ class fleetmgr__fleet__node__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__node__mock:
         if n is not None:
-            return fleetmgr__fleet__node__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), module=fleetmgr__fleet__node__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
+            return fleetmgr__fleet__node__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), software=fleetmgr__fleet__node__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'software'))), module=fleetmgr__fleet__node__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
         return fleetmgr__fleet__node__mock()
 
     mut def copy(self) -> fleetmgr__fleet__node__mock:
@@ -1610,7 +1687,7 @@ class fleetmgr__fleet__node__mock(yadata.MNode):
         return fleetmgr__fleet__node__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class fleetmgr__fleet__node__debug(yadata.MNode):
     connection: bool
 
@@ -1631,7 +1708,7 @@ class fleetmgr__fleet__node__debug(yadata.MNode):
         return fleetmgr__fleet__node__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class fleetmgr__fleet__node__feature_flags(yadata.MNode):
     runtime_schema_fetch: bool
 
@@ -1652,7 +1729,7 @@ class fleetmgr__fleet__node__feature_flags(yadata.MNode):
         return fleetmgr__fleet__node__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class fleetmgr__fleet__node_entry(yadata.MNode):
     name: str
     description: ?str
@@ -1688,7 +1765,7 @@ class fleetmgr__fleet__node_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -1724,7 +1801,7 @@ class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry])
         return fleetmgr__fleet__node(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1746,7 +1823,7 @@ class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker19: None = None
+_breaker20: None = None
 class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -1777,7 +1854,7 @@ class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(u
         return fleetmgr__fleet__device__address__initial_credentials(elements=copied_elements)
 
 
-_breaker20: None = None
+_breaker21: None = None
 class fleetmgr__fleet__device__address_entry(yadata.MNode):
     name: str
     address: str
@@ -1801,7 +1878,7 @@ class fleetmgr__fleet__device__address_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker21: None = None
+_breaker22: None = None
 class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__device__address_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -1835,7 +1912,7 @@ class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__d
         return fleetmgr__fleet__device__address(elements=copied_elements)
 
 
-_breaker22: None = None
+_breaker23: None = None
 class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
     key: str
     private_key: ?str
@@ -1855,7 +1932,7 @@ class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker23: None = None
+_breaker24: None = None
 class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr__fleet__device__credentials__key_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__credentials__key_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
@@ -1888,7 +1965,7 @@ class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr_
         return fleetmgr__fleet__device__credentials__key(elements=copied_elements)
 
 
-_breaker24: None = None
+_breaker25: None = None
 class fleetmgr__fleet__device__credentials(yadata.MNode):
     username: str
     password: ?str
@@ -1913,7 +1990,7 @@ class fleetmgr__fleet__device__credentials(yadata.MNode):
         return fleetmgr__fleet__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker25: None = None
+_breaker26: None = None
 class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1935,7 +2012,7 @@ class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker26: None = None
+_breaker27: None = None
 class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -1966,7 +2043,7 @@ class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: 
         return fleetmgr__fleet__device__initial_credentials(elements=copied_elements)
 
 
-_breaker27: None = None
+_breaker28: None = None
 class fleetmgr__fleet__device__ssh(yadata.MNode):
     cipher: list[str]
     mac: list[str]
@@ -2005,7 +2082,32 @@ class fleetmgr__fleet__device__ssh(yadata.MNode):
         return fleetmgr__fleet__device__ssh.from_gdata(self.to_gdata())
 
 
-_breaker28: None = None
+_breaker29: None = None
+class fleetmgr__fleet__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str=None, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure if failure is not None else "none"
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['fleetmgr:fleet', 'device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__device__mock__software:
+        if n is not None:
+            return fleetmgr__fleet__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'running-release')))
+        return fleetmgr__fleet__device__mock__software()
+
+    mut def copy(self) -> fleetmgr__fleet__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker30: None = None
 class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: str
@@ -2029,7 +2131,7 @@ class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker29: None = None
+_breaker31: None = None
 class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__device__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2063,13 +2165,15 @@ class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fle
         return fleetmgr__fleet__device__mock__module(elements=copied_elements)
 
 
-_breaker30: None = None
+_breaker32: None = None
 class fleetmgr__fleet__device__mock(yadata.MNode):
     enabled: bool
+    software: fleetmgr__fleet__device__mock__software
     module: fleetmgr__fleet__device__mock__module
 
-    mut def __init__(self, enabled: ?bool=None, module: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool=None, software: ?fleetmgr__fleet__device__mock__software=None, module: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled if enabled is not None else False
+        self.software = software if software is not None else fleetmgr__fleet__device__mock__software()
         self.module = fleetmgr__fleet__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2078,7 +2182,7 @@ class fleetmgr__fleet__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__device__mock:
         if n is not None:
-            return fleetmgr__fleet__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), module=fleetmgr__fleet__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
+            return fleetmgr__fleet__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), software=fleetmgr__fleet__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'software'))), module=fleetmgr__fleet__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
         return fleetmgr__fleet__device__mock()
 
     mut def copy(self) -> fleetmgr__fleet__device__mock:
@@ -2086,7 +2190,7 @@ class fleetmgr__fleet__device__mock(yadata.MNode):
         return fleetmgr__fleet__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker31: None = None
+_breaker33: None = None
 class fleetmgr__fleet__device__debug(yadata.MNode):
     connection: bool
 
@@ -2107,7 +2211,7 @@ class fleetmgr__fleet__device__debug(yadata.MNode):
         return fleetmgr__fleet__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker32: None = None
+_breaker34: None = None
 class fleetmgr__fleet__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: bool
 
@@ -2128,7 +2232,7 @@ class fleetmgr__fleet__device__feature_flags(yadata.MNode):
         return fleetmgr__fleet__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker33: None = None
+_breaker35: None = None
 class fleetmgr__fleet__device_entry(yadata.MNode):
     name: str
     type: str
@@ -2168,7 +2272,7 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device_entry.from_gdata(self.to_gdata())
 
-_breaker34: None = None
+_breaker36: None = None
 class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2206,7 +2310,7 @@ class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_ent
         return fleetmgr__fleet__device(elements=copied_elements)
 
 
-_breaker35: None = None
+_breaker37: None = None
 class fleetmgr__fleet(yadata.MNode):
     node: fleetmgr__fleet__node
     device: fleetmgr__fleet__device
@@ -2229,7 +2333,7 @@ class fleetmgr__fleet(yadata.MNode):
         return fleetmgr__fleet.from_gdata(self.to_gdata())
 
 
-_breaker36: None = None
+_breaker38: None = None
 class software__software__upgrade_campaign__device_entry(yadata.MNode):
     name: str
 
@@ -2247,7 +2351,7 @@ class software__software__upgrade_campaign__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign__device_entry.from_gdata(self.to_gdata())
 
-_breaker37: None = None
+_breaker39: None = None
 class software__software__upgrade_campaign__device(yadata.MKeyedList[str, software__software__upgrade_campaign__device_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2278,7 +2382,7 @@ class software__software__upgrade_campaign__device(yadata.MKeyedList[str, softwa
         return software__software__upgrade_campaign__device(elements=copied_elements)
 
 
-_breaker38: None = None
+_breaker40: None = None
 class software__software__upgrade_campaign_entry(yadata.MNode):
     name: str
     target_release: str
@@ -2306,7 +2410,7 @@ class software__software__upgrade_campaign_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign_entry.from_gdata(self.to_gdata())
 
-_breaker39: None = None
+_breaker41: None = None
 class software__software__upgrade_campaign(yadata.MKeyedList[str, software__software__upgrade_campaign_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2344,7 +2448,7 @@ class software__software__upgrade_campaign(yadata.MKeyedList[str, software__soft
         return software__software__upgrade_campaign(elements=copied_elements)
 
 
-_breaker40: None = None
+_breaker42: None = None
 class software__software(yadata.MNode):
     upgrade_campaign: software__software__upgrade_campaign
 
@@ -2365,7 +2469,7 @@ class software__software(yadata.MNode):
         return software__software.from_gdata(self.to_gdata())
 
 
-_breaker41: None = None
+_breaker43: None = None
 class root(yadata.MNode):
     fleet: fleetmgr__fleet
     software: software__software

--- a/fleetmgr/src/fleetmgr/layers/y_0_loose.act
+++ b/fleetmgr/src/fleetmgr/layers/y_0_loose.act
@@ -73,6 +73,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:flee
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -152,6 +157,11 @@ SRC_DNODE_CHILD_21: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fle
 
 SRC_DNODE_CHILD_22: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -430,6 +440,46 @@ SRC_YANG_2: str = r"""module fleetmgr-types {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -1531,6 +1581,31 @@ class fleetmgr__fleet__node__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class fleetmgr__fleet__node__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['fleetmgr:fleet', 'node', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__node__mock__software:
+        if n is not None:
+            return fleetmgr__fleet__node__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'running-release')))
+        return fleetmgr__fleet__node__mock__software()
+
+    mut def copy(self) -> fleetmgr__fleet__node__mock__software:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__node__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -1554,7 +1629,7 @@ class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__node__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -1589,13 +1664,15 @@ class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet
         return fleetmgr__fleet__node__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class fleetmgr__fleet__node__mock(yadata.MNode):
     enabled: ?bool
+    software: fleetmgr__fleet__node__mock__software
     module: fleetmgr__fleet__node__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?fleetmgr__fleet__node__mock__software=None, module: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else fleetmgr__fleet__node__mock__software()
         self.module = fleetmgr__fleet__node__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -1604,7 +1681,7 @@ class fleetmgr__fleet__node__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__node__mock:
         if n is not None:
-            return fleetmgr__fleet__node__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), module=fleetmgr__fleet__node__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
+            return fleetmgr__fleet__node__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), software=fleetmgr__fleet__node__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'software'))), module=fleetmgr__fleet__node__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
         return fleetmgr__fleet__node__mock()
 
     mut def copy(self) -> fleetmgr__fleet__node__mock:
@@ -1612,7 +1689,7 @@ class fleetmgr__fleet__node__mock(yadata.MNode):
         return fleetmgr__fleet__node__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class fleetmgr__fleet__node__debug(yadata.MNode):
     connection: ?bool
 
@@ -1633,7 +1710,7 @@ class fleetmgr__fleet__node__debug(yadata.MNode):
         return fleetmgr__fleet__node__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class fleetmgr__fleet__node__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -1654,7 +1731,7 @@ class fleetmgr__fleet__node__feature_flags(yadata.MNode):
         return fleetmgr__fleet__node__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class fleetmgr__fleet__node_entry(yadata.MNode):
     name: str
     description: ?str
@@ -1690,7 +1767,7 @@ class fleetmgr__fleet__node_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -1725,7 +1802,7 @@ class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry])
         return fleetmgr__fleet__node(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1747,7 +1824,7 @@ class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker19: None = None
+_breaker20: None = None
 class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -1778,7 +1855,7 @@ class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(u
         return fleetmgr__fleet__device__address__initial_credentials(elements=copied_elements)
 
 
-_breaker20: None = None
+_breaker21: None = None
 class fleetmgr__fleet__device__address_entry(yadata.MNode):
     name: str
     address: ?str
@@ -1802,7 +1879,7 @@ class fleetmgr__fleet__device__address_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker21: None = None
+_breaker22: None = None
 class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__device__address_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -1837,7 +1914,7 @@ class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__d
         return fleetmgr__fleet__device__address(elements=copied_elements)
 
 
-_breaker22: None = None
+_breaker23: None = None
 class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
     key: str
     private_key: ?str
@@ -1857,7 +1934,7 @@ class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker23: None = None
+_breaker24: None = None
 class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr__fleet__device__credentials__key_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__credentials__key_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
@@ -1890,7 +1967,7 @@ class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr_
         return fleetmgr__fleet__device__credentials__key(elements=copied_elements)
 
 
-_breaker24: None = None
+_breaker25: None = None
 class fleetmgr__fleet__device__credentials(yadata.MNode):
     username: ?str
     password: ?str
@@ -1915,7 +1992,7 @@ class fleetmgr__fleet__device__credentials(yadata.MNode):
         return fleetmgr__fleet__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker25: None = None
+_breaker26: None = None
 class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1937,7 +2014,7 @@ class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker26: None = None
+_breaker27: None = None
 class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -1968,7 +2045,7 @@ class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: 
         return fleetmgr__fleet__device__initial_credentials(elements=copied_elements)
 
 
-_breaker27: None = None
+_breaker28: None = None
 class fleetmgr__fleet__device__ssh(yadata.MNode):
     cipher: list[str]
     mac: list[str]
@@ -2007,7 +2084,32 @@ class fleetmgr__fleet__device__ssh(yadata.MNode):
         return fleetmgr__fleet__device__ssh.from_gdata(self.to_gdata())
 
 
-_breaker28: None = None
+_breaker29: None = None
+class fleetmgr__fleet__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['fleetmgr:fleet', 'device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__device__mock__software:
+        if n is not None:
+            return fleetmgr__fleet__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'running-release')))
+        return fleetmgr__fleet__device__mock__software()
+
+    mut def copy(self) -> fleetmgr__fleet__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker30: None = None
 class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -2031,7 +2133,7 @@ class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker29: None = None
+_breaker31: None = None
 class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__device__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2066,13 +2168,15 @@ class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fle
         return fleetmgr__fleet__device__mock__module(elements=copied_elements)
 
 
-_breaker30: None = None
+_breaker32: None = None
 class fleetmgr__fleet__device__mock(yadata.MNode):
     enabled: ?bool
+    software: fleetmgr__fleet__device__mock__software
     module: fleetmgr__fleet__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?fleetmgr__fleet__device__mock__software=None, module: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else fleetmgr__fleet__device__mock__software()
         self.module = fleetmgr__fleet__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2081,7 +2185,7 @@ class fleetmgr__fleet__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__device__mock:
         if n is not None:
-            return fleetmgr__fleet__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), module=fleetmgr__fleet__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
+            return fleetmgr__fleet__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), software=fleetmgr__fleet__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'software'))), module=fleetmgr__fleet__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
         return fleetmgr__fleet__device__mock()
 
     mut def copy(self) -> fleetmgr__fleet__device__mock:
@@ -2089,7 +2193,7 @@ class fleetmgr__fleet__device__mock(yadata.MNode):
         return fleetmgr__fleet__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker31: None = None
+_breaker33: None = None
 class fleetmgr__fleet__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -2110,7 +2214,7 @@ class fleetmgr__fleet__device__debug(yadata.MNode):
         return fleetmgr__fleet__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker32: None = None
+_breaker34: None = None
 class fleetmgr__fleet__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -2131,7 +2235,7 @@ class fleetmgr__fleet__device__feature_flags(yadata.MNode):
         return fleetmgr__fleet__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker33: None = None
+_breaker35: None = None
 class fleetmgr__fleet__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -2171,7 +2275,7 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device_entry.from_gdata(self.to_gdata())
 
-_breaker34: None = None
+_breaker36: None = None
 class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2210,7 +2314,7 @@ class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_ent
         return fleetmgr__fleet__device(elements=copied_elements)
 
 
-_breaker35: None = None
+_breaker37: None = None
 class fleetmgr__fleet(yadata.MNode):
     node: fleetmgr__fleet__node
     device: fleetmgr__fleet__device
@@ -2233,7 +2337,7 @@ class fleetmgr__fleet(yadata.MNode):
         return fleetmgr__fleet.from_gdata(self.to_gdata())
 
 
-_breaker36: None = None
+_breaker38: None = None
 class software__software__upgrade_campaign__device_entry(yadata.MNode):
     name: str
 
@@ -2251,7 +2355,7 @@ class software__software__upgrade_campaign__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign__device_entry.from_gdata(self.to_gdata())
 
-_breaker37: None = None
+_breaker39: None = None
 class software__software__upgrade_campaign__device(yadata.MKeyedList[str, software__software__upgrade_campaign__device_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2282,7 +2386,7 @@ class software__software__upgrade_campaign__device(yadata.MKeyedList[str, softwa
         return software__software__upgrade_campaign__device(elements=copied_elements)
 
 
-_breaker38: None = None
+_breaker40: None = None
 class software__software__upgrade_campaign_entry(yadata.MNode):
     name: str
     target_release: ?str
@@ -2310,7 +2414,7 @@ class software__software__upgrade_campaign_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign_entry.from_gdata(self.to_gdata())
 
-_breaker39: None = None
+_breaker41: None = None
 class software__software__upgrade_campaign(yadata.MKeyedList[str, software__software__upgrade_campaign_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2349,7 +2453,7 @@ class software__software__upgrade_campaign(yadata.MKeyedList[str, software__soft
         return software__software__upgrade_campaign(elements=copied_elements)
 
 
-_breaker40: None = None
+_breaker42: None = None
 class software__software(yadata.MNode):
     upgrade_campaign: software__software__upgrade_campaign
 
@@ -2370,7 +2474,7 @@ class software__software(yadata.MNode):
         return software__software.from_gdata(self.to_gdata())
 
 
-_breaker41: None = None
+_breaker43: None = None
 class root(yadata.MNode):
     fleet: fleetmgr__fleet
     software: software__software

--- a/fleetmgr/src/fleetmgr/layers/y_0_oper.act
+++ b/fleetmgr/src/fleetmgr/layers/y_0_oper.act
@@ -74,6 +74,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:flee
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -153,6 +158,11 @@ SRC_DNODE_CHILD_21: DLeaf = DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fle
 
 SRC_DNODE_CHILD_22: DContainer = DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='fleetmgr', namespace='urn:fleetmgr:fleetmgr', prefix='fleetmgr', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -442,6 +452,46 @@ SRC_YANG_2: str = r"""module fleetmgr-types {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -1543,6 +1593,31 @@ class fleetmgr__fleet__node__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class fleetmgr__fleet__node__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['fleetmgr:fleet', 'node', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__node__mock__software:
+        if n is not None:
+            return fleetmgr__fleet__node__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'running-release')))
+        return fleetmgr__fleet__node__mock__software()
+
+    mut def copy(self) -> fleetmgr__fleet__node__mock__software:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__node__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -1566,7 +1641,7 @@ class fleetmgr__fleet__node__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__node__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -1601,13 +1676,15 @@ class fleetmgr__fleet__node__mock__module(yadata.MKeyedList[str, fleetmgr__fleet
         return fleetmgr__fleet__node__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class fleetmgr__fleet__node__mock(yadata.MNode):
     enabled: ?bool
+    software: fleetmgr__fleet__node__mock__software
     module: fleetmgr__fleet__node__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?fleetmgr__fleet__node__mock__software=None, module: list[fleetmgr__fleet__node__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else fleetmgr__fleet__node__mock__software()
         self.module = fleetmgr__fleet__node__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -1616,7 +1693,7 @@ class fleetmgr__fleet__node__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__node__mock:
         if n is not None:
-            return fleetmgr__fleet__node__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), module=fleetmgr__fleet__node__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
+            return fleetmgr__fleet__node__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), software=fleetmgr__fleet__node__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'software'))), module=fleetmgr__fleet__node__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
         return fleetmgr__fleet__node__mock()
 
     mut def copy(self) -> fleetmgr__fleet__node__mock:
@@ -1624,7 +1701,7 @@ class fleetmgr__fleet__node__mock(yadata.MNode):
         return fleetmgr__fleet__node__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class fleetmgr__fleet__node__debug(yadata.MNode):
     connection: ?bool
 
@@ -1645,7 +1722,7 @@ class fleetmgr__fleet__node__debug(yadata.MNode):
         return fleetmgr__fleet__node__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class fleetmgr__fleet__node__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -1666,7 +1743,7 @@ class fleetmgr__fleet__node__feature_flags(yadata.MNode):
         return fleetmgr__fleet__node__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class fleetmgr__fleet__node_entry(yadata.MNode):
     name: str
     description: ?str
@@ -1702,7 +1779,7 @@ class fleetmgr__fleet__node_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__node_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__node_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -1737,7 +1814,7 @@ class fleetmgr__fleet__node(yadata.MKeyedList[str, fleetmgr__fleet__node_entry])
         return fleetmgr__fleet__node(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1759,7 +1836,7 @@ class fleetmgr__fleet__device__address__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker19: None = None
+_breaker20: None = None
 class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -1790,7 +1867,7 @@ class fleetmgr__fleet__device__address__initial_credentials(yadata.MKeyedList[(u
         return fleetmgr__fleet__device__address__initial_credentials(elements=copied_elements)
 
 
-_breaker20: None = None
+_breaker21: None = None
 class fleetmgr__fleet__device__address_entry(yadata.MNode):
     name: str
     address: ?str
@@ -1814,7 +1891,7 @@ class fleetmgr__fleet__device__address_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker21: None = None
+_breaker22: None = None
 class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__device__address_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__address_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -1849,7 +1926,7 @@ class fleetmgr__fleet__device__address(yadata.MKeyedList[str, fleetmgr__fleet__d
         return fleetmgr__fleet__device__address(elements=copied_elements)
 
 
-_breaker22: None = None
+_breaker23: None = None
 class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
     key: str
     private_key: ?str
@@ -1869,7 +1946,7 @@ class fleetmgr__fleet__device__credentials__key_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker23: None = None
+_breaker24: None = None
 class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr__fleet__device__credentials__key_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__credentials__key_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
@@ -1902,7 +1979,7 @@ class fleetmgr__fleet__device__credentials__key(yadata.MKeyedList[str, fleetmgr_
         return fleetmgr__fleet__device__credentials__key(elements=copied_elements)
 
 
-_breaker24: None = None
+_breaker25: None = None
 class fleetmgr__fleet__device__credentials(yadata.MNode):
     username: ?str
     password: ?str
@@ -1927,7 +2004,7 @@ class fleetmgr__fleet__device__credentials(yadata.MNode):
         return fleetmgr__fleet__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker25: None = None
+_breaker26: None = None
 class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -1949,7 +2026,7 @@ class fleetmgr__fleet__device__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker26: None = None
+_breaker27: None = None
 class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), fleetmgr__fleet__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -1980,7 +2057,7 @@ class fleetmgr__fleet__device__initial_credentials(yadata.MKeyedList[(username: 
         return fleetmgr__fleet__device__initial_credentials(elements=copied_elements)
 
 
-_breaker27: None = None
+_breaker28: None = None
 class fleetmgr__fleet__device__ssh(yadata.MNode):
     cipher: list[str]
     mac: list[str]
@@ -2019,7 +2096,32 @@ class fleetmgr__fleet__device__ssh(yadata.MNode):
         return fleetmgr__fleet__device__ssh.from_gdata(self.to_gdata())
 
 
-_breaker28: None = None
+_breaker29: None = None
+class fleetmgr__fleet__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['fleetmgr:fleet', 'device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__device__mock__software:
+        if n is not None:
+            return fleetmgr__fleet__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_fleetmgr, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_fleetmgr, 'running-release')))
+        return fleetmgr__fleet__device__mock__software()
+
+    mut def copy(self) -> fleetmgr__fleet__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return fleetmgr__fleet__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker30: None = None
 class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -2043,7 +2145,7 @@ class fleetmgr__fleet__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker29: None = None
+_breaker31: None = None
 class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fleet__device__mock__module_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2078,13 +2180,15 @@ class fleetmgr__fleet__device__mock__module(yadata.MKeyedList[str, fleetmgr__fle
         return fleetmgr__fleet__device__mock__module(elements=copied_elements)
 
 
-_breaker30: None = None
+_breaker32: None = None
 class fleetmgr__fleet__device__mock(yadata.MNode):
     enabled: ?bool
+    software: fleetmgr__fleet__device__mock__software
     module: fleetmgr__fleet__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?fleetmgr__fleet__device__mock__software=None, module: list[fleetmgr__fleet__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else fleetmgr__fleet__device__mock__software()
         self.module = fleetmgr__fleet__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2093,7 +2197,7 @@ class fleetmgr__fleet__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> fleetmgr__fleet__device__mock:
         if n is not None:
-            return fleetmgr__fleet__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), module=fleetmgr__fleet__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
+            return fleetmgr__fleet__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr, 'enabled')), software=fleetmgr__fleet__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr, 'software'))), module=fleetmgr__fleet__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr, 'module'))))
         return fleetmgr__fleet__device__mock()
 
     mut def copy(self) -> fleetmgr__fleet__device__mock:
@@ -2101,7 +2205,7 @@ class fleetmgr__fleet__device__mock(yadata.MNode):
         return fleetmgr__fleet__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker31: None = None
+_breaker33: None = None
 class fleetmgr__fleet__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -2122,7 +2226,7 @@ class fleetmgr__fleet__device__debug(yadata.MNode):
         return fleetmgr__fleet__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker32: None = None
+_breaker34: None = None
 class fleetmgr__fleet__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -2143,7 +2247,7 @@ class fleetmgr__fleet__device__feature_flags(yadata.MNode):
         return fleetmgr__fleet__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker33: None = None
+_breaker35: None = None
 class fleetmgr__fleet__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -2183,7 +2287,7 @@ class fleetmgr__fleet__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return fleetmgr__fleet__device_entry.from_gdata(self.to_gdata())
 
-_breaker34: None = None
+_breaker36: None = None
 class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_entry]):
     mut def __init__(self, elements: list[fleetmgr__fleet__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2222,7 +2326,7 @@ class fleetmgr__fleet__device(yadata.MKeyedList[str, fleetmgr__fleet__device_ent
         return fleetmgr__fleet__device(elements=copied_elements)
 
 
-_breaker35: None = None
+_breaker37: None = None
 class fleetmgr__fleet(yadata.MNode):
     node: fleetmgr__fleet__node
     device: fleetmgr__fleet__device
@@ -2245,7 +2349,7 @@ class fleetmgr__fleet(yadata.MNode):
         return fleetmgr__fleet.from_gdata(self.to_gdata())
 
 
-_breaker36: None = None
+_breaker38: None = None
 class software__software__upgrade_campaign__device_entry(yadata.MNode):
     name: str
 
@@ -2263,7 +2367,7 @@ class software__software__upgrade_campaign__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign__device_entry.from_gdata(self.to_gdata())
 
-_breaker37: None = None
+_breaker39: None = None
 class software__software__upgrade_campaign__device(yadata.MKeyedList[str, software__software__upgrade_campaign__device_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2294,7 +2398,7 @@ class software__software__upgrade_campaign__device(yadata.MKeyedList[str, softwa
         return software__software__upgrade_campaign__device(elements=copied_elements)
 
 
-_breaker38: None = None
+_breaker40: None = None
 class software__software__upgrade_campaign__state__device_status_entry(yadata.MNode):
     device: str
     status: ?str
@@ -2316,7 +2420,7 @@ class software__software__upgrade_campaign__state__device_status_entry(yadata.MN
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign__state__device_status_entry.from_gdata(self.to_gdata())
 
-_breaker39: None = None
+_breaker41: None = None
 class software__software__upgrade_campaign__state__device_status(yadata.MKeyedList[str, software__software__upgrade_campaign__state__device_status_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign__state__device_status_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.device, elements)
@@ -2351,7 +2455,7 @@ class software__software__upgrade_campaign__state__device_status(yadata.MKeyedLi
         return software__software__upgrade_campaign__state__device_status(elements=copied_elements)
 
 
-_breaker40: None = None
+_breaker42: None = None
 class software__software__upgrade_campaign__state(yadata.MNode):
     total: ?u64
     in_progress: ?u64
@@ -2380,7 +2484,7 @@ class software__software__upgrade_campaign__state(yadata.MNode):
         return software__software__upgrade_campaign__state.from_gdata(self.to_gdata())
 
 
-_breaker41: None = None
+_breaker43: None = None
 class software__software__upgrade_campaign_entry(yadata.MNode):
     name: str
     target_release: ?str
@@ -2410,7 +2514,7 @@ class software__software__upgrade_campaign_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return software__software__upgrade_campaign_entry.from_gdata(self.to_gdata())
 
-_breaker42: None = None
+_breaker44: None = None
 class software__software__upgrade_campaign(yadata.MKeyedList[str, software__software__upgrade_campaign_entry]):
     mut def __init__(self, elements: list[software__software__upgrade_campaign_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2449,7 +2553,7 @@ class software__software__upgrade_campaign(yadata.MKeyedList[str, software__soft
         return software__software__upgrade_campaign(elements=copied_elements)
 
 
-_breaker43: None = None
+_breaker45: None = None
 class software__software(yadata.MNode):
     upgrade_campaign: software__software__upgrade_campaign
 
@@ -2470,7 +2574,7 @@ class software__software(yadata.MNode):
         return software__software.from_gdata(self.to_gdata())
 
 
-_breaker44: None = None
+_breaker46: None = None
 class root(yadata.MNode):
     fleet: fleetmgr__fleet
     software: software__software
@@ -2518,7 +2622,7 @@ def _present(n: ?ygdata.Node) -> ?ygdata.Node:
             return n
     return None
 
-_breaker45: None = None
+_breaker47: None = None
 class fleetmgr__fleet__node__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2534,7 +2638,7 @@ class fleetmgr__fleet__node__address__initial_credentials_entry_subs(Subscriptio
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker46: None = None
+_breaker48: None = None
 proc def fleetmgr__fleet__node__address__initial_credentials_deliver(cb: action(?(node_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__node__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
     inst: ?fleetmgr__fleet__node__address__initial_credentials_entry = None
@@ -2582,7 +2686,7 @@ class fleetmgr__fleet__node__address__initial_credentials_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker47: None = None
+_breaker49: None = None
 class fleetmgr__fleet__node__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2600,7 +2704,7 @@ class fleetmgr__fleet__node__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker48: None = None
+_breaker50: None = None
 proc def fleetmgr__fleet__node__address_deliver(cb: action(?(node_name: str, address_name: str), ?fleetmgr__fleet__node__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str, address_name: str) = None
     inst: ?fleetmgr__fleet__node__address_entry = None
@@ -2647,7 +2751,7 @@ class fleetmgr__fleet__node__address_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker49: None = None
+_breaker51: None = None
 class fleetmgr__fleet__node__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2661,7 +2765,7 @@ class fleetmgr__fleet__node__credentials__key_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker50: None = None
+_breaker52: None = None
 proc def fleetmgr__fleet__node__credentials__key_deliver(cb: action(?(node_name: str, key_key: str), ?fleetmgr__fleet__node__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str, key_key: str) = None
     inst: ?fleetmgr__fleet__node__credentials__key_entry = None
@@ -2705,7 +2809,7 @@ class fleetmgr__fleet__node__credentials__key_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker51: None = None
+_breaker53: None = None
 proc def fleetmgr__fleet__node__credentials_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str) = None
     inst: ?fleetmgr__fleet__node__credentials = None
@@ -2744,7 +2848,7 @@ class fleetmgr__fleet__node__credentials_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__credentials_deliver(cb, n, err), root=self.filt())
 
-_breaker52: None = None
+_breaker54: None = None
 class fleetmgr__fleet__node__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2760,7 +2864,7 @@ class fleetmgr__fleet__node__initial_credentials_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker53: None = None
+_breaker55: None = None
 proc def fleetmgr__fleet__node__initial_credentials_deliver(cb: action(?(node_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__node__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
     inst: ?fleetmgr__fleet__node__initial_credentials_entry = None
@@ -2807,7 +2911,7 @@ class fleetmgr__fleet__node__initial_credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker54: None = None
+_breaker56: None = None
 proc def fleetmgr__fleet__node__ssh_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str) = None
     inst: ?fleetmgr__fleet__node__ssh = None
@@ -2860,7 +2964,47 @@ class fleetmgr__fleet__node__ssh_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__ssh_deliver(cb, n, err), root=self.filt())
 
-_breaker55: None = None
+_breaker57: None = None
+proc def fleetmgr__fleet__node__mock__software_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__mock__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str) = None
+    inst: ?fleetmgr__fleet__node__mock__software = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'mock'))
+            c4 = _at(c3, ygdata.Id(NS_fleetmgr, 'software'))
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = fleetmgr__fleet__node__mock__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
+class fleetmgr__fleet__node__mock__software_subs(SubscriptionNode):
+    upgrade_duration: SubscriptionNode
+    failure: SubscriptionNode
+    running_release: SubscriptionNode
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.upgrade_duration = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'upgrade-duration'), parent=path))
+        self.failure = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'failure'), parent=path))
+        self.running_release = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'running-release'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.upgrade_duration, self.failure, self.running_release]
+        return direct
+
+    def dst(self, cb: action(?(node_name: str), ?fleetmgr__fleet__node__mock__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__mock__software_deliver(cb, n, err), root=self.filt())
+
+_breaker58: None = None
 class fleetmgr__fleet__node__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -2878,7 +3022,7 @@ class fleetmgr__fleet__node__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker56: None = None
+_breaker59: None = None
 proc def fleetmgr__fleet__node__mock__module_deliver(cb: action(?(node_name: str, module_name: str), ?fleetmgr__fleet__node__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str, module_name: str) = None
     inst: ?fleetmgr__fleet__node__mock__module_entry = None
@@ -2926,7 +3070,7 @@ class fleetmgr__fleet__node__mock__module_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker57: None = None
+_breaker60: None = None
 proc def fleetmgr__fleet__node__mock_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str) = None
     inst: ?fleetmgr__fleet__node__mock = None
@@ -2946,15 +3090,17 @@ proc def fleetmgr__fleet__node__mock_deliver(cb: action(?(node_name: str), ?flee
 
 class fleetmgr__fleet__node__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
+    software: fleetmgr__fleet__node__mock__software_subs
     module: fleetmgr__fleet__node__mock__module_subs
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'enabled'), parent=path))
+        self.software = fleetmgr__fleet__node__mock__software_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'software'), parent=path))
         self.module = fleetmgr__fleet__node__mock__module_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'module'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.enabled, self.module]
+        direct: list[SubscriptionNode] = [self.enabled, self.software, self.module]
         return direct
 
     def dst(self, cb: action(?(node_name: str), ?fleetmgr__fleet__node__mock, ?Exception) -> None) -> ygdata.Dst:
@@ -2963,7 +3109,7 @@ class fleetmgr__fleet__node__mock_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__mock_deliver(cb, n, err), root=self.filt())
 
-_breaker58: None = None
+_breaker61: None = None
 proc def fleetmgr__fleet__node__debug_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str) = None
     inst: ?fleetmgr__fleet__node__debug = None
@@ -2998,7 +3144,7 @@ class fleetmgr__fleet__node__debug_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__debug_deliver(cb, n, err), root=self.filt())
 
-_breaker59: None = None
+_breaker62: None = None
 proc def fleetmgr__fleet__node__feature_flags_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str) = None
     inst: ?fleetmgr__fleet__node__feature_flags = None
@@ -3033,7 +3179,7 @@ class fleetmgr__fleet__node__feature_flags_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__feature_flags_deliver(cb, n, err), root=self.filt())
 
-_breaker60: None = None
+_breaker63: None = None
 class fleetmgr__fleet__node_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -3063,7 +3209,7 @@ class fleetmgr__fleet__node_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
 
-_breaker61: None = None
+_breaker64: None = None
 proc def fleetmgr__fleet__node_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(node_name: str) = None
     inst: ?fleetmgr__fleet__node_entry = None
@@ -3121,7 +3267,7 @@ class fleetmgr__fleet__node_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
 
-_breaker62: None = None
+_breaker65: None = None
 class fleetmgr__fleet__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3137,7 +3283,7 @@ class fleetmgr__fleet__device__address__initial_credentials_entry_subs(Subscript
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker63: None = None
+_breaker66: None = None
 proc def fleetmgr__fleet__device__address__initial_credentials_deliver(cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__device__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
     inst: ?fleetmgr__fleet__device__address__initial_credentials_entry = None
@@ -3185,7 +3331,7 @@ class fleetmgr__fleet__device__address__initial_credentials_subs(SubscriptionNod
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker64: None = None
+_breaker67: None = None
 class fleetmgr__fleet__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -3203,7 +3349,7 @@ class fleetmgr__fleet__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker65: None = None
+_breaker68: None = None
 proc def fleetmgr__fleet__device__address_deliver(cb: action(?(device_name: str, address_name: str), ?fleetmgr__fleet__device__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, address_name: str) = None
     inst: ?fleetmgr__fleet__device__address_entry = None
@@ -3250,7 +3396,7 @@ class fleetmgr__fleet__device__address_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker66: None = None
+_breaker69: None = None
 class fleetmgr__fleet__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -3264,7 +3410,7 @@ class fleetmgr__fleet__device__credentials__key_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker67: None = None
+_breaker70: None = None
 proc def fleetmgr__fleet__device__credentials__key_deliver(cb: action(?(device_name: str, key_key: str), ?fleetmgr__fleet__device__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, key_key: str) = None
     inst: ?fleetmgr__fleet__device__credentials__key_entry = None
@@ -3308,7 +3454,7 @@ class fleetmgr__fleet__device__credentials__key_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker68: None = None
+_breaker71: None = None
 proc def fleetmgr__fleet__device__credentials_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?fleetmgr__fleet__device__credentials = None
@@ -3347,7 +3493,7 @@ class fleetmgr__fleet__device__credentials_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__credentials_deliver(cb, n, err), root=self.filt())
 
-_breaker69: None = None
+_breaker72: None = None
 class fleetmgr__fleet__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3363,7 +3509,7 @@ class fleetmgr__fleet__device__initial_credentials_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker70: None = None
+_breaker73: None = None
 proc def fleetmgr__fleet__device__initial_credentials_deliver(cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__device__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
     inst: ?fleetmgr__fleet__device__initial_credentials_entry = None
@@ -3410,7 +3556,7 @@ class fleetmgr__fleet__device__initial_credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker71: None = None
+_breaker74: None = None
 proc def fleetmgr__fleet__device__ssh_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?fleetmgr__fleet__device__ssh = None
@@ -3463,7 +3609,47 @@ class fleetmgr__fleet__device__ssh_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__ssh_deliver(cb, n, err), root=self.filt())
 
-_breaker72: None = None
+_breaker75: None = None
+proc def fleetmgr__fleet__device__mock__software_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__mock__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?fleetmgr__fleet__device__mock__software = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'mock'))
+            c4 = _at(c3, ygdata.Id(NS_fleetmgr, 'software'))
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = fleetmgr__fleet__device__mock__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
+class fleetmgr__fleet__device__mock__software_subs(SubscriptionNode):
+    upgrade_duration: SubscriptionNode
+    failure: SubscriptionNode
+    running_release: SubscriptionNode
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.upgrade_duration = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'upgrade-duration'), parent=path))
+        self.failure = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'failure'), parent=path))
+        self.running_release = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'running-release'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.upgrade_duration, self.failure, self.running_release]
+        return direct
+
+    def dst(self, cb: action(?(device_name: str), ?fleetmgr__fleet__device__mock__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__mock__software_deliver(cb, n, err), root=self.filt())
+
+_breaker76: None = None
 class fleetmgr__fleet__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -3481,7 +3667,7 @@ class fleetmgr__fleet__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker73: None = None
+_breaker77: None = None
 proc def fleetmgr__fleet__device__mock__module_deliver(cb: action(?(device_name: str, module_name: str), ?fleetmgr__fleet__device__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, module_name: str) = None
     inst: ?fleetmgr__fleet__device__mock__module_entry = None
@@ -3529,7 +3715,7 @@ class fleetmgr__fleet__device__mock__module_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker74: None = None
+_breaker78: None = None
 proc def fleetmgr__fleet__device__mock_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?fleetmgr__fleet__device__mock = None
@@ -3549,15 +3735,17 @@ proc def fleetmgr__fleet__device__mock_deliver(cb: action(?(device_name: str), ?
 
 class fleetmgr__fleet__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
+    software: fleetmgr__fleet__device__mock__software_subs
     module: fleetmgr__fleet__device__mock__module_subs
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'enabled'), parent=path))
+        self.software = fleetmgr__fleet__device__mock__software_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'software'), parent=path))
         self.module = fleetmgr__fleet__device__mock__module_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'module'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.enabled, self.module]
+        direct: list[SubscriptionNode] = [self.enabled, self.software, self.module]
         return direct
 
     def dst(self, cb: action(?(device_name: str), ?fleetmgr__fleet__device__mock, ?Exception) -> None) -> ygdata.Dst:
@@ -3566,7 +3754,7 @@ class fleetmgr__fleet__device__mock_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__mock_deliver(cb, n, err), root=self.filt())
 
-_breaker75: None = None
+_breaker79: None = None
 proc def fleetmgr__fleet__device__debug_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?fleetmgr__fleet__device__debug = None
@@ -3601,7 +3789,7 @@ class fleetmgr__fleet__device__debug_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__debug_deliver(cb, n, err), root=self.filt())
 
-_breaker76: None = None
+_breaker80: None = None
 proc def fleetmgr__fleet__device__feature_flags_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?fleetmgr__fleet__device__feature_flags = None
@@ -3636,7 +3824,7 @@ class fleetmgr__fleet__device__feature_flags_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__feature_flags_deliver(cb, n, err), root=self.filt())
 
-_breaker77: None = None
+_breaker81: None = None
 class fleetmgr__fleet__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -3670,7 +3858,7 @@ class fleetmgr__fleet__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.type, self.shard, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
 
-_breaker78: None = None
+_breaker82: None = None
 proc def fleetmgr__fleet__device_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?fleetmgr__fleet__device_entry = None
@@ -3732,7 +3920,7 @@ class fleetmgr__fleet__device_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.type, self.shard, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
 
-_breaker79: None = None
+_breaker83: None = None
 proc def fleetmgr__fleet_deliver(cb: action(?fleetmgr__fleet, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     inst: ?fleetmgr__fleet = None
     if n is not None:
@@ -3765,7 +3953,7 @@ class fleetmgr__fleet_subs(SubscriptionNode):
         and an error."""
         return ygdata.Dst(lambda n, err: fleetmgr__fleet_deliver(cb, n, err), root=self.filt())
 
-_breaker80: None = None
+_breaker84: None = None
 class software__software__upgrade_campaign__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
 
@@ -3777,7 +3965,7 @@ class software__software__upgrade_campaign__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name]
         return direct
 
-_breaker81: None = None
+_breaker85: None = None
 proc def software__software__upgrade_campaign__device_deliver(cb: action(?(upgrade_campaign_name: str, device_name: str), ?software__software__upgrade_campaign__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(upgrade_campaign_name: str, device_name: str) = None
     inst: ?software__software__upgrade_campaign__device_entry = None
@@ -3818,7 +4006,7 @@ class software__software__upgrade_campaign__device_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name]
         return direct
 
-_breaker82: None = None
+_breaker86: None = None
 class software__software__upgrade_campaign__state__device_status_entry_subs(SubscriptionNode):
     device: SubscriptionNode
     status: SubscriptionNode
@@ -3834,7 +4022,7 @@ class software__software__upgrade_campaign__state__device_status_entry_subs(Subs
         direct: list[SubscriptionNode] = [self.device, self.status, self.running_release]
         return direct
 
-_breaker83: None = None
+_breaker87: None = None
 proc def software__software__upgrade_campaign__state__device_status_deliver(cb: action(?(upgrade_campaign_name: str, device_status_device: str), ?software__software__upgrade_campaign__state__device_status_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(upgrade_campaign_name: str, device_status_device: str) = None
     inst: ?software__software__upgrade_campaign__state__device_status_entry = None
@@ -3880,7 +4068,7 @@ class software__software__upgrade_campaign__state__device_status_subs(Subscripti
         direct: list[SubscriptionNode] = [self.device, self.status, self.running_release]
         return direct
 
-_breaker84: None = None
+_breaker88: None = None
 proc def software__software__upgrade_campaign__state_deliver(cb: action(?(upgrade_campaign_name: str), ?software__software__upgrade_campaign__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(upgrade_campaign_name: str) = None
     inst: ?software__software__upgrade_campaign__state = None
@@ -3923,7 +4111,7 @@ class software__software__upgrade_campaign__state_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: software__software__upgrade_campaign__state_deliver(cb, n, err), root=self.filt())
 
-_breaker85: None = None
+_breaker89: None = None
 class software__software__upgrade_campaign_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     target_release: SubscriptionNode
@@ -3947,7 +4135,7 @@ class software__software__upgrade_campaign_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.target_release, self.image_url, self.allow_staging, self.device, self.admin_state, self.state]
         return direct
 
-_breaker86: None = None
+_breaker90: None = None
 proc def software__software__upgrade_campaign_deliver(cb: action(?(upgrade_campaign_name: str), ?software__software__upgrade_campaign_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(upgrade_campaign_name: str) = None
     inst: ?software__software__upgrade_campaign_entry = None
@@ -3999,7 +4187,7 @@ class software__software__upgrade_campaign_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.target_release, self.image_url, self.allow_staging, self.device, self.admin_state, self.state]
         return direct
 
-_breaker87: None = None
+_breaker91: None = None
 proc def software__software_deliver(cb: action(?software__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     inst: ?software__software = None
     if n is not None:
@@ -4030,7 +4218,7 @@ class software__software_subs(SubscriptionNode):
         and an error."""
         return ygdata.Dst(lambda n, err: software__software_deliver(cb, n, err), root=self.filt())
 
-_breaker88: None = None
+_breaker92: None = None
 class root_subs(SubscriptionNode):
     fleet: fleetmgr__fleet_subs
     software: software__software_subs

--- a/fleetmgr/src/fleetmgr/layers/y_0_oper.act
+++ b/fleetmgr/src/fleetmgr/layers/y_0_oper.act
@@ -2498,6 +2498,26 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
 _breaker45: None = None
 class fleetmgr__fleet__node__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
@@ -2515,6 +2535,24 @@ class fleetmgr__fleet__node__address__initial_credentials_entry_subs(Subscriptio
         return direct
 
 _breaker46: None = None
+proc def fleetmgr__fleet__node__address__initial_credentials_deliver(cb: action(?(node_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__node__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?fleetmgr__fleet__node__address__initial_credentials_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            e3 = _one(_at(e2, ygdata.Id(NS_fleetmgr, 'address')), 'address')
+            e4 = _one(_at(e3, ygdata.Id(NS_fleetmgr, 'initial-credentials')), 'initial-credentials')
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), address_name=e3.get_str(ygdata.Id(NS_fleetmgr, 'name')), initial_credentials_username=e4.get_str(ygdata.Id(NS_fleetmgr, 'username')), initial_credentials_password=e4.get_str(ygdata.Id(NS_fleetmgr, 'password')), initial_credentials_key=e4.get_str(ygdata.Id(NS_fleetmgr, 'key')))
+            here = _present(e4)
+            if here is not None:
+                inst = fleetmgr__fleet__node__address__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2533,6 +2571,12 @@ class fleetmgr__fleet__node__address__initial_credentials_subs(SubscriptionNode)
         ]
         base_path = self._path!.parent
         return fleetmgr__fleet__node__address__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'initial-credentials'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(node_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__node__address__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__address__initial_credentials_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
@@ -2557,6 +2601,23 @@ class fleetmgr__fleet__node__address_entry_subs(SubscriptionNode):
         return direct
 
 _breaker48: None = None
+proc def fleetmgr__fleet__node__address_deliver(cb: action(?(node_name: str, address_name: str), ?fleetmgr__fleet__node__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str, address_name: str) = None
+    inst: ?fleetmgr__fleet__node__address_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            e3 = _one(_at(e2, ygdata.Id(NS_fleetmgr, 'address')), 'address')
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), address_name=e3.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = fleetmgr__fleet__node__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2575,6 +2636,12 @@ class fleetmgr__fleet__node__address_subs(SubscriptionNode):
         ]
         base_path = self._path!.parent
         return fleetmgr__fleet__node__address_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'address'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(node_name: str, address_name: str), ?fleetmgr__fleet__node__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__address_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
@@ -2595,6 +2662,24 @@ class fleetmgr__fleet__node__credentials__key_entry_subs(SubscriptionNode):
         return direct
 
 _breaker50: None = None
+proc def fleetmgr__fleet__node__credentials__key_deliver(cb: action(?(node_name: str, key_key: str), ?fleetmgr__fleet__node__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str, key_key: str) = None
+    inst: ?fleetmgr__fleet__node__credentials__key_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'credentials'))
+            e4 = _one(_at(c3, ygdata.Id(NS_fleetmgr, 'key')), 'key')
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), key_key=e4.get_str(ygdata.Id(NS_fleetmgr, 'key')))
+            here = _present(e4)
+            if here is not None:
+                inst = fleetmgr__fleet__node__credentials__key_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2610,11 +2695,34 @@ class fleetmgr__fleet__node__credentials__key_subs(SubscriptionNode):
         base_path = self._path!.parent
         return fleetmgr__fleet__node__credentials__key_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'key'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(node_name: str, key_key: str), ?fleetmgr__fleet__node__credentials__key_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__credentials__key_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
 _breaker51: None = None
+proc def fleetmgr__fleet__node__credentials_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str) = None
+    inst: ?fleetmgr__fleet__node__credentials = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'credentials'))
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__node__credentials.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2629,6 +2737,12 @@ class fleetmgr__fleet__node__credentials_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
+
+    def dst(self, cb: action(?(node_name: str), ?fleetmgr__fleet__node__credentials, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__credentials_deliver(cb, n, err), root=self.filt())
 
 _breaker52: None = None
 class fleetmgr__fleet__node__initial_credentials_entry_subs(SubscriptionNode):
@@ -2647,6 +2761,23 @@ class fleetmgr__fleet__node__initial_credentials_entry_subs(SubscriptionNode):
         return direct
 
 _breaker53: None = None
+proc def fleetmgr__fleet__node__initial_credentials_deliver(cb: action(?(node_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__node__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?fleetmgr__fleet__node__initial_credentials_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            e3 = _one(_at(e2, ygdata.Id(NS_fleetmgr, 'initial-credentials')), 'initial-credentials')
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), initial_credentials_username=e3.get_str(ygdata.Id(NS_fleetmgr, 'username')), initial_credentials_password=e3.get_str(ygdata.Id(NS_fleetmgr, 'password')), initial_credentials_key=e3.get_str(ygdata.Id(NS_fleetmgr, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = fleetmgr__fleet__node__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2666,11 +2797,34 @@ class fleetmgr__fleet__node__initial_credentials_subs(SubscriptionNode):
         base_path = self._path!.parent
         return fleetmgr__fleet__node__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(node_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__node__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
 _breaker54: None = None
+proc def fleetmgr__fleet__node__ssh_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str) = None
+    inst: ?fleetmgr__fleet__node__ssh = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'ssh'))
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__node__ssh.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__ssh_subs(SubscriptionNode):
     cipher: SubscriptionNode
     mac: SubscriptionNode
@@ -2700,6 +2854,12 @@ class fleetmgr__fleet__node__ssh_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
         return direct
 
+    def dst(self, cb: action(?(node_name: str), ?fleetmgr__fleet__node__ssh, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__ssh_deliver(cb, n, err), root=self.filt())
+
 _breaker55: None = None
 class fleetmgr__fleet__node__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
@@ -2719,6 +2879,24 @@ class fleetmgr__fleet__node__mock__module_entry_subs(SubscriptionNode):
         return direct
 
 _breaker56: None = None
+proc def fleetmgr__fleet__node__mock__module_deliver(cb: action(?(node_name: str, module_name: str), ?fleetmgr__fleet__node__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str, module_name: str) = None
+    inst: ?fleetmgr__fleet__node__mock__module_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'mock'))
+            e4 = _one(_at(c3, ygdata.Id(NS_fleetmgr, 'module')), 'module')
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), module_name=e4.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(e4)
+            if here is not None:
+                inst = fleetmgr__fleet__node__mock__module_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -2738,11 +2916,34 @@ class fleetmgr__fleet__node__mock__module_subs(SubscriptionNode):
         base_path = self._path!.parent
         return fleetmgr__fleet__node__mock__module_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'module'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(node_name: str, module_name: str), ?fleetmgr__fleet__node__mock__module_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__mock__module_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
 _breaker57: None = None
+proc def fleetmgr__fleet__node__mock_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str) = None
+    inst: ?fleetmgr__fleet__node__mock = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'mock'))
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__node__mock.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
     module: fleetmgr__fleet__node__mock__module_subs
@@ -2756,7 +2957,30 @@ class fleetmgr__fleet__node__mock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.module]
         return direct
 
+    def dst(self, cb: action(?(node_name: str), ?fleetmgr__fleet__node__mock, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__mock_deliver(cb, n, err), root=self.filt())
+
 _breaker58: None = None
+proc def fleetmgr__fleet__node__debug_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str) = None
+    inst: ?fleetmgr__fleet__node__debug = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'debug'))
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__node__debug.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -2768,7 +2992,30 @@ class fleetmgr__fleet__node__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
+    def dst(self, cb: action(?(node_name: str), ?fleetmgr__fleet__node__debug, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__debug_deliver(cb, n, err), root=self.filt())
+
 _breaker59: None = None
+proc def fleetmgr__fleet__node__feature_flags_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str) = None
+    inst: ?fleetmgr__fleet__node__feature_flags = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'feature-flags'))
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__node__feature_flags.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -2779,6 +3026,12 @@ class fleetmgr__fleet__node__feature_flags_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
+
+    def dst(self, cb: action(?(node_name: str), ?fleetmgr__fleet__node__feature_flags, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node__feature_flags_deliver(cb, n, err), root=self.filt())
 
 _breaker60: None = None
 class fleetmgr__fleet__node_entry_subs(SubscriptionNode):
@@ -2811,6 +3064,22 @@ class fleetmgr__fleet__node_entry_subs(SubscriptionNode):
         return direct
 
 _breaker61: None = None
+proc def fleetmgr__fleet__node_deliver(cb: action(?(node_name: str), ?fleetmgr__fleet__node_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(node_name: str) = None
+    inst: ?fleetmgr__fleet__node_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'node')), 'node')
+            keys = (node_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = fleetmgr__fleet__node_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__node_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -2842,6 +3111,12 @@ class fleetmgr__fleet__node_subs(SubscriptionNode):
         base_path = self._path!.parent
         return fleetmgr__fleet__node_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'node'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(node_name: str), ?fleetmgr__fleet__node_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__node_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
@@ -2863,6 +3138,24 @@ class fleetmgr__fleet__device__address__initial_credentials_entry_subs(Subscript
         return direct
 
 _breaker63: None = None
+proc def fleetmgr__fleet__device__address__initial_credentials_deliver(cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__device__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?fleetmgr__fleet__device__address__initial_credentials_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            e3 = _one(_at(e2, ygdata.Id(NS_fleetmgr, 'address')), 'address')
+            e4 = _one(_at(e3, ygdata.Id(NS_fleetmgr, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), address_name=e3.get_str(ygdata.Id(NS_fleetmgr, 'name')), initial_credentials_username=e4.get_str(ygdata.Id(NS_fleetmgr, 'username')), initial_credentials_password=e4.get_str(ygdata.Id(NS_fleetmgr, 'password')), initial_credentials_key=e4.get_str(ygdata.Id(NS_fleetmgr, 'key')))
+            here = _present(e4)
+            if here is not None:
+                inst = fleetmgr__fleet__device__address__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2881,6 +3174,12 @@ class fleetmgr__fleet__device__address__initial_credentials_subs(SubscriptionNod
         ]
         base_path = self._path!.parent
         return fleetmgr__fleet__device__address__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'initial-credentials'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__device__address__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__address__initial_credentials_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
@@ -2905,6 +3204,23 @@ class fleetmgr__fleet__device__address_entry_subs(SubscriptionNode):
         return direct
 
 _breaker65: None = None
+proc def fleetmgr__fleet__device__address_deliver(cb: action(?(device_name: str, address_name: str), ?fleetmgr__fleet__device__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str) = None
+    inst: ?fleetmgr__fleet__device__address_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            e3 = _one(_at(e2, ygdata.Id(NS_fleetmgr, 'address')), 'address')
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), address_name=e3.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = fleetmgr__fleet__device__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2923,6 +3239,12 @@ class fleetmgr__fleet__device__address_subs(SubscriptionNode):
         ]
         base_path = self._path!.parent
         return fleetmgr__fleet__device__address_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'address'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(device_name: str, address_name: str), ?fleetmgr__fleet__device__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__address_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
@@ -2943,6 +3265,24 @@ class fleetmgr__fleet__device__credentials__key_entry_subs(SubscriptionNode):
         return direct
 
 _breaker67: None = None
+proc def fleetmgr__fleet__device__credentials__key_deliver(cb: action(?(device_name: str, key_key: str), ?fleetmgr__fleet__device__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, key_key: str) = None
+    inst: ?fleetmgr__fleet__device__credentials__key_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'credentials'))
+            e4 = _one(_at(c3, ygdata.Id(NS_fleetmgr, 'key')), 'key')
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), key_key=e4.get_str(ygdata.Id(NS_fleetmgr, 'key')))
+            here = _present(e4)
+            if here is not None:
+                inst = fleetmgr__fleet__device__credentials__key_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2958,11 +3298,34 @@ class fleetmgr__fleet__device__credentials__key_subs(SubscriptionNode):
         base_path = self._path!.parent
         return fleetmgr__fleet__device__credentials__key_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'key'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, key_key: str), ?fleetmgr__fleet__device__credentials__key_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__credentials__key_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
 _breaker68: None = None
+proc def fleetmgr__fleet__device__credentials_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?fleetmgr__fleet__device__credentials = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'credentials'))
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__device__credentials.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2977,6 +3340,12 @@ class fleetmgr__fleet__device__credentials_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
+
+    def dst(self, cb: action(?(device_name: str), ?fleetmgr__fleet__device__credentials, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__credentials_deliver(cb, n, err), root=self.filt())
 
 _breaker69: None = None
 class fleetmgr__fleet__device__initial_credentials_entry_subs(SubscriptionNode):
@@ -2995,6 +3364,23 @@ class fleetmgr__fleet__device__initial_credentials_entry_subs(SubscriptionNode):
         return direct
 
 _breaker70: None = None
+proc def fleetmgr__fleet__device__initial_credentials_deliver(cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__device__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?fleetmgr__fleet__device__initial_credentials_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            e3 = _one(_at(e2, ygdata.Id(NS_fleetmgr, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), initial_credentials_username=e3.get_str(ygdata.Id(NS_fleetmgr, 'username')), initial_credentials_password=e3.get_str(ygdata.Id(NS_fleetmgr, 'password')), initial_credentials_key=e3.get_str(ygdata.Id(NS_fleetmgr, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = fleetmgr__fleet__device__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3014,11 +3400,34 @@ class fleetmgr__fleet__device__initial_credentials_subs(SubscriptionNode):
         base_path = self._path!.parent
         return fleetmgr__fleet__device__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?fleetmgr__fleet__device__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
 _breaker71: None = None
+proc def fleetmgr__fleet__device__ssh_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?fleetmgr__fleet__device__ssh = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'ssh'))
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__device__ssh.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__ssh_subs(SubscriptionNode):
     cipher: SubscriptionNode
     mac: SubscriptionNode
@@ -3048,6 +3457,12 @@ class fleetmgr__fleet__device__ssh_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?fleetmgr__fleet__device__ssh, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__ssh_deliver(cb, n, err), root=self.filt())
+
 _breaker72: None = None
 class fleetmgr__fleet__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
@@ -3067,6 +3482,24 @@ class fleetmgr__fleet__device__mock__module_entry_subs(SubscriptionNode):
         return direct
 
 _breaker73: None = None
+proc def fleetmgr__fleet__device__mock__module_deliver(cb: action(?(device_name: str, module_name: str), ?fleetmgr__fleet__device__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, module_name: str) = None
+    inst: ?fleetmgr__fleet__device__mock__module_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'mock'))
+            e4 = _one(_at(c3, ygdata.Id(NS_fleetmgr, 'module')), 'module')
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')), module_name=e4.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(e4)
+            if here is not None:
+                inst = fleetmgr__fleet__device__mock__module_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -3086,11 +3519,34 @@ class fleetmgr__fleet__device__mock__module_subs(SubscriptionNode):
         base_path = self._path!.parent
         return fleetmgr__fleet__device__mock__module_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'module'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, module_name: str), ?fleetmgr__fleet__device__mock__module_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__mock__module_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
 _breaker74: None = None
+proc def fleetmgr__fleet__device__mock_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?fleetmgr__fleet__device__mock = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'mock'))
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__device__mock.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
     module: fleetmgr__fleet__device__mock__module_subs
@@ -3104,7 +3560,30 @@ class fleetmgr__fleet__device__mock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.module]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?fleetmgr__fleet__device__mock, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__mock_deliver(cb, n, err), root=self.filt())
+
 _breaker75: None = None
+proc def fleetmgr__fleet__device__debug_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?fleetmgr__fleet__device__debug = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'debug'))
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__device__debug.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -3116,7 +3595,30 @@ class fleetmgr__fleet__device__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
+    def dst(self, cb: action(?(device_name: str), ?fleetmgr__fleet__device__debug, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__debug_deliver(cb, n, err), root=self.filt())
+
 _breaker76: None = None
+proc def fleetmgr__fleet__device__feature_flags_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?fleetmgr__fleet__device__feature_flags = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr, 'feature-flags'))
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = fleetmgr__fleet__device__feature_flags.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -3127,6 +3629,12 @@ class fleetmgr__fleet__device__feature_flags_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
+
+    def dst(self, cb: action(?(device_name: str), ?fleetmgr__fleet__device__feature_flags, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device__feature_flags_deliver(cb, n, err), root=self.filt())
 
 _breaker77: None = None
 class fleetmgr__fleet__device_entry_subs(SubscriptionNode):
@@ -3163,6 +3671,22 @@ class fleetmgr__fleet__device_entry_subs(SubscriptionNode):
         return direct
 
 _breaker78: None = None
+proc def fleetmgr__fleet__device_deliver(cb: action(?(device_name: str), ?fleetmgr__fleet__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?fleetmgr__fleet__device_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            e2 = _one(_at(c1, ygdata.Id(NS_fleetmgr, 'device')), 'device')
+            keys = (device_name=e2.get_str(ygdata.Id(NS_fleetmgr, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = fleetmgr__fleet__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class fleetmgr__fleet__device_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -3198,11 +3722,30 @@ class fleetmgr__fleet__device_subs(SubscriptionNode):
         base_path = self._path!.parent
         return fleetmgr__fleet__device_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str), ?fleetmgr__fleet__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.type, self.shard, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags]
         return direct
 
 _breaker79: None = None
+proc def fleetmgr__fleet_deliver(cb: action(?fleetmgr__fleet, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?fleetmgr__fleet = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_fleetmgr, 'fleet'))
+            here = _present(c1)
+            if here is not None:
+                inst = fleetmgr__fleet.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class fleetmgr__fleet_subs(SubscriptionNode):
     node: fleetmgr__fleet__node_subs
     device: fleetmgr__fleet__device_subs
@@ -3215,6 +3758,12 @@ class fleetmgr__fleet_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.node, self.device]
         return direct
+
+    def dst(self, cb: action(?fleetmgr__fleet, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: fleetmgr__fleet_deliver(cb, n, err), root=self.filt())
 
 _breaker80: None = None
 class software__software__upgrade_campaign__device_entry_subs(SubscriptionNode):
@@ -3229,6 +3778,23 @@ class software__software__upgrade_campaign__device_entry_subs(SubscriptionNode):
         return direct
 
 _breaker81: None = None
+proc def software__software__upgrade_campaign__device_deliver(cb: action(?(upgrade_campaign_name: str, device_name: str), ?software__software__upgrade_campaign__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(upgrade_campaign_name: str, device_name: str) = None
+    inst: ?software__software__upgrade_campaign__device_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_software, 'software'))
+            e2 = _one(_at(c1, ygdata.Id(NS_software, 'upgrade-campaign')), 'upgrade-campaign')
+            e3 = _one(_at(e2, ygdata.Id(NS_software, 'device')), 'device')
+            keys = (upgrade_campaign_name=e2.get_str(ygdata.Id(NS_software, 'name')), device_name=e3.get_str(ygdata.Id(NS_software, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = software__software__upgrade_campaign__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class software__software__upgrade_campaign__device_subs(SubscriptionNode):
     name: SubscriptionNode
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -3241,6 +3807,12 @@ class software__software__upgrade_campaign__device_subs(SubscriptionNode):
         ]
         base_path = self._path!.parent
         return software__software__upgrade_campaign__device_entry_subs(SubscriptionPath(ygdata.Id(NS_software, 'device'), predicates=predicates, parent=base_path))
+
+    def dst(self, cb: action(?(upgrade_campaign_name: str, device_name: str), ?software__software__upgrade_campaign__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: software__software__upgrade_campaign__device_deliver(cb, n, err), root=self.filt())
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name]
@@ -3263,6 +3835,24 @@ class software__software__upgrade_campaign__state__device_status_entry_subs(Subs
         return direct
 
 _breaker83: None = None
+proc def software__software__upgrade_campaign__state__device_status_deliver(cb: action(?(upgrade_campaign_name: str, device_status_device: str), ?software__software__upgrade_campaign__state__device_status_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(upgrade_campaign_name: str, device_status_device: str) = None
+    inst: ?software__software__upgrade_campaign__state__device_status_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_software, 'software'))
+            e2 = _one(_at(c1, ygdata.Id(NS_software, 'upgrade-campaign')), 'upgrade-campaign')
+            c3 = _at(e2, ygdata.Id(NS_software, 'state'))
+            e4 = _one(_at(c3, ygdata.Id(NS_software, 'device-status')), 'device-status')
+            keys = (upgrade_campaign_name=e2.get_str(ygdata.Id(NS_software, 'name')), device_status_device=e4.get_str(ygdata.Id(NS_software, 'device')))
+            here = _present(e4)
+            if here is not None:
+                inst = software__software__upgrade_campaign__state__device_status_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class software__software__upgrade_campaign__state__device_status_subs(SubscriptionNode):
     device: SubscriptionNode
     status: SubscriptionNode
@@ -3280,11 +3870,34 @@ class software__software__upgrade_campaign__state__device_status_subs(Subscripti
         base_path = self._path!.parent
         return software__software__upgrade_campaign__state__device_status_entry_subs(SubscriptionPath(ygdata.Id(NS_software, 'device-status'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(upgrade_campaign_name: str, device_status_device: str), ?software__software__upgrade_campaign__state__device_status_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: software__software__upgrade_campaign__state__device_status_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.device, self.status, self.running_release]
         return direct
 
 _breaker84: None = None
+proc def software__software__upgrade_campaign__state_deliver(cb: action(?(upgrade_campaign_name: str), ?software__software__upgrade_campaign__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(upgrade_campaign_name: str) = None
+    inst: ?software__software__upgrade_campaign__state = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_software, 'software'))
+            e2 = _one(_at(c1, ygdata.Id(NS_software, 'upgrade-campaign')), 'upgrade-campaign')
+            c3 = _at(e2, ygdata.Id(NS_software, 'state'))
+            keys = (upgrade_campaign_name=e2.get_str(ygdata.Id(NS_software, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = software__software__upgrade_campaign__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class software__software__upgrade_campaign__state_subs(SubscriptionNode):
     total: SubscriptionNode
     in_progress: SubscriptionNode
@@ -3303,6 +3916,12 @@ class software__software__upgrade_campaign__state_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.total, self.in_progress, self.succeeded, self.failed, self.device_status]
         return direct
+
+    def dst(self, cb: action(?(upgrade_campaign_name: str), ?software__software__upgrade_campaign__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: software__software__upgrade_campaign__state_deliver(cb, n, err), root=self.filt())
 
 _breaker85: None = None
 class software__software__upgrade_campaign_entry_subs(SubscriptionNode):
@@ -3329,6 +3948,22 @@ class software__software__upgrade_campaign_entry_subs(SubscriptionNode):
         return direct
 
 _breaker86: None = None
+proc def software__software__upgrade_campaign_deliver(cb: action(?(upgrade_campaign_name: str), ?software__software__upgrade_campaign_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(upgrade_campaign_name: str) = None
+    inst: ?software__software__upgrade_campaign_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_software, 'software'))
+            e2 = _one(_at(c1, ygdata.Id(NS_software, 'upgrade-campaign')), 'upgrade-campaign')
+            keys = (upgrade_campaign_name=e2.get_str(ygdata.Id(NS_software, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = software__software__upgrade_campaign_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class software__software__upgrade_campaign_subs(SubscriptionNode):
     name: SubscriptionNode
     target_release: SubscriptionNode
@@ -3354,11 +3989,30 @@ class software__software__upgrade_campaign_subs(SubscriptionNode):
         base_path = self._path!.parent
         return software__software__upgrade_campaign_entry_subs(SubscriptionPath(ygdata.Id(NS_software, 'upgrade-campaign'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(upgrade_campaign_name: str), ?software__software__upgrade_campaign_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: software__software__upgrade_campaign_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.target_release, self.image_url, self.allow_staging, self.device, self.admin_state, self.state]
         return direct
 
 _breaker87: None = None
+proc def software__software_deliver(cb: action(?software__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?software__software = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_software, 'software'))
+            here = _present(c1)
+            if here is not None:
+                inst = software__software.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class software__software_subs(SubscriptionNode):
     upgrade_campaign: software__software__upgrade_campaign_subs
 
@@ -3369,6 +4023,12 @@ class software__software_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.upgrade_campaign]
         return direct
+
+    def dst(self, cb: action(?software__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: software__software_deliver(cb, n, err), root=self.filt())
 
 _breaker88: None = None
 class root_subs(SubscriptionNode):
@@ -3386,17 +4046,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/fleetmgr/src/fleetmgr/layers/y_1.act
+++ b/fleetmgr/src/fleetmgr/layers/y_1.act
@@ -176,6 +176,11 @@ SRC_DNODE_CHILD_24: DLeaf = DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr
 
 SRC_DNODE_CHILD_25: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -377,6 +382,46 @@ SRC_YANG_1: str = r"""module fleetmgr-types {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -3205,6 +3250,31 @@ class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
 
 
 _breaker33: None = None
+class stratoweave_rfs__rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str=None, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure if failure is not None else "none"
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'fleetmgr-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'running-release')))
+        return stratoweave_rfs__rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker34: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: str
@@ -3228,7 +3298,7 @@ class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker34: None = None
+_breaker35: None = None
 class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3262,13 +3332,15 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
         return stratoweave_rfs__rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker35: None = None
+_breaker36: None = None
 class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     enabled: bool
+    software: stratoweave_rfs__rfs__device__mock__software
     module: stratoweave_rfs__rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool=None, module: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool=None, software: ?stratoweave_rfs__rfs__device__mock__software=None, module: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled if enabled is not None else False
+        self.software = software if software is not None else stratoweave_rfs__rfs__device__mock__software()
         self.module = stratoweave_rfs__rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -3277,7 +3349,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'enabled')), module=stratoweave_rfs__rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'module'))))
+            return stratoweave_rfs__rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'enabled')), software=stratoweave_rfs__rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'software'))), module=stratoweave_rfs__rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'module'))))
         return stratoweave_rfs__rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__rfs__device__mock:
@@ -3285,7 +3357,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker36: None = None
+_breaker37: None = None
 class stratoweave_rfs__rfs__device__debug(yadata.MNode):
     connection: bool
 
@@ -3306,7 +3378,7 @@ class stratoweave_rfs__rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker37: None = None
+_breaker38: None = None
 class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: bool
 
@@ -3327,7 +3399,7 @@ class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker38: None = None
+_breaker39: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -3347,7 +3419,7 @@ class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker39: None = None
+_breaker40: None = None
 class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -3380,7 +3452,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
         return stratoweave_rfs__rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker40: None = None
+_breaker41: None = None
 class stratoweave_rfs__rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -3409,7 +3481,7 @@ class stratoweave_rfs__rfs__device__software(yadata.MNode):
         return stratoweave_rfs__rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker41: None = None
+_breaker42: None = None
 class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     name: str
     type: str
@@ -3449,7 +3521,7 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker42: None = None
+_breaker43: None = None
 class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3486,7 +3558,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
         return stratoweave_rfs__rfs__device(elements=copied_elements)
 
 
-_breaker43: None = None
+_breaker44: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
     flotilla_status: stratoweave_rfs__rfs__flotilla_status
@@ -3508,7 +3580,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker44: None = None
+_breaker45: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3539,7 +3611,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker45: None = None
+_breaker46: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs

--- a/fleetmgr/src/fleetmgr/layers/y_1.act
+++ b/fleetmgr/src/fleetmgr/layers/y_1.act
@@ -75,6 +75,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -623,6 +628,46 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -2548,6 +2593,31 @@ class stratoweave_rfs__device__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class stratoweave_rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str=None, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure if failure is not None else "none"
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'running-release')))
+        return stratoweave_rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: str
@@ -2571,7 +2641,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2605,13 +2675,15 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: bool
+    software: stratoweave_rfs__device__mock__software
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool=None, software: ?stratoweave_rfs__device__mock__software=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled if enabled is not None else False
+        self.software = software if software is not None else stratoweave_rfs__device__mock__software()
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2620,7 +2692,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), software=stratoweave_rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_stratoweave_rfs, 'software'))), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:
@@ -2628,7 +2700,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class stratoweave_rfs__device__debug(yadata.MNode):
     connection: bool
 
@@ -2649,7 +2721,7 @@ class stratoweave_rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class stratoweave_rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: bool
 
@@ -2670,7 +2742,7 @@ class stratoweave_rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -2690,7 +2762,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -2723,7 +2795,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
         return stratoweave_rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class stratoweave_rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -2752,7 +2824,7 @@ class stratoweave_rfs__device__software(yadata.MNode):
         return stratoweave_rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker19: None = None
+_breaker20: None = None
 class stratoweave_rfs__device_entry(yadata.MNode):
     name: str
     description: ?str
@@ -2792,7 +2864,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker20: None = None
+_breaker21: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2830,7 +2902,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
         return stratoweave_rfs__device(elements=copied_elements)
 
 
-_breaker21: None = None
+_breaker22: None = None
 class stratoweave_rfs__rfs__flotilla_status(yadata.MNode):
     enabled: bool
 
@@ -2851,7 +2923,7 @@ class stratoweave_rfs__rfs__flotilla_status(yadata.MNode):
         return stratoweave_rfs__rfs__flotilla_status.from_gdata(self.to_gdata())
 
 
-_breaker22: None = None
+_breaker23: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -2873,7 +2945,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_entry(yadata.MN
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker23: None = None
+_breaker24: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -2904,7 +2976,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedLi
         return stratoweave_rfs__rfs__device__address__initial_credentials(elements=copied_elements)
 
 
-_breaker24: None = None
+_breaker25: None = None
 class stratoweave_rfs__rfs__device__address_entry(yadata.MNode):
     name: str
     address: str
@@ -2928,7 +3000,7 @@ class stratoweave_rfs__rfs__device__address_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker25: None = None
+_breaker26: None = None
 class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2962,7 +3034,7 @@ class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__rfs__device__address(elements=copied_elements)
 
 
-_breaker26: None = None
+_breaker27: None = None
 class stratoweave_rfs__rfs__device__credentials__key_entry(yadata.MNode):
     key: str
     private_key: ?str
@@ -2982,7 +3054,7 @@ class stratoweave_rfs__rfs__device__credentials__key_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker27: None = None
+_breaker28: None = None
 class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__credentials__key_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
@@ -3015,7 +3087,7 @@ class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stra
         return stratoweave_rfs__rfs__device__credentials__key(elements=copied_elements)
 
 
-_breaker28: None = None
+_breaker29: None = None
 class stratoweave_rfs__rfs__device__credentials(yadata.MNode):
     username: str
     password: ?str
@@ -3040,7 +3112,7 @@ class stratoweave_rfs__rfs__device__credentials(yadata.MNode):
         return stratoweave_rfs__rfs__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker29: None = None
+_breaker30: None = None
 class stratoweave_rfs__rfs__device__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -3062,7 +3134,7 @@ class stratoweave_rfs__rfs__device__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker30: None = None
+_breaker31: None = None
 class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -3093,7 +3165,7 @@ class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(usern
         return stratoweave_rfs__rfs__device__initial_credentials(elements=copied_elements)
 
 
-_breaker31: None = None
+_breaker32: None = None
 class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
     cipher: list[str]
     mac: list[str]
@@ -3132,7 +3204,7 @@ class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
         return stratoweave_rfs__rfs__device__ssh.from_gdata(self.to_gdata())
 
 
-_breaker32: None = None
+_breaker33: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: str
@@ -3156,7 +3228,7 @@ class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker33: None = None
+_breaker34: None = None
 class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3190,7 +3262,7 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
         return stratoweave_rfs__rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker34: None = None
+_breaker35: None = None
 class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     enabled: bool
     module: stratoweave_rfs__rfs__device__mock__module
@@ -3213,7 +3285,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker35: None = None
+_breaker36: None = None
 class stratoweave_rfs__rfs__device__debug(yadata.MNode):
     connection: bool
 
@@ -3234,7 +3306,7 @@ class stratoweave_rfs__rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker36: None = None
+_breaker37: None = None
 class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: bool
 
@@ -3255,7 +3327,7 @@ class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker37: None = None
+_breaker38: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -3275,7 +3347,7 @@ class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker38: None = None
+_breaker39: None = None
 class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -3308,7 +3380,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
         return stratoweave_rfs__rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker39: None = None
+_breaker40: None = None
 class stratoweave_rfs__rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -3337,7 +3409,7 @@ class stratoweave_rfs__rfs__device__software(yadata.MNode):
         return stratoweave_rfs__rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker40: None = None
+_breaker41: None = None
 class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     name: str
     type: str
@@ -3377,7 +3449,7 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker41: None = None
+_breaker42: None = None
 class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3414,7 +3486,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
         return stratoweave_rfs__rfs__device(elements=copied_elements)
 
 
-_breaker42: None = None
+_breaker43: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
     flotilla_status: stratoweave_rfs__rfs__flotilla_status
@@ -3436,7 +3508,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker43: None = None
+_breaker44: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3467,7 +3539,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker44: None = None
+_breaker45: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs

--- a/fleetmgr/src/fleetmgr/layers/y_1_loose.act
+++ b/fleetmgr/src/fleetmgr/layers/y_1_loose.act
@@ -176,6 +176,11 @@ SRC_DNODE_CHILD_24: DLeaf = DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr
 
 SRC_DNODE_CHILD_25: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -377,6 +382,46 @@ SRC_YANG_1: str = r"""module fleetmgr-types {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -3207,6 +3252,31 @@ class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
 
 
 _breaker33: None = None
+class stratoweave_rfs__rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'fleetmgr-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'running-release')))
+        return stratoweave_rfs__rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker34: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -3230,7 +3300,7 @@ class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker34: None = None
+_breaker35: None = None
 class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3265,13 +3335,15 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
         return stratoweave_rfs__rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker35: None = None
+_breaker36: None = None
 class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     enabled: ?bool
+    software: stratoweave_rfs__rfs__device__mock__software
     module: stratoweave_rfs__rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?stratoweave_rfs__rfs__device__mock__software=None, module: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else stratoweave_rfs__rfs__device__mock__software()
         self.module = stratoweave_rfs__rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -3280,7 +3352,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'enabled')), module=stratoweave_rfs__rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'module'))))
+            return stratoweave_rfs__rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'enabled')), software=stratoweave_rfs__rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'software'))), module=stratoweave_rfs__rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'module'))))
         return stratoweave_rfs__rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__rfs__device__mock:
@@ -3288,7 +3360,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker36: None = None
+_breaker37: None = None
 class stratoweave_rfs__rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -3309,7 +3381,7 @@ class stratoweave_rfs__rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker37: None = None
+_breaker38: None = None
 class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -3330,7 +3402,7 @@ class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker38: None = None
+_breaker39: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -3350,7 +3422,7 @@ class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker39: None = None
+_breaker40: None = None
 class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -3383,7 +3455,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
         return stratoweave_rfs__rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker40: None = None
+_breaker41: None = None
 class stratoweave_rfs__rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -3412,7 +3484,7 @@ class stratoweave_rfs__rfs__device__software(yadata.MNode):
         return stratoweave_rfs__rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker41: None = None
+_breaker42: None = None
 class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -3452,7 +3524,7 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker42: None = None
+_breaker43: None = None
 class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3489,7 +3561,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
         return stratoweave_rfs__rfs__device(elements=copied_elements)
 
 
-_breaker43: None = None
+_breaker44: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
     flotilla_status: stratoweave_rfs__rfs__flotilla_status
@@ -3511,7 +3583,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker44: None = None
+_breaker45: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3542,7 +3614,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker45: None = None
+_breaker46: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs

--- a/fleetmgr/src/fleetmgr/layers/y_1_loose.act
+++ b/fleetmgr/src/fleetmgr/layers/y_1_loose.act
@@ -75,6 +75,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -623,6 +628,46 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -2549,6 +2594,31 @@ class stratoweave_rfs__device__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class stratoweave_rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'running-release')))
+        return stratoweave_rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -2572,7 +2642,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2607,13 +2677,15 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: ?bool
+    software: stratoweave_rfs__device__mock__software
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?stratoweave_rfs__device__mock__software=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else stratoweave_rfs__device__mock__software()
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2622,7 +2694,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), software=stratoweave_rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_stratoweave_rfs, 'software'))), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:
@@ -2630,7 +2702,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class stratoweave_rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -2651,7 +2723,7 @@ class stratoweave_rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class stratoweave_rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -2672,7 +2744,7 @@ class stratoweave_rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -2692,7 +2764,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -2725,7 +2797,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
         return stratoweave_rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class stratoweave_rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -2754,7 +2826,7 @@ class stratoweave_rfs__device__software(yadata.MNode):
         return stratoweave_rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker19: None = None
+_breaker20: None = None
 class stratoweave_rfs__device_entry(yadata.MNode):
     name: str
     description: ?str
@@ -2794,7 +2866,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker20: None = None
+_breaker21: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2831,7 +2903,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
         return stratoweave_rfs__device(elements=copied_elements)
 
 
-_breaker21: None = None
+_breaker22: None = None
 class stratoweave_rfs__rfs__flotilla_status(yadata.MNode):
     enabled: ?bool
 
@@ -2852,7 +2924,7 @@ class stratoweave_rfs__rfs__flotilla_status(yadata.MNode):
         return stratoweave_rfs__rfs__flotilla_status.from_gdata(self.to_gdata())
 
 
-_breaker22: None = None
+_breaker23: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -2874,7 +2946,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_entry(yadata.MN
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker23: None = None
+_breaker24: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -2905,7 +2977,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedLi
         return stratoweave_rfs__rfs__device__address__initial_credentials(elements=copied_elements)
 
 
-_breaker24: None = None
+_breaker25: None = None
 class stratoweave_rfs__rfs__device__address_entry(yadata.MNode):
     name: str
     address: ?str
@@ -2929,7 +3001,7 @@ class stratoweave_rfs__rfs__device__address_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker25: None = None
+_breaker26: None = None
 class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2964,7 +3036,7 @@ class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__rfs__device__address(elements=copied_elements)
 
 
-_breaker26: None = None
+_breaker27: None = None
 class stratoweave_rfs__rfs__device__credentials__key_entry(yadata.MNode):
     key: str
     private_key: ?str
@@ -2984,7 +3056,7 @@ class stratoweave_rfs__rfs__device__credentials__key_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker27: None = None
+_breaker28: None = None
 class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__credentials__key_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
@@ -3017,7 +3089,7 @@ class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stra
         return stratoweave_rfs__rfs__device__credentials__key(elements=copied_elements)
 
 
-_breaker28: None = None
+_breaker29: None = None
 class stratoweave_rfs__rfs__device__credentials(yadata.MNode):
     username: ?str
     password: ?str
@@ -3042,7 +3114,7 @@ class stratoweave_rfs__rfs__device__credentials(yadata.MNode):
         return stratoweave_rfs__rfs__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker29: None = None
+_breaker30: None = None
 class stratoweave_rfs__rfs__device__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -3064,7 +3136,7 @@ class stratoweave_rfs__rfs__device__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker30: None = None
+_breaker31: None = None
 class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -3095,7 +3167,7 @@ class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(usern
         return stratoweave_rfs__rfs__device__initial_credentials(elements=copied_elements)
 
 
-_breaker31: None = None
+_breaker32: None = None
 class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
     cipher: list[str]
     mac: list[str]
@@ -3134,7 +3206,7 @@ class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
         return stratoweave_rfs__rfs__device__ssh.from_gdata(self.to_gdata())
 
 
-_breaker32: None = None
+_breaker33: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -3158,7 +3230,7 @@ class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker33: None = None
+_breaker34: None = None
 class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3193,7 +3265,7 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
         return stratoweave_rfs__rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker34: None = None
+_breaker35: None = None
 class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     enabled: ?bool
     module: stratoweave_rfs__rfs__device__mock__module
@@ -3216,7 +3288,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker35: None = None
+_breaker36: None = None
 class stratoweave_rfs__rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -3237,7 +3309,7 @@ class stratoweave_rfs__rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker36: None = None
+_breaker37: None = None
 class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -3258,7 +3330,7 @@ class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker37: None = None
+_breaker38: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -3278,7 +3350,7 @@ class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker38: None = None
+_breaker39: None = None
 class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -3311,7 +3383,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
         return stratoweave_rfs__rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker39: None = None
+_breaker40: None = None
 class stratoweave_rfs__rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -3340,7 +3412,7 @@ class stratoweave_rfs__rfs__device__software(yadata.MNode):
         return stratoweave_rfs__rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker40: None = None
+_breaker41: None = None
 class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -3380,7 +3452,7 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker41: None = None
+_breaker42: None = None
 class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3417,7 +3489,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
         return stratoweave_rfs__rfs__device(elements=copied_elements)
 
 
-_breaker42: None = None
+_breaker43: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
     flotilla_status: stratoweave_rfs__rfs__flotilla_status
@@ -3439,7 +3511,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker43: None = None
+_breaker44: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3470,7 +3542,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker44: None = None
+_breaker45: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs

--- a/fleetmgr/src/fleetmgr/layers/y_1_oper.act
+++ b/fleetmgr/src/fleetmgr/layers/y_1_oper.act
@@ -213,6 +213,11 @@ SRC_DNODE_CHILD_31: DLeaf = DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr
 
 SRC_DNODE_CHILD_32: DContainer = DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='fleetmgr-rfs', namespace='urn:fleetmgr:rfs', prefix='fleetmgr-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -414,6 +419,46 @@ SRC_YANG_1: str = r"""module fleetmgr-types {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -3496,6 +3541,31 @@ class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
 
 
 _breaker42: None = None
+class stratoweave_rfs__rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'fleetmgr-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_fleetmgr_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_fleetmgr_rfs, 'running-release')))
+        return stratoweave_rfs__rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker43: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -3519,7 +3589,7 @@ class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker43: None = None
+_breaker44: None = None
 class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3554,13 +3624,15 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
         return stratoweave_rfs__rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker44: None = None
+_breaker45: None = None
 class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     enabled: ?bool
+    software: stratoweave_rfs__rfs__device__mock__software
     module: stratoweave_rfs__rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?stratoweave_rfs__rfs__device__mock__software=None, module: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else stratoweave_rfs__rfs__device__mock__software()
         self.module = stratoweave_rfs__rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -3569,7 +3641,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'enabled')), module=stratoweave_rfs__rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'module'))))
+            return stratoweave_rfs__rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_fleetmgr_rfs, 'enabled')), software=stratoweave_rfs__rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_fleetmgr_rfs, 'software'))), module=stratoweave_rfs__rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_fleetmgr_rfs, 'module'))))
         return stratoweave_rfs__rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__rfs__device__mock:
@@ -3577,7 +3649,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker45: None = None
+_breaker46: None = None
 class stratoweave_rfs__rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -3598,7 +3670,7 @@ class stratoweave_rfs__rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker46: None = None
+_breaker47: None = None
 class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -3619,7 +3691,7 @@ class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker47: None = None
+_breaker48: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -3639,7 +3711,7 @@ class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker48: None = None
+_breaker49: None = None
 class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -3672,7 +3744,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
         return stratoweave_rfs__rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker49: None = None
+_breaker50: None = None
 class stratoweave_rfs__rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -3701,7 +3773,7 @@ class stratoweave_rfs__rfs__device__software(yadata.MNode):
         return stratoweave_rfs__rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker50: None = None
+_breaker51: None = None
 class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -3741,7 +3813,7 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker51: None = None
+_breaker52: None = None
 class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3778,7 +3850,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
         return stratoweave_rfs__rfs__device(elements=copied_elements)
 
 
-_breaker52: None = None
+_breaker53: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
     flotilla_status: stratoweave_rfs__rfs__flotilla_status
@@ -3800,7 +3872,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker53: None = None
+_breaker54: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3831,7 +3903,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker54: None = None
+_breaker55: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
@@ -3879,7 +3951,7 @@ def _present(n: ?ygdata.Node) -> ?ygdata.Node:
             return n
     return None
 
-_breaker55: None = None
+_breaker56: None = None
 class stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3895,7 +3967,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry_subs(Subscript
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker56: None = None
+_breaker57: None = None
 proc def stratoweave_rfs__device__address__initial_credentials_deliver(cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
     inst: ?stratoweave_rfs__device__address__initial_credentials_entry = None
@@ -3942,7 +4014,7 @@ class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNod
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker57: None = None
+_breaker58: None = None
 class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -3960,7 +4032,7 @@ class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker58: None = None
+_breaker59: None = None
 proc def stratoweave_rfs__device__address_deliver(cb: action(?(device_name: str, address_name: str), ?stratoweave_rfs__device__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, address_name: str) = None
     inst: ?stratoweave_rfs__device__address_entry = None
@@ -4006,7 +4078,7 @@ class stratoweave_rfs__device__address_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker59: None = None
+_breaker60: None = None
 class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -4020,7 +4092,7 @@ class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker60: None = None
+_breaker61: None = None
 proc def stratoweave_rfs__device__credentials__key_deliver(cb: action(?(device_name: str, key_key: str), ?stratoweave_rfs__device__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, key_key: str) = None
     inst: ?stratoweave_rfs__device__credentials__key_entry = None
@@ -4063,7 +4135,7 @@ class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker61: None = None
+_breaker62: None = None
 proc def stratoweave_rfs__device__credentials_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__credentials = None
@@ -4101,7 +4173,7 @@ class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__credentials_deliver(cb, n, err), root=self.filt())
 
-_breaker62: None = None
+_breaker63: None = None
 class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4117,7 +4189,7 @@ class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker63: None = None
+_breaker64: None = None
 proc def stratoweave_rfs__device__initial_credentials_deliver(cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
     inst: ?stratoweave_rfs__device__initial_credentials_entry = None
@@ -4163,7 +4235,7 @@ class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker64: None = None
+_breaker65: None = None
 proc def stratoweave_rfs__device__ssh_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__ssh = None
@@ -4215,7 +4287,7 @@ class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__ssh_deliver(cb, n, err), root=self.filt())
 
-_breaker65: None = None
+_breaker66: None = None
 proc def stratoweave_rfs__device__mock__software_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__mock__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__mock__software = None
@@ -4254,7 +4326,7 @@ class stratoweave_rfs__device__mock__software_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock__software_deliver(cb, n, err), root=self.filt())
 
-_breaker66: None = None
+_breaker67: None = None
 class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -4272,7 +4344,7 @@ class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker67: None = None
+_breaker68: None = None
 proc def stratoweave_rfs__device__mock__module_deliver(cb: action(?(device_name: str, module_name: str), ?stratoweave_rfs__device__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, module_name: str) = None
     inst: ?stratoweave_rfs__device__mock__module_entry = None
@@ -4319,7 +4391,7 @@ class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker68: None = None
+_breaker69: None = None
 proc def stratoweave_rfs__device__mock_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__mock = None
@@ -4357,7 +4429,7 @@ class stratoweave_rfs__device__mock_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock_deliver(cb, n, err), root=self.filt())
 
-_breaker69: None = None
+_breaker70: None = None
 proc def stratoweave_rfs__device__debug_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__debug = None
@@ -4391,7 +4463,7 @@ class stratoweave_rfs__device__debug_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__debug_deliver(cb, n, err), root=self.filt())
 
-_breaker70: None = None
+_breaker71: None = None
 proc def stratoweave_rfs__device__feature_flags_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__feature_flags = None
@@ -4425,7 +4497,7 @@ class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__feature_flags_deliver(cb, n, err), root=self.filt())
 
-_breaker71: None = None
+_breaker72: None = None
 class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -4439,7 +4511,7 @@ class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker72: None = None
+_breaker73: None = None
 proc def stratoweave_rfs__device__software__veto_deliver(cb: action(?(device_name: str, veto_holder: str), ?stratoweave_rfs__device__software__veto_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, veto_holder: str) = None
     inst: ?stratoweave_rfs__device__software__veto_entry = None
@@ -4482,7 +4554,7 @@ class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker73: None = None
+_breaker74: None = None
 class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -4504,7 +4576,7 @@ class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker74: None = None
+_breaker75: None = None
 proc def stratoweave_rfs__device__software__state__job_deliver(cb: action(?(device_name: str, job_name: str), ?stratoweave_rfs__device__software__state__job_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str, job_name: str) = None
     inst: ?stratoweave_rfs__device__software__state__job_entry = None
@@ -4556,7 +4628,7 @@ class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker75: None = None
+_breaker76: None = None
 proc def stratoweave_rfs__device__software__state__precheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__precheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__software__state__precheck = None
@@ -4596,7 +4668,7 @@ class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__precheck_deliver(cb, n, err), root=self.filt())
 
-_breaker76: None = None
+_breaker77: None = None
 proc def stratoweave_rfs__device__software__state__postcheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__postcheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__software__state__postcheck = None
@@ -4636,7 +4708,7 @@ class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode)
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__postcheck_deliver(cb, n, err), root=self.filt())
 
-_breaker77: None = None
+_breaker78: None = None
 proc def stratoweave_rfs__device__software__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__software__state = None
@@ -4679,7 +4751,7 @@ class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state_deliver(cb, n, err), root=self.filt())
 
-_breaker78: None = None
+_breaker79: None = None
 proc def stratoweave_rfs__device__software_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__software = None
@@ -4723,7 +4795,7 @@ class stratoweave_rfs__device__software_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software_deliver(cb, n, err), root=self.filt())
 
-_breaker79: None = None
+_breaker80: None = None
 proc def stratoweave_rfs__device__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device__state = None
@@ -4755,7 +4827,7 @@ class stratoweave_rfs__device__state_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__device__state_deliver(cb, n, err), root=self.filt())
 
-_breaker80: None = None
+_breaker81: None = None
 class stratoweave_rfs__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -4791,7 +4863,7 @@ class stratoweave_rfs__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker81: None = None
+_breaker82: None = None
 proc def stratoweave_rfs__device_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(device_name: str) = None
     inst: ?stratoweave_rfs__device_entry = None
@@ -4854,7 +4926,7 @@ class stratoweave_rfs__device_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker82: None = None
+_breaker83: None = None
 class stratoweave_rfs__rfs__flotilla_status__state__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     status: SubscriptionNode
@@ -4870,7 +4942,7 @@ class stratoweave_rfs__rfs__flotilla_status__state__device_entry_subs(Subscripti
         direct: list[SubscriptionNode] = [self.name, self.status, self.running_release]
         return direct
 
-_breaker83: None = None
+_breaker84: None = None
 proc def stratoweave_rfs__rfs__flotilla_status__state__device_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__flotilla_status__state__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str) = None
     inst: ?stratoweave_rfs__rfs__flotilla_status__state__device_entry = None
@@ -4916,7 +4988,7 @@ class stratoweave_rfs__rfs__flotilla_status__state__device_subs(SubscriptionNode
         direct: list[SubscriptionNode] = [self.name, self.status, self.running_release]
         return direct
 
-_breaker84: None = None
+_breaker85: None = None
 proc def stratoweave_rfs__rfs__flotilla_status__state_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__flotilla_status__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str) = None
     inst: ?stratoweave_rfs__rfs__flotilla_status__state = None
@@ -4951,7 +5023,7 @@ class stratoweave_rfs__rfs__flotilla_status__state_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__flotilla_status__state_deliver(cb, n, err), root=self.filt())
 
-_breaker85: None = None
+_breaker86: None = None
 proc def stratoweave_rfs__rfs__flotilla_status_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__flotilla_status, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str) = None
     inst: ?stratoweave_rfs__rfs__flotilla_status = None
@@ -4987,7 +5059,7 @@ class stratoweave_rfs__rfs__flotilla_status_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__flotilla_status_deliver(cb, n, err), root=self.filt())
 
-_breaker86: None = None
+_breaker87: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -5003,7 +5075,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_entry_subs(Subs
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker87: None = None
+_breaker88: None = None
 proc def stratoweave_rfs__rfs__device__address__initial_credentials_deliver(cb: action(?(rfs_name: str, device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__rfs__device__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
     inst: ?stratoweave_rfs__rfs__device__address__initial_credentials_entry = None
@@ -5051,7 +5123,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_subs(Subscripti
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker88: None = None
+_breaker89: None = None
 class stratoweave_rfs__rfs__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -5069,7 +5141,7 @@ class stratoweave_rfs__rfs__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker89: None = None
+_breaker90: None = None
 proc def stratoweave_rfs__rfs__device__address_deliver(cb: action(?(rfs_name: str, device_name: str, address_name: str), ?stratoweave_rfs__rfs__device__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str, address_name: str) = None
     inst: ?stratoweave_rfs__rfs__device__address_entry = None
@@ -5116,7 +5188,7 @@ class stratoweave_rfs__rfs__device__address_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker90: None = None
+_breaker91: None = None
 class stratoweave_rfs__rfs__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -5130,7 +5202,7 @@ class stratoweave_rfs__rfs__device__credentials__key_entry_subs(SubscriptionNode
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker91: None = None
+_breaker92: None = None
 proc def stratoweave_rfs__rfs__device__credentials__key_deliver(cb: action(?(rfs_name: str, device_name: str, key_key: str), ?stratoweave_rfs__rfs__device__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str, key_key: str) = None
     inst: ?stratoweave_rfs__rfs__device__credentials__key_entry = None
@@ -5174,7 +5246,7 @@ class stratoweave_rfs__rfs__device__credentials__key_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker92: None = None
+_breaker93: None = None
 proc def stratoweave_rfs__rfs__device__credentials_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str) = None
     inst: ?stratoweave_rfs__rfs__device__credentials = None
@@ -5213,7 +5285,7 @@ class stratoweave_rfs__rfs__device__credentials_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__credentials_deliver(cb, n, err), root=self.filt())
 
-_breaker93: None = None
+_breaker94: None = None
 class stratoweave_rfs__rfs__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -5229,7 +5301,7 @@ class stratoweave_rfs__rfs__device__initial_credentials_entry_subs(SubscriptionN
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker94: None = None
+_breaker95: None = None
 proc def stratoweave_rfs__rfs__device__initial_credentials_deliver(cb: action(?(rfs_name: str, device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__rfs__device__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
     inst: ?stratoweave_rfs__rfs__device__initial_credentials_entry = None
@@ -5276,7 +5348,7 @@ class stratoweave_rfs__rfs__device__initial_credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker95: None = None
+_breaker96: None = None
 proc def stratoweave_rfs__rfs__device__ssh_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str) = None
     inst: ?stratoweave_rfs__rfs__device__ssh = None
@@ -5329,7 +5401,47 @@ class stratoweave_rfs__rfs__device__ssh_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__ssh_deliver(cb, n, err), root=self.filt())
 
-_breaker96: None = None
+_breaker97: None = None
+proc def stratoweave_rfs__rfs__device__mock__software_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__mock__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device__mock__software = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'mock'))
+            c4 = _at(c3, ygdata.Id(NS_fleetmgr_rfs, 'software'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__mock__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
+class stratoweave_rfs__rfs__device__mock__software_subs(SubscriptionNode):
+    upgrade_duration: SubscriptionNode
+    failure: SubscriptionNode
+    running_release: SubscriptionNode
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.upgrade_duration = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'upgrade-duration'), parent=path))
+        self.failure = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'failure'), parent=path))
+        self.running_release = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'running-release'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.upgrade_duration, self.failure, self.running_release]
+        return direct
+
+    def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__mock__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__mock__software_deliver(cb, n, err), root=self.filt())
+
+_breaker98: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -5347,7 +5459,7 @@ class stratoweave_rfs__rfs__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker97: None = None
+_breaker99: None = None
 proc def stratoweave_rfs__rfs__device__mock__module_deliver(cb: action(?(rfs_name: str, device_name: str, module_name: str), ?stratoweave_rfs__rfs__device__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str, module_name: str) = None
     inst: ?stratoweave_rfs__rfs__device__mock__module_entry = None
@@ -5395,7 +5507,7 @@ class stratoweave_rfs__rfs__device__mock__module_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker98: None = None
+_breaker100: None = None
 proc def stratoweave_rfs__rfs__device__mock_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str) = None
     inst: ?stratoweave_rfs__rfs__device__mock = None
@@ -5415,15 +5527,17 @@ proc def stratoweave_rfs__rfs__device__mock_deliver(cb: action(?(rfs_name: str, 
 
 class stratoweave_rfs__rfs__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
+    software: stratoweave_rfs__rfs__device__mock__software_subs
     module: stratoweave_rfs__rfs__device__mock__module_subs
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'enabled'), parent=path))
+        self.software = stratoweave_rfs__rfs__device__mock__software_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'software'), parent=path))
         self.module = stratoweave_rfs__rfs__device__mock__module_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'module'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.enabled, self.module]
+        direct: list[SubscriptionNode] = [self.enabled, self.software, self.module]
         return direct
 
     def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__mock, ?Exception) -> None) -> ygdata.Dst:
@@ -5432,7 +5546,7 @@ class stratoweave_rfs__rfs__device__mock_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__mock_deliver(cb, n, err), root=self.filt())
 
-_breaker99: None = None
+_breaker101: None = None
 proc def stratoweave_rfs__rfs__device__debug_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str) = None
     inst: ?stratoweave_rfs__rfs__device__debug = None
@@ -5467,7 +5581,7 @@ class stratoweave_rfs__rfs__device__debug_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__debug_deliver(cb, n, err), root=self.filt())
 
-_breaker100: None = None
+_breaker102: None = None
 proc def stratoweave_rfs__rfs__device__feature_flags_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str) = None
     inst: ?stratoweave_rfs__rfs__device__feature_flags = None
@@ -5502,7 +5616,7 @@ class stratoweave_rfs__rfs__device__feature_flags_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__feature_flags_deliver(cb, n, err), root=self.filt())
 
-_breaker101: None = None
+_breaker103: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -5516,7 +5630,7 @@ class stratoweave_rfs__rfs__device__software__veto_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker102: None = None
+_breaker104: None = None
 proc def stratoweave_rfs__rfs__device__software__veto_deliver(cb: action(?(rfs_name: str, device_name: str, veto_holder: str), ?stratoweave_rfs__rfs__device__software__veto_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str, veto_holder: str) = None
     inst: ?stratoweave_rfs__rfs__device__software__veto_entry = None
@@ -5560,7 +5674,7 @@ class stratoweave_rfs__rfs__device__software__veto_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker103: None = None
+_breaker105: None = None
 proc def stratoweave_rfs__rfs__device__software_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str) = None
     inst: ?stratoweave_rfs__rfs__device__software = None
@@ -5603,7 +5717,7 @@ class stratoweave_rfs__rfs__device__software_subs(SubscriptionNode):
         after a change or None when it is gone, and an error."""
         return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__software_deliver(cb, n, err), root=self.filt())
 
-_breaker104: None = None
+_breaker106: None = None
 class stratoweave_rfs__rfs__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -5637,7 +5751,7 @@ class stratoweave_rfs__rfs__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.type, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software]
         return direct
 
-_breaker105: None = None
+_breaker107: None = None
 proc def stratoweave_rfs__rfs__device_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str, device_name: str) = None
     inst: ?stratoweave_rfs__rfs__device_entry = None
@@ -5699,7 +5813,7 @@ class stratoweave_rfs__rfs__device_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.type, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software]
         return direct
 
-_breaker106: None = None
+_breaker108: None = None
 class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     flotilla_status: stratoweave_rfs__rfs__flotilla_status_subs
@@ -5715,7 +5829,7 @@ class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.flotilla_status, self.device]
         return direct
 
-_breaker107: None = None
+_breaker109: None = None
 proc def stratoweave_rfs__rfs_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
     keys: ?(rfs_name: str) = None
     inst: ?stratoweave_rfs__rfs_entry = None
@@ -5758,7 +5872,7 @@ class stratoweave_rfs__rfs_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.flotilla_status, self.device]
         return direct
 
-_breaker108: None = None
+_breaker110: None = None
 class root_subs(SubscriptionNode):
     device: stratoweave_rfs__device_subs
     rfs: stratoweave_rfs__rfs_subs

--- a/fleetmgr/src/fleetmgr/layers/y_1_oper.act
+++ b/fleetmgr/src/fleetmgr/layers/y_1_oper.act
@@ -76,6 +76,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -660,6 +665,46 @@ SRC_YANG_3: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -2586,6 +2631,31 @@ class stratoweave_rfs__device__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class stratoweave_rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'running-release')))
+        return stratoweave_rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -2609,7 +2679,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2644,13 +2714,15 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: ?bool
+    software: stratoweave_rfs__device__mock__software
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?stratoweave_rfs__device__mock__software=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else stratoweave_rfs__device__mock__software()
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2659,7 +2731,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), software=stratoweave_rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_stratoweave_rfs, 'software'))), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:
@@ -2667,7 +2739,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class stratoweave_rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -2688,7 +2760,7 @@ class stratoweave_rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class stratoweave_rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -2709,7 +2781,7 @@ class stratoweave_rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -2729,7 +2801,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -2762,7 +2834,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
         return stratoweave_rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class stratoweave_rfs__device__software__state__job_entry(yadata.MNode):
     name: str
     state: ?str
@@ -2790,7 +2862,7 @@ class stratoweave_rfs__device__software__state__job_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__state__job_entry.from_gdata(self.to_gdata())
 
-_breaker19: None = None
+_breaker20: None = None
 class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, stratoweave_rfs__device__software__state__job_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__state__job_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2831,7 +2903,7 @@ class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, strat
         return stratoweave_rfs__device__software__state__job(elements=copied_elements)
 
 
-_breaker20: None = None
+_breaker21: None = None
 class stratoweave_rfs__device__software__state__precheck(yadata.MNode):
     verdict: ?str
     detail: ?str
@@ -2856,7 +2928,7 @@ class stratoweave_rfs__device__software__state__precheck(yadata.MNode):
         return stratoweave_rfs__device__software__state__precheck.from_gdata(self.to_gdata())
 
 
-_breaker21: None = None
+_breaker22: None = None
 class stratoweave_rfs__device__software__state__postcheck(yadata.MNode):
     verdict: ?str
     detail: ?str
@@ -2881,7 +2953,7 @@ class stratoweave_rfs__device__software__state__postcheck(yadata.MNode):
         return stratoweave_rfs__device__software__state__postcheck.from_gdata(self.to_gdata())
 
 
-_breaker22: None = None
+_breaker23: None = None
 class stratoweave_rfs__device__software__state(yadata.MNode):
     status: ?str
     running_release: ?str
@@ -2910,7 +2982,7 @@ class stratoweave_rfs__device__software__state(yadata.MNode):
         return stratoweave_rfs__device__software__state.from_gdata(self.to_gdata())
 
 
-_breaker23: None = None
+_breaker24: None = None
 class stratoweave_rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -2941,7 +3013,7 @@ class stratoweave_rfs__device__software(yadata.MNode):
         return stratoweave_rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker24: None = None
+_breaker25: None = None
 class stratoweave_rfs__device__state(yadata.MNode):
 
     mut def __init__(self) -> None:
@@ -2961,7 +3033,7 @@ class stratoweave_rfs__device__state(yadata.MNode):
         return stratoweave_rfs__device__state.from_gdata(self.to_gdata())
 
 
-_breaker25: None = None
+_breaker26: None = None
 class stratoweave_rfs__device_entry(yadata.MNode):
     name: str
     description: ?str
@@ -3003,7 +3075,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker26: None = None
+_breaker27: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3040,7 +3112,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
         return stratoweave_rfs__device(elements=copied_elements)
 
 
-_breaker27: None = None
+_breaker28: None = None
 class stratoweave_rfs__rfs__flotilla_status__state__device_entry(yadata.MNode):
     name: str
     status: ?str
@@ -3062,7 +3134,7 @@ class stratoweave_rfs__rfs__flotilla_status__state__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__flotilla_status__state__device_entry.from_gdata(self.to_gdata())
 
-_breaker28: None = None
+_breaker29: None = None
 class stratoweave_rfs__rfs__flotilla_status__state__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__flotilla_status__state__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__flotilla_status__state__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3097,7 +3169,7 @@ class stratoweave_rfs__rfs__flotilla_status__state__device(yadata.MKeyedList[str
         return stratoweave_rfs__rfs__flotilla_status__state__device(elements=copied_elements)
 
 
-_breaker29: None = None
+_breaker30: None = None
 class stratoweave_rfs__rfs__flotilla_status__state(yadata.MNode):
     device: stratoweave_rfs__rfs__flotilla_status__state__device
 
@@ -3118,7 +3190,7 @@ class stratoweave_rfs__rfs__flotilla_status__state(yadata.MNode):
         return stratoweave_rfs__rfs__flotilla_status__state.from_gdata(self.to_gdata())
 
 
-_breaker30: None = None
+_breaker31: None = None
 class stratoweave_rfs__rfs__flotilla_status(yadata.MNode):
     enabled: ?bool
     state: stratoweave_rfs__rfs__flotilla_status__state
@@ -3141,7 +3213,7 @@ class stratoweave_rfs__rfs__flotilla_status(yadata.MNode):
         return stratoweave_rfs__rfs__flotilla_status.from_gdata(self.to_gdata())
 
 
-_breaker31: None = None
+_breaker32: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -3163,7 +3235,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_entry(yadata.MN
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker32: None = None
+_breaker33: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__address__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -3194,7 +3266,7 @@ class stratoweave_rfs__rfs__device__address__initial_credentials(yadata.MKeyedLi
         return stratoweave_rfs__rfs__device__address__initial_credentials(elements=copied_elements)
 
 
-_breaker33: None = None
+_breaker34: None = None
 class stratoweave_rfs__rfs__device__address_entry(yadata.MNode):
     name: str
     address: ?str
@@ -3218,7 +3290,7 @@ class stratoweave_rfs__rfs__device__address_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker34: None = None
+_breaker35: None = None
 class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__address_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__address_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3253,7 +3325,7 @@ class stratoweave_rfs__rfs__device__address(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__rfs__device__address(elements=copied_elements)
 
 
-_breaker35: None = None
+_breaker36: None = None
 class stratoweave_rfs__rfs__device__credentials__key_entry(yadata.MNode):
     key: str
     private_key: ?str
@@ -3273,7 +3345,7 @@ class stratoweave_rfs__rfs__device__credentials__key_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker36: None = None
+_breaker37: None = None
 class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__credentials__key_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__credentials__key_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.key, elements)
@@ -3306,7 +3378,7 @@ class stratoweave_rfs__rfs__device__credentials__key(yadata.MKeyedList[str, stra
         return stratoweave_rfs__rfs__device__credentials__key(elements=copied_elements)
 
 
-_breaker37: None = None
+_breaker38: None = None
 class stratoweave_rfs__rfs__device__credentials(yadata.MNode):
     username: ?str
     password: ?str
@@ -3331,7 +3403,7 @@ class stratoweave_rfs__rfs__device__credentials(yadata.MNode):
         return stratoweave_rfs__rfs__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker38: None = None
+_breaker39: None = None
 class stratoweave_rfs__rfs__device__initial_credentials_entry(yadata.MNode):
     username: str
     password: str
@@ -3353,7 +3425,7 @@ class stratoweave_rfs__rfs__device__initial_credentials_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker39: None = None
+_breaker40: None = None
 class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(username: str, password: str, key: str), stratoweave_rfs__rfs__device__initial_credentials_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__initial_credentials_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: (username=e.username, password=e.password, key=e.key), elements)
@@ -3384,7 +3456,7 @@ class stratoweave_rfs__rfs__device__initial_credentials(yadata.MKeyedList[(usern
         return stratoweave_rfs__rfs__device__initial_credentials(elements=copied_elements)
 
 
-_breaker40: None = None
+_breaker41: None = None
 class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
     cipher: list[str]
     mac: list[str]
@@ -3423,7 +3495,7 @@ class stratoweave_rfs__rfs__device__ssh(yadata.MNode):
         return stratoweave_rfs__rfs__device__ssh.from_gdata(self.to_gdata())
 
 
-_breaker41: None = None
+_breaker42: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -3447,7 +3519,7 @@ class stratoweave_rfs__rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker42: None = None
+_breaker43: None = None
 class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3482,7 +3554,7 @@ class stratoweave_rfs__rfs__device__mock__module(yadata.MKeyedList[str, stratowe
         return stratoweave_rfs__rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker43: None = None
+_breaker44: None = None
 class stratoweave_rfs__rfs__device__mock(yadata.MNode):
     enabled: ?bool
     module: stratoweave_rfs__rfs__device__mock__module
@@ -3505,7 +3577,7 @@ class stratoweave_rfs__rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker44: None = None
+_breaker45: None = None
 class stratoweave_rfs__rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -3526,7 +3598,7 @@ class stratoweave_rfs__rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker45: None = None
+_breaker46: None = None
 class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -3547,7 +3619,7 @@ class stratoweave_rfs__rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker46: None = None
+_breaker47: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -3567,7 +3639,7 @@ class stratoweave_rfs__rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker47: None = None
+_breaker48: None = None
 class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -3600,7 +3672,7 @@ class stratoweave_rfs__rfs__device__software__veto(yadata.MKeyedList[str, strato
         return stratoweave_rfs__rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker48: None = None
+_breaker49: None = None
 class stratoweave_rfs__rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -3629,7 +3701,7 @@ class stratoweave_rfs__rfs__device__software(yadata.MNode):
         return stratoweave_rfs__rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker49: None = None
+_breaker50: None = None
 class stratoweave_rfs__rfs__device_entry(yadata.MNode):
     name: str
     type: ?str
@@ -3669,7 +3741,7 @@ class stratoweave_rfs__rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker50: None = None
+_breaker51: None = None
 class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3706,7 +3778,7 @@ class stratoweave_rfs__rfs__device(yadata.MKeyedList[str, stratoweave_rfs__rfs__
         return stratoweave_rfs__rfs__device(elements=copied_elements)
 
 
-_breaker51: None = None
+_breaker52: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
     flotilla_status: stratoweave_rfs__rfs__flotilla_status
@@ -3728,7 +3800,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker52: None = None
+_breaker53: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -3759,7 +3831,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker53: None = None
+_breaker54: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
@@ -3787,7 +3859,27 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
-_breaker54: None = None
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
+_breaker55: None = None
 class stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3803,7 +3895,24 @@ class stratoweave_rfs__device__address__initial_credentials_entry_subs(Subscript
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker55: None = None
+_breaker56: None = None
+proc def stratoweave_rfs__device__address__initial_credentials_deliver(cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__device__address__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'address')), 'address')
+            e3 = _one(_at(e2, ygdata.Id(NS_stratoweave_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), address_name=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), initial_credentials_username=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'username')), initial_credentials_password=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'password')), initial_credentials_key=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3823,11 +3932,17 @@ class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNod
         base_path = self._path!.parent
         return stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__address__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__address__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker56: None = None
+_breaker57: None = None
 class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -3845,7 +3960,23 @@ class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker57: None = None
+_breaker58: None = None
+proc def stratoweave_rfs__device__address_deliver(cb: action(?(device_name: str, address_name: str), ?stratoweave_rfs__device__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str) = None
+    inst: ?stratoweave_rfs__device__address_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'address')), 'address')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), address_name=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__device__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -3865,11 +3996,17 @@ class stratoweave_rfs__device__address_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__address_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'address'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, address_name: str), ?stratoweave_rfs__device__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__address_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker58: None = None
+_breaker59: None = None
 class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -3883,7 +4020,24 @@ class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker59: None = None
+_breaker60: None = None
+proc def stratoweave_rfs__device__credentials__key_deliver(cb: action(?(device_name: str, key_key: str), ?stratoweave_rfs__device__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, key_key: str) = None
+    inst: ?stratoweave_rfs__device__credentials__key_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'credentials'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'key')), 'key')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), key_key=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__credentials__key_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -3899,11 +4053,33 @@ class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'key'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, key_key: str), ?stratoweave_rfs__device__credentials__key_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__credentials__key_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker60: None = None
+_breaker61: None = None
+proc def stratoweave_rfs__device__credentials_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__credentials = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'credentials'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__credentials.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3919,7 +4095,13 @@ class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker61: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__credentials, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__credentials_deliver(cb, n, err), root=self.filt())
+
+_breaker62: None = None
 class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3935,7 +4117,23 @@ class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker62: None = None
+_breaker63: None = None
+proc def stratoweave_rfs__device__initial_credentials_deliver(cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__device__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), initial_credentials_username=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'username')), initial_credentials_password=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'password')), initial_credentials_key=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__device__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -3955,11 +4153,33 @@ class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker63: None = None
+_breaker64: None = None
+proc def stratoweave_rfs__device__ssh_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__ssh = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'ssh'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__ssh.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
     cipher: SubscriptionNode
     mac: SubscriptionNode
@@ -3989,7 +4209,52 @@ class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
         return direct
 
-_breaker64: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__ssh, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__ssh_deliver(cb, n, err), root=self.filt())
+
+_breaker65: None = None
+proc def stratoweave_rfs__device__mock__software_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__mock__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__mock__software = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
+class stratoweave_rfs__device__mock__software_subs(SubscriptionNode):
+    upgrade_duration: SubscriptionNode
+    failure: SubscriptionNode
+    running_release: SubscriptionNode
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.upgrade_duration = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration'), parent=path))
+        self.failure = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'failure'), parent=path))
+        self.running_release = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'running-release'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.upgrade_duration, self.failure, self.running_release]
+        return direct
+
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__mock__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock__software_deliver(cb, n, err), root=self.filt())
+
+_breaker66: None = None
 class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -4007,7 +4272,24 @@ class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker65: None = None
+_breaker67: None = None
+proc def stratoweave_rfs__device__mock__module_deliver(cb: action(?(device_name: str, module_name: str), ?stratoweave_rfs__device__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, module_name: str) = None
+    inst: ?stratoweave_rfs__device__mock__module_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'module')), 'module')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), module_name=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock__module_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -4027,25 +4309,71 @@ class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__mock__module_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'module'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, module_name: str), ?stratoweave_rfs__device__mock__module_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock__module_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker66: None = None
+_breaker68: None = None
+proc def stratoweave_rfs__device__mock_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__mock = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
+    software: stratoweave_rfs__device__mock__software_subs
     module: stratoweave_rfs__device__mock__module_subs
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'enabled'), parent=path))
+        self.software = stratoweave_rfs__device__mock__software_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'software'), parent=path))
         self.module = stratoweave_rfs__device__mock__module_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'module'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.enabled, self.module]
+        direct: list[SubscriptionNode] = [self.enabled, self.software, self.module]
         return direct
 
-_breaker67: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__mock, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock_deliver(cb, n, err), root=self.filt())
+
+_breaker69: None = None
+proc def stratoweave_rfs__device__debug_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__debug = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'debug'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__debug.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -4057,7 +4385,29 @@ class stratoweave_rfs__device__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
-_breaker68: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__debug, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__debug_deliver(cb, n, err), root=self.filt())
+
+_breaker70: None = None
+proc def stratoweave_rfs__device__feature_flags_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__feature_flags = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'feature-flags'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__feature_flags.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -4069,7 +4419,13 @@ class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
 
-_breaker69: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__feature_flags, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__feature_flags_deliver(cb, n, err), root=self.filt())
+
+_breaker71: None = None
 class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -4083,7 +4439,24 @@ class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker70: None = None
+_breaker72: None = None
+proc def stratoweave_rfs__device__software__veto_deliver(cb: action(?(device_name: str, veto_holder: str), ?stratoweave_rfs__device__software__veto_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, veto_holder: str) = None
+    inst: ?stratoweave_rfs__device__software__veto_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'veto')), 'veto')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), veto_holder=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'holder')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__veto_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -4099,11 +4472,17 @@ class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__software__veto_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'veto'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, veto_holder: str), ?stratoweave_rfs__device__software__veto_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__veto_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker71: None = None
+_breaker73: None = None
 class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -4125,7 +4504,25 @@ class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker72: None = None
+_breaker74: None = None
+proc def stratoweave_rfs__device__software__state__job_deliver(cb: action(?(device_name: str, job_name: str), ?stratoweave_rfs__device__software__state__job_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, job_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__job_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            e4 = _one(_at(c3, ygdata.Id(NS_stratoweave_rfs, 'job')), 'job')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), job_name=e4.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__job_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -4149,11 +4546,35 @@ class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'job'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, job_name: str), ?stratoweave_rfs__device__software__state__job_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__job_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker73: None = None
+_breaker75: None = None
+proc def stratoweave_rfs__device__software__state__precheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__precheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__precheck = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            c4 = _at(c3, ygdata.Id(NS_stratoweave_rfs, 'precheck'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__precheck.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -4169,7 +4590,31 @@ class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
-_breaker74: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__precheck, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__precheck_deliver(cb, n, err), root=self.filt())
+
+_breaker76: None = None
+proc def stratoweave_rfs__device__software__state__postcheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__postcheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__postcheck = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            c4 = _at(c3, ygdata.Id(NS_stratoweave_rfs, 'postcheck'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__postcheck.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -4185,7 +4630,30 @@ class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
-_breaker75: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__postcheck, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__postcheck_deliver(cb, n, err), root=self.filt())
+
+_breaker77: None = None
+proc def stratoweave_rfs__device__software__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
     status: SubscriptionNode
     running_release: SubscriptionNode
@@ -4205,7 +4673,29 @@ class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.status, self.running_release, self.job, self.precheck, self.postcheck]
         return direct
 
-_breaker76: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state_deliver(cb, n, err), root=self.filt())
+
+_breaker78: None = None
+proc def stratoweave_rfs__device__software_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software_subs(SubscriptionNode):
     upgrade_campaign: SubscriptionNode
     target_release: SubscriptionNode
@@ -4227,7 +4717,29 @@ class stratoweave_rfs__device__software_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.upgrade_campaign, self.target_release, self.image_url, self.allow_staging, self.veto, self.state]
         return direct
 
-_breaker77: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software_deliver(cb, n, err), root=self.filt())
+
+_breaker79: None = None
+proc def stratoweave_rfs__device__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__state_subs(SubscriptionNode):
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -4237,7 +4749,13 @@ class stratoweave_rfs__device__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = []
         return direct
 
-_breaker78: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__state_deliver(cb, n, err), root=self.filt())
+
+_breaker80: None = None
 class stratoweave_rfs__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -4273,7 +4791,22 @@ class stratoweave_rfs__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker79: None = None
+_breaker81: None = None
+proc def stratoweave_rfs__device_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e1)
+            if here is not None:
+                inst = stratoweave_rfs__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -4311,11 +4844,17 @@ class stratoweave_rfs__device_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker80: None = None
+_breaker82: None = None
 class stratoweave_rfs__rfs__flotilla_status__state__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     status: SubscriptionNode
@@ -4331,7 +4870,25 @@ class stratoweave_rfs__rfs__flotilla_status__state__device_entry_subs(Subscripti
         direct: list[SubscriptionNode] = [self.name, self.status, self.running_release]
         return direct
 
-_breaker81: None = None
+_breaker83: None = None
+proc def stratoweave_rfs__rfs__flotilla_status__state__device_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__flotilla_status__state__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str) = None
+    inst: ?stratoweave_rfs__rfs__flotilla_status__state__device_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            c2 = _at(e1, ygdata.Id(NS_fleetmgr_rfs, 'flotilla-status'))
+            c3 = _at(c2, ygdata.Id(NS_fleetmgr_rfs, 'state'))
+            e4 = _one(_at(c3, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e4.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(e4)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__flotilla_status__state__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__flotilla_status__state__device_subs(SubscriptionNode):
     name: SubscriptionNode
     status: SubscriptionNode
@@ -4349,11 +4906,34 @@ class stratoweave_rfs__rfs__flotilla_status__state__device_subs(SubscriptionNode
         base_path = self._path!.parent
         return stratoweave_rfs__rfs__flotilla_status__state__device_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__flotilla_status__state__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__flotilla_status__state__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.status, self.running_release]
         return direct
 
-_breaker82: None = None
+_breaker84: None = None
+proc def stratoweave_rfs__rfs__flotilla_status__state_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__flotilla_status__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str) = None
+    inst: ?stratoweave_rfs__rfs__flotilla_status__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            c2 = _at(e1, ygdata.Id(NS_fleetmgr_rfs, 'flotilla-status'))
+            c3 = _at(c2, ygdata.Id(NS_fleetmgr_rfs, 'state'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__flotilla_status__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__flotilla_status__state_subs(SubscriptionNode):
     device: stratoweave_rfs__rfs__flotilla_status__state__device_subs
 
@@ -4365,7 +4945,29 @@ class stratoweave_rfs__rfs__flotilla_status__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.device]
         return direct
 
-_breaker83: None = None
+    def dst(self, cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__flotilla_status__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__flotilla_status__state_deliver(cb, n, err), root=self.filt())
+
+_breaker85: None = None
+proc def stratoweave_rfs__rfs__flotilla_status_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__flotilla_status, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str) = None
+    inst: ?stratoweave_rfs__rfs__flotilla_status = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            c2 = _at(e1, ygdata.Id(NS_fleetmgr_rfs, 'flotilla-status'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__flotilla_status.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__flotilla_status_subs(SubscriptionNode):
     enabled: SubscriptionNode
     state: stratoweave_rfs__rfs__flotilla_status__state_subs
@@ -4379,7 +4981,13 @@ class stratoweave_rfs__rfs__flotilla_status_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.state]
         return direct
 
-_breaker84: None = None
+    def dst(self, cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs__flotilla_status, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__flotilla_status_deliver(cb, n, err), root=self.filt())
+
+_breaker86: None = None
 class stratoweave_rfs__rfs__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4395,7 +5003,25 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_entry_subs(Subs
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker85: None = None
+_breaker87: None = None
+proc def stratoweave_rfs__rfs__device__address__initial_credentials_deliver(cb: action(?(rfs_name: str, device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__rfs__device__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__rfs__device__address__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            e3 = _one(_at(e2, ygdata.Id(NS_fleetmgr_rfs, 'address')), 'address')
+            e4 = _one(_at(e3, ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), address_name=e3.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), initial_credentials_username=e4.get_str(ygdata.Id(NS_fleetmgr_rfs, 'username')), initial_credentials_password=e4.get_str(ygdata.Id(NS_fleetmgr_rfs, 'password')), initial_credentials_key=e4.get_str(ygdata.Id(NS_fleetmgr_rfs, 'key')))
+            here = _present(e4)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__address__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4415,11 +5041,17 @@ class stratoweave_rfs__rfs__device__address__initial_credentials_subs(Subscripti
         base_path = self._path!.parent
         return stratoweave_rfs__rfs__device__address__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str, device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__rfs__device__address__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__address__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker86: None = None
+_breaker88: None = None
 class stratoweave_rfs__rfs__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -4437,7 +5069,24 @@ class stratoweave_rfs__rfs__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker87: None = None
+_breaker89: None = None
+proc def stratoweave_rfs__rfs__device__address_deliver(cb: action(?(rfs_name: str, device_name: str, address_name: str), ?stratoweave_rfs__rfs__device__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str, address_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device__address_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            e3 = _one(_at(e2, ygdata.Id(NS_fleetmgr_rfs, 'address')), 'address')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), address_name=e3.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -4457,11 +5106,17 @@ class stratoweave_rfs__rfs__device__address_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs__device__address_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'address'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str, device_name: str, address_name: str), ?stratoweave_rfs__rfs__device__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__address_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker88: None = None
+_breaker90: None = None
 class stratoweave_rfs__rfs__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -4475,7 +5130,25 @@ class stratoweave_rfs__rfs__device__credentials__key_entry_subs(SubscriptionNode
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker89: None = None
+_breaker91: None = None
+proc def stratoweave_rfs__rfs__device__credentials__key_deliver(cb: action(?(rfs_name: str, device_name: str, key_key: str), ?stratoweave_rfs__rfs__device__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str, key_key: str) = None
+    inst: ?stratoweave_rfs__rfs__device__credentials__key_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'credentials'))
+            e4 = _one(_at(c3, ygdata.Id(NS_fleetmgr_rfs, 'key')), 'key')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), key_key=e4.get_str(ygdata.Id(NS_fleetmgr_rfs, 'key')))
+            here = _present(e4)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__credentials__key_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -4491,11 +5164,34 @@ class stratoweave_rfs__rfs__device__credentials__key_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs__device__credentials__key_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'key'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str, device_name: str, key_key: str), ?stratoweave_rfs__rfs__device__credentials__key_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__credentials__key_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker90: None = None
+_breaker92: None = None
+proc def stratoweave_rfs__rfs__device__credentials_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device__credentials = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'credentials'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__credentials.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4511,7 +5207,13 @@ class stratoweave_rfs__rfs__device__credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker91: None = None
+    def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__credentials, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__credentials_deliver(cb, n, err), root=self.filt())
+
+_breaker93: None = None
 class stratoweave_rfs__rfs__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4527,7 +5229,24 @@ class stratoweave_rfs__rfs__device__initial_credentials_entry_subs(SubscriptionN
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker92: None = None
+_breaker94: None = None
+proc def stratoweave_rfs__rfs__device__initial_credentials_deliver(cb: action(?(rfs_name: str, device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__rfs__device__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__rfs__device__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            e3 = _one(_at(e2, ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), initial_credentials_username=e3.get_str(ygdata.Id(NS_fleetmgr_rfs, 'username')), initial_credentials_password=e3.get_str(ygdata.Id(NS_fleetmgr_rfs, 'password')), initial_credentials_key=e3.get_str(ygdata.Id(NS_fleetmgr_rfs, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -4547,11 +5266,34 @@ class stratoweave_rfs__rfs__device__initial_credentials_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs__device__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str, device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__rfs__device__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker93: None = None
+_breaker95: None = None
+proc def stratoweave_rfs__rfs__device__ssh_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device__ssh = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'ssh'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__ssh.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__ssh_subs(SubscriptionNode):
     cipher: SubscriptionNode
     mac: SubscriptionNode
@@ -4581,7 +5323,13 @@ class stratoweave_rfs__rfs__device__ssh_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
         return direct
 
-_breaker94: None = None
+    def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__ssh, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__ssh_deliver(cb, n, err), root=self.filt())
+
+_breaker96: None = None
 class stratoweave_rfs__rfs__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -4599,7 +5347,25 @@ class stratoweave_rfs__rfs__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker95: None = None
+_breaker97: None = None
+proc def stratoweave_rfs__rfs__device__mock__module_deliver(cb: action(?(rfs_name: str, device_name: str, module_name: str), ?stratoweave_rfs__rfs__device__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str, module_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device__mock__module_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'mock'))
+            e4 = _one(_at(c3, ygdata.Id(NS_fleetmgr_rfs, 'module')), 'module')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), module_name=e4.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(e4)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__mock__module_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -4619,11 +5385,34 @@ class stratoweave_rfs__rfs__device__mock__module_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs__device__mock__module_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'module'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str, device_name: str, module_name: str), ?stratoweave_rfs__rfs__device__mock__module_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__mock__module_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker96: None = None
+_breaker98: None = None
+proc def stratoweave_rfs__rfs__device__mock_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device__mock = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'mock'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__mock.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
     module: stratoweave_rfs__rfs__device__mock__module_subs
@@ -4637,7 +5426,30 @@ class stratoweave_rfs__rfs__device__mock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.enabled, self.module]
         return direct
 
-_breaker97: None = None
+    def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__mock, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__mock_deliver(cb, n, err), root=self.filt())
+
+_breaker99: None = None
+proc def stratoweave_rfs__rfs__device__debug_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device__debug = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'debug'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__debug.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -4649,7 +5461,30 @@ class stratoweave_rfs__rfs__device__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
-_breaker98: None = None
+    def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__debug, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__debug_deliver(cb, n, err), root=self.filt())
+
+_breaker100: None = None
+proc def stratoweave_rfs__rfs__device__feature_flags_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device__feature_flags = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'feature-flags'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__feature_flags.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -4661,7 +5496,13 @@ class stratoweave_rfs__rfs__device__feature_flags_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
 
-_breaker99: None = None
+    def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__feature_flags, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__feature_flags_deliver(cb, n, err), root=self.filt())
+
+_breaker101: None = None
 class stratoweave_rfs__rfs__device__software__veto_entry_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -4675,7 +5516,25 @@ class stratoweave_rfs__rfs__device__software__veto_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker100: None = None
+_breaker102: None = None
+proc def stratoweave_rfs__rfs__device__software__veto_deliver(cb: action(?(rfs_name: str, device_name: str, veto_holder: str), ?stratoweave_rfs__rfs__device__software__veto_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str, veto_holder: str) = None
+    inst: ?stratoweave_rfs__rfs__device__software__veto_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'software'))
+            e4 = _one(_at(c3, ygdata.Id(NS_fleetmgr_rfs, 'veto')), 'veto')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')), veto_holder=e4.get_str(ygdata.Id(NS_fleetmgr_rfs, 'holder')))
+            here = _present(e4)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__software__veto_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__software__veto_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -4691,11 +5550,34 @@ class stratoweave_rfs__rfs__device__software__veto_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs__device__software__veto_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'veto'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str, device_name: str, veto_holder: str), ?stratoweave_rfs__rfs__device__software__veto_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__software__veto_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker101: None = None
+_breaker103: None = None
+proc def stratoweave_rfs__rfs__device__software_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device__software = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            c3 = _at(e2, ygdata.Id(NS_fleetmgr_rfs, 'software'))
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device__software_subs(SubscriptionNode):
     upgrade_campaign: SubscriptionNode
     target_release: SubscriptionNode
@@ -4715,7 +5597,13 @@ class stratoweave_rfs__rfs__device__software_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.upgrade_campaign, self.target_release, self.image_url, self.allow_staging, self.veto]
         return direct
 
-_breaker102: None = None
+    def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device__software_deliver(cb, n, err), root=self.filt())
+
+_breaker104: None = None
 class stratoweave_rfs__rfs__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -4749,7 +5637,23 @@ class stratoweave_rfs__rfs__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.type, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software]
         return direct
 
-_breaker103: None = None
+_breaker105: None = None
+proc def stratoweave_rfs__rfs__device_deliver(cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str, device_name: str) = None
+    inst: ?stratoweave_rfs__rfs__device_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            e2 = _one(_at(e1, ygdata.Id(NS_fleetmgr_rfs, 'device')), 'device')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), device_name=e2.get_str(ygdata.Id(NS_fleetmgr_rfs, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__rfs__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs__device_subs(SubscriptionNode):
     name: SubscriptionNode
     type: SubscriptionNode
@@ -4785,11 +5689,17 @@ class stratoweave_rfs__rfs__device_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs__device_entry_subs(SubscriptionPath(ygdata.Id(NS_fleetmgr_rfs, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str, device_name: str), ?stratoweave_rfs__rfs__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.type, self.description, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software]
         return direct
 
-_breaker104: None = None
+_breaker106: None = None
 class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     flotilla_status: stratoweave_rfs__rfs__flotilla_status_subs
@@ -4805,7 +5715,22 @@ class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.flotilla_status, self.device]
         return direct
 
-_breaker105: None = None
+_breaker107: None = None
+proc def stratoweave_rfs__rfs_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str) = None
+    inst: ?stratoweave_rfs__rfs_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e1)
+            if here is not None:
+                inst = stratoweave_rfs__rfs_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs_subs(SubscriptionNode):
     name: SubscriptionNode
     flotilla_status: stratoweave_rfs__rfs__flotilla_status_subs
@@ -4823,11 +5748,17 @@ class stratoweave_rfs__rfs_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'rfs'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.flotilla_status, self.device]
         return direct
 
-_breaker106: None = None
+_breaker108: None = None
 class root_subs(SubscriptionNode):
     device: stratoweave_rfs__device_subs
     rfs: stratoweave_rfs__rfs_subs
@@ -4843,17 +5774,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/fleetmgr/src/fleetmgr/layers/y_2_oper.act
+++ b/fleetmgr/src/fleetmgr/layers/y_2_oper.act
@@ -241,6 +241,26 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
 _breaker5: None = None
 class stratoweave_device__devices__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
@@ -256,6 +276,22 @@ class stratoweave_device__devices__device_entry_subs(SubscriptionNode):
         return direct
 
 _breaker6: None = None
+proc def stratoweave_device__devices__device_deliver(cb: action(?(device_name: str), ?stratoweave_device__devices__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_device__devices__device_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_stratoweave_device, 'devices'))
+            e2 = _one(_at(c1, ygdata.Id(NS_stratoweave_device, 'device')), 'device')
+            keys = (device_name=e2.get_str(ygdata.Id(NS_stratoweave_device, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_device__devices__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_device__devices__device_subs(SubscriptionNode):
     name: SubscriptionNode
     modset_id: SubscriptionNode
@@ -271,11 +307,30 @@ class stratoweave_device__devices__device_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_device__devices__device_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_device, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_device__devices__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_device__devices__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.modset_id]
         return direct
 
 _breaker7: None = None
+proc def stratoweave_device__devices_deliver(cb: action(?stratoweave_device__devices, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?stratoweave_device__devices = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_stratoweave_device, 'devices'))
+            here = _present(c1)
+            if here is not None:
+                inst = stratoweave_device__devices.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class stratoweave_device__devices_subs(SubscriptionNode):
     device: stratoweave_device__devices__device_subs
 
@@ -286,6 +341,12 @@ class stratoweave_device__devices_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.device]
         return direct
+
+    def dst(self, cb: action(?stratoweave_device__devices, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_device__devices_deliver(cb, n, err), root=self.filt())
 
 _breaker8: None = None
 class root_subs(SubscriptionNode):
@@ -301,17 +362,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/fleetmgr/src/fleetmgr/rfs.act
+++ b/fleetmgr/src/fleetmgr/rfs.act
@@ -116,6 +116,9 @@ class Device(base.Device):
         dev.ssh.minimum_rsa_bits = i.ssh.minimum_rsa_bits
 
         dev.mock.enabled = i.mock.enabled
+        dev.mock.software.upgrade_duration = i.mock.software.upgrade_duration
+        dev.mock.software.failure = i.mock.software.failure
+        dev.mock.software.running_release = i.mock.software.running_release
         for module in i.mock.module:
             out_module = dev.mock.module.create(
                 module.name,

--- a/fleetmgr/src/fleetmgr/rfs.act
+++ b/fleetmgr/src/fleetmgr/rfs.act
@@ -51,6 +51,10 @@ actor FlotillaStatusTransform(
         else:
             publish(root)
 
+    def shutdown() -> None:
+        # Releasing the subscriptions here is a separate change.
+        pass
+
     def on_conf(conf: y_1.stratoweave_rfs__rfs__flotilla_status) -> None:
         if subscriptions is None:
             subscriptions = ygdata.SubscriptionManager(dev.tree_provider(), str(path))

--- a/fleetmgr/src/flotilla/device_types.act
+++ b/fleetmgr/src/flotilla/device_types.act
@@ -13,6 +13,12 @@ import flotilla.devices.iosxe as iosxe_dev
 import flotilla.devices.iosxe_oper as iosxe_oper
 
 
+def _mock_upgrade_seconds(dmc) -> float:
+    """mock/software/upgrade-duration in seconds; absent means an instant upgrade."""
+    d = dmc.mock.software.upgrade_duration
+    return float(d!) if d is not None else 0.0
+
+
 def _iosxe_adapter(dev: swdev.DeviceMgr, schema, dmc, registry,
                    log_handler: logging.Handler,
                    connect_cap: ?net.TCPConnectCap):
@@ -21,8 +27,12 @@ def _iosxe_adapter(dev: swdev.DeviceMgr, schema, dmc, registry,
     if dmc.mock.enabled:
         server = adapter.get_mock_server()
         if server is not None:
+            running = dmc.mock.software.running_release
             mock = swxemock.IosXeSoftwareMock(
-                server!, log_handler, complete_after=0.5)
+                server!, log_handler,
+                upgrade_duration=_mock_upgrade_seconds(dmc),
+                failure=dmc.mock.software.failure,
+                running=running if running is not None else swxemock.OLD_RELEASE)
             mock.attach()
     return adapter
 
@@ -30,10 +40,11 @@ def _iosxe_adapter(dev: swdev.DeviceMgr, schema, dmc, registry,
 def _iosxe_software(dev: swdev.DeviceMgr, dmc, log_handler: logging.Handler,
                     connect_cap: ?net.TCPConnectCap) -> swdev.SoftwareAdapter:
     if dmc.mock.enabled:
-        # The production adapter still runs end to end. Poll faster only when
-        # its device-side NETCONF session is mocked for the demo.
+        # The production adapter still runs end to end; only its polls are
+        # scaled to the slowest mock operation so the poll budgets hold.
+        p = max([0.1, swxemock.longest_op_seconds(_mock_upgrade_seconds(dmc)) / 50.0])
         return swxe.IosXeSoftwareAdapter(dev, dmc, log_handler, connect_cap,
-                                         0.1, 0.2)
+                                         p, 2.0 * p)
     return swxe.IosXeSoftwareAdapter(dev, dmc, log_handler, connect_cap)
 
 

--- a/fleetmgr/src/flotilla/devices/iosxe_oper.act
+++ b/fleetmgr/src/flotilla/devices/iosxe_oper.act
@@ -622,11 +622,11 @@ class Cisco_IOS_XE_install_oper__install_oper_data__install_location_information
 _breaker13: None = None
 class Cisco_IOS_XE_install_oper__install_oper_data__install_location_information__install_version_state_info(yadata.MList[Cisco_IOS_XE_install_oper__install_oper_data__install_location_information__install_version_state_info_entry]):
     mut def __init__(self, elements: list[Cisco_IOS_XE_install_oper__install_oper_data__install_location_information__install_version_state_info_entry]=[]) -> None:
-        self.elements = elements
+        self._elements = elements
 
     mut def create(self, version_state: ?str=None, version: ?str=None) -> Cisco_IOS_XE_install_oper__install_oper_data__install_location_information__install_version_state_info_entry:
         res = Cisco_IOS_XE_install_oper__install_oper_data__install_location_information__install_version_state_info_entry(version_state=version_state, version=version)
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -667,11 +667,11 @@ class Cisco_IOS_XE_install_oper__install_oper_data__install_location_information
 _breaker15: None = None
 class Cisco_IOS_XE_install_oper__install_oper_data__install_location_information(yadata.MList[Cisco_IOS_XE_install_oper__install_oper_data__install_location_information_entry]):
     mut def __init__(self, elements: list[Cisco_IOS_XE_install_oper__install_oper_data__install_location_information_entry]=[]) -> None:
-        self.elements = elements
+        self._elements = elements
 
     mut def create(self) -> Cisco_IOS_XE_install_oper__install_oper_data__install_location_information_entry:
         res = Cisco_IOS_XE_install_oper__install_oper_data__install_location_information_entry()
-        self.elements.append(res)
+        self._append(res)
         return res
 
     @staticmethod
@@ -951,7 +951,42 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
 _breaker25: None = None
+proc def Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data_deliver(cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware-data'))
+            c2 = _at(c1, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware'))
+            c3 = _at(c2, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-system-data'))
+            here = _present(c3)
+            if here is not None:
+                inst = Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data_subs(SubscriptionNode):
     software_version: SubscriptionNode
 
@@ -963,7 +998,27 @@ class Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__
         direct: list[SubscriptionNode] = [self.software_version]
         return direct
 
+    def dst(self, cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data_deliver(cb, n, err), root=self.filt())
+
 _breaker26: None = None
+proc def Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_deliver(cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware-data'))
+            c2 = _at(c1, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware'))
+            here = _present(c2)
+            if here is not None:
+                inst = Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_subs(SubscriptionNode):
     device_system_data: Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware__device_system_data_subs
 
@@ -975,7 +1030,26 @@ class Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_s
         direct: list[SubscriptionNode] = [self.device_system_data]
         return direct
 
+    def dst(self, cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_deliver(cb, n, err), root=self.filt())
+
 _breaker27: None = None
+proc def Cisco_IOS_XE_device_hardware_oper__device_hardware_data_deliver(cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?Cisco_IOS_XE_device_hardware_oper__device_hardware_data = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_Cisco_IOS_XE_device_hardware_oper, 'device-hardware-data'))
+            here = _present(c1)
+            if here is not None:
+                inst = Cisco_IOS_XE_device_hardware_oper__device_hardware_data.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class Cisco_IOS_XE_device_hardware_oper__device_hardware_data_subs(SubscriptionNode):
     device_hardware: Cisco_IOS_XE_device_hardware_oper__device_hardware_data__device_hardware_subs
 
@@ -986,6 +1060,12 @@ class Cisco_IOS_XE_device_hardware_oper__device_hardware_data_subs(SubscriptionN
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.device_hardware]
         return direct
+
+    def dst(self, cb: action(?Cisco_IOS_XE_device_hardware_oper__device_hardware_data, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: Cisco_IOS_XE_device_hardware_oper__device_hardware_data_deliver(cb, n, err), root=self.filt())
 
 _breaker28: None = None
 class Cisco_IOS_XE_install_oper__install_oper_data__install_oper__install_txn_summary_op_subs(SubscriptionNode):
@@ -1076,6 +1156,19 @@ class Cisco_IOS_XE_install_oper__install_oper_data__install_location_information
         return direct
 
 _breaker34: None = None
+proc def Cisco_IOS_XE_install_oper__install_oper_data_deliver(cb: action(?Cisco_IOS_XE_install_oper__install_oper_data, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?Cisco_IOS_XE_install_oper__install_oper_data = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_Cisco_IOS_XE_install_oper, 'install-oper-data'))
+            here = _present(c1)
+            if here is not None:
+                inst = Cisco_IOS_XE_install_oper__install_oper_data.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class Cisco_IOS_XE_install_oper__install_oper_data_subs(SubscriptionNode):
     install_oper: Cisco_IOS_XE_install_oper__install_oper_data__install_oper_subs
     install_oper_hist: Cisco_IOS_XE_install_oper__install_oper_data__install_oper_hist_subs
@@ -1091,7 +1184,26 @@ class Cisco_IOS_XE_install_oper__install_oper_data_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.install_oper, self.install_oper_hist, self.install_location_information]
         return direct
 
+    def dst(self, cb: action(?Cisco_IOS_XE_install_oper__install_oper_data, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: Cisco_IOS_XE_install_oper__install_oper_data_deliver(cb, n, err), root=self.filt())
+
 _breaker35: None = None
+proc def cpe_device__system_deliver(cb: action(?cpe_device__system, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?cpe_device__system = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_cpe_device, 'system'))
+            here = _present(c1)
+            if here is not None:
+                inst = cpe_device__system.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class cpe_device__system_subs(SubscriptionNode):
     hostname: SubscriptionNode
 
@@ -1102,6 +1214,12 @@ class cpe_device__system_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.hostname]
         return direct
+
+    def dst(self, cb: action(?cpe_device__system, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: cpe_device__system_deliver(cb, n, err), root=self.filt())
 
 _breaker36: None = None
 class root_subs(SubscriptionNode):
@@ -1121,17 +1239,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/fleetmgr/src/flotilla/layers/y_0.act
+++ b/fleetmgr/src/flotilla/layers/y_0.act
@@ -75,6 +75,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -305,6 +310,46 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -2226,6 +2271,31 @@ class stratoweave_rfs__device__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class stratoweave_rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str=None, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure if failure is not None else "none"
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'running-release')))
+        return stratoweave_rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: str
@@ -2249,7 +2319,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2283,13 +2353,15 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: bool
+    software: stratoweave_rfs__device__mock__software
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool=None, software: ?stratoweave_rfs__device__mock__software=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled if enabled is not None else False
+        self.software = software if software is not None else stratoweave_rfs__device__mock__software()
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2298,7 +2370,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), software=stratoweave_rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_stratoweave_rfs, 'software'))), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:
@@ -2306,7 +2378,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class stratoweave_rfs__device__debug(yadata.MNode):
     connection: bool
 
@@ -2327,7 +2399,7 @@ class stratoweave_rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class stratoweave_rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: bool
 
@@ -2348,7 +2420,7 @@ class stratoweave_rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -2368,7 +2440,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -2401,7 +2473,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
         return stratoweave_rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class stratoweave_rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -2430,7 +2502,7 @@ class stratoweave_rfs__device__software(yadata.MNode):
         return stratoweave_rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker19: None = None
+_breaker20: None = None
 class stratoweave_rfs__device_entry(yadata.MNode):
     name: str
     description: ?str
@@ -2470,7 +2542,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker20: None = None
+_breaker21: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2508,7 +2580,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
         return stratoweave_rfs__device(elements=copied_elements)
 
 
-_breaker21: None = None
+_breaker22: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
 
@@ -2526,7 +2598,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker22: None = None
+_breaker23: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2557,7 +2629,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker23: None = None
+_breaker24: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs

--- a/fleetmgr/src/flotilla/layers/y_0_loose.act
+++ b/fleetmgr/src/flotilla/layers/y_0_loose.act
@@ -75,6 +75,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -305,6 +310,46 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -2227,6 +2272,31 @@ class stratoweave_rfs__device__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class stratoweave_rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'running-release')))
+        return stratoweave_rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -2250,7 +2320,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2285,13 +2355,15 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: ?bool
+    software: stratoweave_rfs__device__mock__software
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?stratoweave_rfs__device__mock__software=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else stratoweave_rfs__device__mock__software()
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2300,7 +2372,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), software=stratoweave_rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_stratoweave_rfs, 'software'))), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:
@@ -2308,7 +2380,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class stratoweave_rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -2329,7 +2401,7 @@ class stratoweave_rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class stratoweave_rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -2350,7 +2422,7 @@ class stratoweave_rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -2370,7 +2442,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -2403,7 +2475,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
         return stratoweave_rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class stratoweave_rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -2432,7 +2504,7 @@ class stratoweave_rfs__device__software(yadata.MNode):
         return stratoweave_rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker19: None = None
+_breaker20: None = None
 class stratoweave_rfs__device_entry(yadata.MNode):
     name: str
     description: ?str
@@ -2472,7 +2544,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker20: None = None
+_breaker21: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2509,7 +2581,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
         return stratoweave_rfs__device(elements=copied_elements)
 
 
-_breaker21: None = None
+_breaker22: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
 
@@ -2527,7 +2599,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker22: None = None
+_breaker23: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2558,7 +2630,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker23: None = None
+_breaker24: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs

--- a/fleetmgr/src/flotilla/layers/y_0_oper.act
+++ b/fleetmgr/src/flotilla/layers/y_0_oper.act
@@ -76,6 +76,11 @@ SRC_DNODE_CHILD_8: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_9: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='software', config=True, description='How the mock behaves during a software upgrade.', presence=False, children=[
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='upgrade-duration', config=True, description='Seconds a whole mock software upgrade takes, spread over its\noperations as measured on a real device. Absent or 0 completes\neach operation at once.', mandatory=False, type=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])), units='seconds'),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='failure', config=True, description='IOS XE failure the mock reproduces during an upgrade.', default='none', mandatory=False, type=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'none':0, 'download-failed':1, 'add-failed':2, 'activate-refused':3, 'commit-failed':4, 'reverts':5})),
+        DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='running-release', config=True, description='Release the mock runs before any upgrade. Absent means 17.18.02.', mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -335,6 +340,46 @@ SRC_YANG_1: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
+      }
+      container software {
+        description
+          "How the mock behaves during a software upgrade.";
+        leaf upgrade-duration {
+          description
+            "Seconds a whole mock software upgrade takes, spread over its
+             operations as measured on a real device. Absent or 0 completes
+             each operation at once.";
+          units "seconds";
+          type uint16;
+        }
+        leaf failure {
+          description
+            "IOS XE failure the mock reproduces during an upgrade.";
+          type enumeration {
+            enum none;
+            enum download-failed {
+              description "The download fails after xcopy was accepted.";
+            }
+            enum add-failed {
+              description "The verify stage fails after install add was accepted.";
+            }
+            enum activate-refused {
+              description "activate is rejected, as when the image was not added.";
+            }
+            enum commit-failed {
+              description "The commit stage fails after install-commit was accepted.";
+            }
+            enum reverts {
+              description "The abort timer runs out before the commit.";
+            }
+          }
+          default "none";
+        }
+        leaf running-release {
+          description
+            "Release the mock runs before any upgrade. Absent means 17.18.02.";
+          type string;
+        }
       }
       list module {
         key "name";
@@ -2257,6 +2302,31 @@ class stratoweave_rfs__device__ssh(yadata.MNode):
 
 
 _breaker11: None = None
+class stratoweave_rfs__device__mock__software(yadata.MNode):
+    upgrade_duration: ?u64
+    failure: ?str
+    running_release: ?str
+
+    mut def __init__(self, upgrade_duration: ?u64, failure: ?str, running_release: ?str) -> None:
+        self.upgrade_duration = upgrade_duration
+        self.failure = failure
+        self.running_release = running_release
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock', 'software'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock__software:
+        if n is not None:
+            return stratoweave_rfs__device__mock__software(upgrade_duration=n.get_opt_u64(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration')), failure=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'failure')), running_release=n.get_opt_str(ygdata.Id(NS_stratoweave_rfs, 'running-release')))
+        return stratoweave_rfs__device__mock__software()
+
+    mut def copy(self) -> stratoweave_rfs__device__mock__software:
+        """Create a deep copy of this adata object"""
+        return stratoweave_rfs__device__mock__software.from_gdata(self.to_gdata())
+
+
+_breaker12: None = None
 class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
     name: str
     namespace: ?str
@@ -2280,7 +2350,7 @@ class stratoweave_rfs__device__mock__module_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker12: None = None
+_breaker13: None = None
 class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_rfs__device__mock__module_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2315,13 +2385,15 @@ class stratoweave_rfs__device__mock__module(yadata.MKeyedList[str, stratoweave_r
         return stratoweave_rfs__device__mock__module(elements=copied_elements)
 
 
-_breaker13: None = None
+_breaker14: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: ?bool
+    software: stratoweave_rfs__device__mock__software
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, software: ?stratoweave_rfs__device__mock__software=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
+        self.software = software if software is not None else stratoweave_rfs__device__mock__software()
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     mut def to_gdata(self) -> ygdata.Node:
@@ -2330,7 +2402,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), software=stratoweave_rfs__device__mock__software.from_gdata(n.get_opt_cnt(ygdata.Id(NS_stratoweave_rfs, 'software'))), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:
@@ -2338,7 +2410,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker14: None = None
+_breaker15: None = None
 class stratoweave_rfs__device__debug(yadata.MNode):
     connection: ?bool
 
@@ -2359,7 +2431,7 @@ class stratoweave_rfs__device__debug(yadata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker15: None = None
+_breaker16: None = None
 class stratoweave_rfs__device__feature_flags(yadata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -2380,7 +2452,7 @@ class stratoweave_rfs__device__feature_flags(yadata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker16: None = None
+_breaker17: None = None
 class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
     holder: str
     reason: ?str
@@ -2400,7 +2472,7 @@ class stratoweave_rfs__device__software__veto_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__veto_entry.from_gdata(self.to_gdata())
 
-_breaker17: None = None
+_breaker18: None = None
 class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave_rfs__device__software__veto_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__veto_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.holder, elements)
@@ -2433,7 +2505,7 @@ class stratoweave_rfs__device__software__veto(yadata.MKeyedList[str, stratoweave
         return stratoweave_rfs__device__software__veto(elements=copied_elements)
 
 
-_breaker18: None = None
+_breaker19: None = None
 class stratoweave_rfs__device__software__state__job_entry(yadata.MNode):
     name: str
     state: ?str
@@ -2461,7 +2533,7 @@ class stratoweave_rfs__device__software__state__job_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__software__state__job_entry.from_gdata(self.to_gdata())
 
-_breaker19: None = None
+_breaker20: None = None
 class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, stratoweave_rfs__device__software__state__job_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device__software__state__job_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2502,7 +2574,7 @@ class stratoweave_rfs__device__software__state__job(yadata.MKeyedList[str, strat
         return stratoweave_rfs__device__software__state__job(elements=copied_elements)
 
 
-_breaker20: None = None
+_breaker21: None = None
 class stratoweave_rfs__device__software__state__precheck(yadata.MNode):
     verdict: ?str
     detail: ?str
@@ -2527,7 +2599,7 @@ class stratoweave_rfs__device__software__state__precheck(yadata.MNode):
         return stratoweave_rfs__device__software__state__precheck.from_gdata(self.to_gdata())
 
 
-_breaker21: None = None
+_breaker22: None = None
 class stratoweave_rfs__device__software__state__postcheck(yadata.MNode):
     verdict: ?str
     detail: ?str
@@ -2552,7 +2624,7 @@ class stratoweave_rfs__device__software__state__postcheck(yadata.MNode):
         return stratoweave_rfs__device__software__state__postcheck.from_gdata(self.to_gdata())
 
 
-_breaker22: None = None
+_breaker23: None = None
 class stratoweave_rfs__device__software__state(yadata.MNode):
     status: ?str
     running_release: ?str
@@ -2581,7 +2653,7 @@ class stratoweave_rfs__device__software__state(yadata.MNode):
         return stratoweave_rfs__device__software__state.from_gdata(self.to_gdata())
 
 
-_breaker23: None = None
+_breaker24: None = None
 class stratoweave_rfs__device__software(yadata.MNode):
     upgrade_campaign: ?str
     target_release: ?str
@@ -2612,7 +2684,7 @@ class stratoweave_rfs__device__software(yadata.MNode):
         return stratoweave_rfs__device__software.from_gdata(self.to_gdata())
 
 
-_breaker24: None = None
+_breaker25: None = None
 class stratoweave_rfs__device__state(yadata.MNode):
 
     mut def __init__(self) -> None:
@@ -2632,7 +2704,7 @@ class stratoweave_rfs__device__state(yadata.MNode):
         return stratoweave_rfs__device__state.from_gdata(self.to_gdata())
 
 
-_breaker25: None = None
+_breaker26: None = None
 class stratoweave_rfs__device_entry(yadata.MNode):
     name: str
     description: ?str
@@ -2674,7 +2746,7 @@ class stratoweave_rfs__device_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker26: None = None
+_breaker27: None = None
 class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2711,7 +2783,7 @@ class stratoweave_rfs__device(yadata.MKeyedList[str, stratoweave_rfs__device_ent
         return stratoweave_rfs__device(elements=copied_elements)
 
 
-_breaker27: None = None
+_breaker28: None = None
 class stratoweave_rfs__rfs_entry(yadata.MNode):
     name: str
 
@@ -2729,7 +2801,7 @@ class stratoweave_rfs__rfs_entry(yadata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker28: None = None
+_breaker29: None = None
 class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
     mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
@@ -2760,7 +2832,7 @@ class stratoweave_rfs__rfs(yadata.MKeyedList[str, stratoweave_rfs__rfs_entry]):
         return stratoweave_rfs__rfs(elements=copied_elements)
 
 
-_breaker29: None = None
+_breaker30: None = None
 class root(yadata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
@@ -2788,7 +2860,27 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
-_breaker30: None = None
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
+_breaker31: None = None
 class stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2804,7 +2896,24 @@ class stratoweave_rfs__device__address__initial_credentials_entry_subs(Subscript
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker31: None = None
+_breaker32: None = None
+proc def stratoweave_rfs__device__address__initial_credentials_deliver(cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__address__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__device__address__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'address')), 'address')
+            e3 = _one(_at(e2, ygdata.Id(NS_stratoweave_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), address_name=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), initial_credentials_username=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'username')), initial_credentials_password=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'password')), initial_credentials_key=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2824,11 +2933,17 @@ class stratoweave_rfs__device__address__initial_credentials_subs(SubscriptionNod
         base_path = self._path!.parent
         return stratoweave_rfs__device__address__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, address_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__address__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__address__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker32: None = None
+_breaker33: None = None
 class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2846,7 +2961,23 @@ class stratoweave_rfs__device__address_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker33: None = None
+_breaker34: None = None
+proc def stratoweave_rfs__device__address_deliver(cb: action(?(device_name: str, address_name: str), ?stratoweave_rfs__device__address_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, address_name: str) = None
+    inst: ?stratoweave_rfs__device__address_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'address')), 'address')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), address_name=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__device__address_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__address_subs(SubscriptionNode):
     name: SubscriptionNode
     address: SubscriptionNode
@@ -2866,11 +2997,17 @@ class stratoweave_rfs__device__address_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__address_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'address'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, address_name: str), ?stratoweave_rfs__device__address_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__address_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.address, self.port, self.initial_credentials]
         return direct
 
-_breaker34: None = None
+_breaker35: None = None
 class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2884,7 +3021,24 @@ class stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker35: None = None
+_breaker36: None = None
+proc def stratoweave_rfs__device__credentials__key_deliver(cb: action(?(device_name: str, key_key: str), ?stratoweave_rfs__device__credentials__key_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, key_key: str) = None
+    inst: ?stratoweave_rfs__device__credentials__key_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'credentials'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'key')), 'key')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), key_key=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__credentials__key_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
     key: SubscriptionNode
     private_key: SubscriptionNode
@@ -2900,11 +3054,33 @@ class stratoweave_rfs__device__credentials__key_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__credentials__key_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'key'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, key_key: str), ?stratoweave_rfs__device__credentials__key_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__credentials__key_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.key, self.private_key]
         return direct
 
-_breaker36: None = None
+_breaker37: None = None
+proc def stratoweave_rfs__device__credentials_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__credentials, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__credentials = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'credentials'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__credentials.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2920,7 +3096,13 @@ class stratoweave_rfs__device__credentials_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker37: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__credentials, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__credentials_deliver(cb, n, err), root=self.filt())
+
+_breaker38: None = None
 class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2936,7 +3118,23 @@ class stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker38: None = None
+_breaker39: None = None
+proc def stratoweave_rfs__device__initial_credentials_deliver(cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__initial_credentials_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str) = None
+    inst: ?stratoweave_rfs__device__initial_credentials_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            e2 = _one(_at(e1, ygdata.Id(NS_stratoweave_rfs, 'initial-credentials')), 'initial-credentials')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), initial_credentials_username=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'username')), initial_credentials_password=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'password')), initial_credentials_key=e2.get_str(ygdata.Id(NS_stratoweave_rfs, 'key')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_rfs__device__initial_credentials_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
     username: SubscriptionNode
     password: SubscriptionNode
@@ -2956,11 +3154,33 @@ class stratoweave_rfs__device__initial_credentials_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__initial_credentials_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'initial-credentials'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, initial_credentials_username: str, initial_credentials_password: str, initial_credentials_key: str), ?stratoweave_rfs__device__initial_credentials_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__initial_credentials_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.username, self.password, self.key]
         return direct
 
-_breaker39: None = None
+_breaker40: None = None
+proc def stratoweave_rfs__device__ssh_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__ssh, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__ssh = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'ssh'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__ssh.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
     cipher: SubscriptionNode
     mac: SubscriptionNode
@@ -2990,7 +3210,52 @@ class stratoweave_rfs__device__ssh_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.cipher, self.mac, self.key_exchange, self.host_key_algorithm, self.public_key_algorithm, self.compression_algorithm, self.compression_level, self.rekey_after_bytes, self.rekey_after_seconds, self.minimum_rsa_bits]
         return direct
 
-_breaker40: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__ssh, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__ssh_deliver(cb, n, err), root=self.filt())
+
+_breaker41: None = None
+proc def stratoweave_rfs__device__mock__software_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__mock__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__mock__software = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
+class stratoweave_rfs__device__mock__software_subs(SubscriptionNode):
+    upgrade_duration: SubscriptionNode
+    failure: SubscriptionNode
+    running_release: SubscriptionNode
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.upgrade_duration = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'upgrade-duration'), parent=path))
+        self.failure = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'failure'), parent=path))
+        self.running_release = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'running-release'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.upgrade_duration, self.failure, self.running_release]
+        return direct
+
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__mock__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock__software_deliver(cb, n, err), root=self.filt())
+
+_breaker42: None = None
 class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -3008,7 +3273,24 @@ class stratoweave_rfs__device__mock__module_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker41: None = None
+_breaker43: None = None
+proc def stratoweave_rfs__device__mock__module_deliver(cb: action(?(device_name: str, module_name: str), ?stratoweave_rfs__device__mock__module_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, module_name: str) = None
+    inst: ?stratoweave_rfs__device__mock__module_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'module')), 'module')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), module_name=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock__module_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
     name: SubscriptionNode
     namespace: SubscriptionNode
@@ -3028,25 +3310,71 @@ class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__mock__module_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'module'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, module_name: str), ?stratoweave_rfs__device__mock__module_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock__module_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.namespace, self.revision, self.feature]
         return direct
 
-_breaker42: None = None
+_breaker44: None = None
+proc def stratoweave_rfs__device__mock_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__mock, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__mock = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'mock'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__mock.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
+    software: stratoweave_rfs__device__mock__software_subs
     module: stratoweave_rfs__device__mock__module_subs
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'enabled'), parent=path))
+        self.software = stratoweave_rfs__device__mock__software_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'software'), parent=path))
         self.module = stratoweave_rfs__device__mock__module_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'module'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.enabled, self.module]
+        direct: list[SubscriptionNode] = [self.enabled, self.software, self.module]
         return direct
 
-_breaker43: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__mock, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__mock_deliver(cb, n, err), root=self.filt())
+
+_breaker45: None = None
+proc def stratoweave_rfs__device__debug_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__debug, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__debug = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'debug'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__debug.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__debug_subs(SubscriptionNode):
     connection: SubscriptionNode
 
@@ -3058,7 +3386,29 @@ class stratoweave_rfs__device__debug_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.connection]
         return direct
 
-_breaker44: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__debug, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__debug_deliver(cb, n, err), root=self.filt())
+
+_breaker46: None = None
+proc def stratoweave_rfs__device__feature_flags_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__feature_flags, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__feature_flags = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'feature-flags'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__feature_flags.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
     runtime_schema_fetch: SubscriptionNode
 
@@ -3070,7 +3420,13 @@ class stratoweave_rfs__device__feature_flags_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.runtime_schema_fetch]
         return direct
 
-_breaker45: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__feature_flags, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__feature_flags_deliver(cb, n, err), root=self.filt())
+
+_breaker47: None = None
 class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -3084,7 +3440,24 @@ class stratoweave_rfs__device__software__veto_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker46: None = None
+_breaker48: None = None
+proc def stratoweave_rfs__device__software__veto_deliver(cb: action(?(device_name: str, veto_holder: str), ?stratoweave_rfs__device__software__veto_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, veto_holder: str) = None
+    inst: ?stratoweave_rfs__device__software__veto_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            e3 = _one(_at(c2, ygdata.Id(NS_stratoweave_rfs, 'veto')), 'veto')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), veto_holder=e3.get_str(ygdata.Id(NS_stratoweave_rfs, 'holder')))
+            here = _present(e3)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__veto_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
     holder: SubscriptionNode
     reason: SubscriptionNode
@@ -3100,11 +3473,17 @@ class stratoweave_rfs__device__software__veto_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__software__veto_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'veto'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, veto_holder: str), ?stratoweave_rfs__device__software__veto_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__veto_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.holder, self.reason]
         return direct
 
-_breaker47: None = None
+_breaker49: None = None
 class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -3126,7 +3505,25 @@ class stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker48: None = None
+_breaker50: None = None
+proc def stratoweave_rfs__device__software__state__job_deliver(cb: action(?(device_name: str, job_name: str), ?stratoweave_rfs__device__software__state__job_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str, job_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__job_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            e4 = _one(_at(c3, ygdata.Id(NS_stratoweave_rfs, 'job')), 'job')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')), job_name=e4.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__job_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
     name: SubscriptionNode
     state: SubscriptionNode
@@ -3150,11 +3547,35 @@ class stratoweave_rfs__device__software__state__job_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device__software__state__job_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'job'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str, job_name: str), ?stratoweave_rfs__device__software__state__job_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__job_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.state, self.started, self.ended, self.progress, self.message]
         return direct
 
-_breaker49: None = None
+_breaker51: None = None
+proc def stratoweave_rfs__device__software__state__precheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__precheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__precheck = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            c4 = _at(c3, ygdata.Id(NS_stratoweave_rfs, 'precheck'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__precheck.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -3170,7 +3591,31 @@ class stratoweave_rfs__device__software__state__precheck_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
-_breaker50: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__precheck, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__precheck_deliver(cb, n, err), root=self.filt())
+
+_breaker52: None = None
+proc def stratoweave_rfs__device__software__state__postcheck_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__postcheck, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state__postcheck = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            c4 = _at(c3, ygdata.Id(NS_stratoweave_rfs, 'postcheck'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c4)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state__postcheck.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode):
     verdict: SubscriptionNode
     detail: SubscriptionNode
@@ -3186,7 +3631,30 @@ class stratoweave_rfs__device__software__state__postcheck_subs(SubscriptionNode)
         direct: list[SubscriptionNode] = [self.verdict, self.detail, self.at]
         return direct
 
-_breaker51: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state__postcheck, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state__postcheck_deliver(cb, n, err), root=self.filt())
+
+_breaker53: None = None
+proc def stratoweave_rfs__device__software__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            c3 = _at(c2, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c3)
+            if here is not None:
+                inst = stratoweave_rfs__device__software__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
     status: SubscriptionNode
     running_release: SubscriptionNode
@@ -3206,7 +3674,29 @@ class stratoweave_rfs__device__software__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.status, self.running_release, self.job, self.precheck, self.postcheck]
         return direct
 
-_breaker52: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software__state_deliver(cb, n, err), root=self.filt())
+
+_breaker54: None = None
+proc def stratoweave_rfs__device__software_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__software, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__software = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'software'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__software.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__software_subs(SubscriptionNode):
     upgrade_campaign: SubscriptionNode
     target_release: SubscriptionNode
@@ -3228,7 +3718,29 @@ class stratoweave_rfs__device__software_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.upgrade_campaign, self.target_release, self.image_url, self.allow_staging, self.veto, self.state]
         return direct
 
-_breaker53: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__software, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__software_deliver(cb, n, err), root=self.filt())
+
+_breaker55: None = None
+proc def stratoweave_rfs__device__state_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device__state, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device__state = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            c2 = _at(e1, ygdata.Id(NS_stratoweave_rfs, 'state'))
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(c2)
+            if here is not None:
+                inst = stratoweave_rfs__device__state.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device__state_subs(SubscriptionNode):
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -3238,7 +3750,13 @@ class stratoweave_rfs__device__state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = []
         return direct
 
-_breaker54: None = None
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device__state, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this container as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device__state_deliver(cb, n, err), root=self.filt())
+
+_breaker56: None = None
 class stratoweave_rfs__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -3274,7 +3792,22 @@ class stratoweave_rfs__device_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker55: None = None
+_breaker57: None = None
+proc def stratoweave_rfs__device_deliver(cb: action(?(device_name: str), ?stratoweave_rfs__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_rfs__device_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'device')), 'device')
+            keys = (device_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e1)
+            if here is not None:
+                inst = stratoweave_rfs__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__device_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -3312,11 +3845,17 @@ class stratoweave_rfs__device_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__device_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_rfs__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.address, self.credentials, self.initial_credentials, self.ssh, self.approval_required, self.mock, self.debug, self.feature_flags, self.software, self.state]
         return direct
 
-_breaker56: None = None
+_breaker58: None = None
 class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
     name: SubscriptionNode
 
@@ -3328,7 +3867,22 @@ class stratoweave_rfs__rfs_entry_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name]
         return direct
 
-_breaker57: None = None
+_breaker59: None = None
+proc def stratoweave_rfs__rfs_deliver(cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(rfs_name: str) = None
+    inst: ?stratoweave_rfs__rfs_entry = None
+    if n is not None:
+        try:
+            e1 = _one(_at(n, ygdata.Id(NS_stratoweave_rfs, 'rfs')), 'rfs')
+            keys = (rfs_name=e1.get_str(ygdata.Id(NS_stratoweave_rfs, 'name')))
+            here = _present(e1)
+            if here is not None:
+                inst = stratoweave_rfs__rfs_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_rfs__rfs_subs(SubscriptionNode):
     name: SubscriptionNode
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
@@ -3342,11 +3896,17 @@ class stratoweave_rfs__rfs_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_rfs__rfs_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'rfs'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(rfs_name: str), ?stratoweave_rfs__rfs_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_rfs__rfs_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name]
         return direct
 
-_breaker58: None = None
+_breaker60: None = None
 class root_subs(SubscriptionNode):
     device: stratoweave_rfs__device_subs
     rfs: stratoweave_rfs__rfs_subs
@@ -3362,17 +3922,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/fleetmgr/src/flotilla/layers/y_1_oper.act
+++ b/fleetmgr/src/flotilla/layers/y_1_oper.act
@@ -241,6 +241,26 @@ actor rpc_root(tp: ygdata.TreeProvider):
 
 
 
+def _at(n: ?ygdata.Node, name: ygdata.Id) -> ?ygdata.Node:
+    """The child name of n on a delivery's spine, if there."""
+    if n is not None:
+        return n.children.get(name)
+    return None
+
+def _one(n: ?ygdata.Node, what: str) -> ygdata.Node:
+    """The one entry of a list on a delivery's spine."""
+    if isinstance(n, ygdata.List):
+        if len(n.elements) == 1:
+            return n.elements[0]
+    raise ValueError("a rooted delivery without its " + what + " entry")
+
+def _present(n: ?ygdata.Node) -> ?ygdata.Node:
+    """An instance that is there: not missing, not an Absent."""
+    if n is not None:
+        if not isinstance(n, ygdata.Absent):
+            return n
+    return None
+
 _breaker5: None = None
 class stratoweave_device__devices__device_entry_subs(SubscriptionNode):
     name: SubscriptionNode
@@ -256,6 +276,22 @@ class stratoweave_device__devices__device_entry_subs(SubscriptionNode):
         return direct
 
 _breaker6: None = None
+proc def stratoweave_device__devices__device_deliver(cb: action(?(device_name: str), ?stratoweave_device__devices__device_entry, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    keys: ?(device_name: str) = None
+    inst: ?stratoweave_device__devices__device_entry = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_stratoweave_device, 'devices'))
+            e2 = _one(_at(c1, ygdata.Id(NS_stratoweave_device, 'device')), 'device')
+            keys = (device_name=e2.get_str(ygdata.Id(NS_stratoweave_device, 'name')))
+            here = _present(e2)
+            if here is not None:
+                inst = stratoweave_device__devices__device_entry.from_gdata(here)
+        except Exception as e:
+            cb(None, None, e)
+            return
+    cb(keys, inst, err)
+
 class stratoweave_device__devices__device_subs(SubscriptionNode):
     name: SubscriptionNode
     modset_id: SubscriptionNode
@@ -271,11 +307,30 @@ class stratoweave_device__devices__device_subs(SubscriptionNode):
         base_path = self._path!.parent
         return stratoweave_device__devices__device_entry_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_device, 'device'), predicates=predicates, parent=base_path))
 
+    def dst(self, cb: action(?(device_name: str), ?stratoweave_device__devices__device_entry, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        the keys of the lists on the way down, this entry as it is
+        after a change or None when it is gone, and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_device__devices__device_deliver(cb, n, err), root=self.filt())
+
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.name, self.modset_id]
         return direct
 
 _breaker7: None = None
+proc def stratoweave_device__devices_deliver(cb: action(?stratoweave_device__devices, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    inst: ?stratoweave_device__devices = None
+    if n is not None:
+        try:
+            c1 = _at(n, ygdata.Id(NS_stratoweave_device, 'devices'))
+            here = _present(c1)
+            if here is not None:
+                inst = stratoweave_device__devices.from_gdata(here)
+        except Exception as e:
+            cb(None, e)
+            return
+    cb(inst, err)
+
 class stratoweave_device__devices_subs(SubscriptionNode):
     device: stratoweave_device__devices__device_subs
 
@@ -286,6 +341,12 @@ class stratoweave_device__devices_subs(SubscriptionNode):
     pure def _direct_children(self) -> list[SubscriptionNode]:
         direct: list[SubscriptionNode] = [self.device]
         return direct
+
+    def dst(self, cb: action(?stratoweave_device__devices, ?Exception) -> None) -> ygdata.Dst:
+        """A destination rooted here: cb gets, one instance at a time,
+        this container as it is after a change or None when it is gone,
+        and an error."""
+        return ygdata.Dst(lambda n, err: stratoweave_device__devices_deliver(cb, n, err), root=self.filt())
 
 _breaker8: None = None
 class root_subs(SubscriptionNode):
@@ -301,17 +362,15 @@ class root_subs(SubscriptionNode):
 
 subs: root_subs = root_subs()
 
-actor DstAdapter(cb: action(?root, ?Exception) -> None):
-    on_update: action(?ygdata.Node, ?Exception) -> None
-    def on_update(n: ?ygdata.Node, err: ?Exception) -> None:
-        if err is not None:
-            cb(None, err)
-            return
-        if n is not None:
-            cb(root.from_gdata(n), None)
-            return
+proc def _deliver_root(cb: action(?root, ?Exception) -> None, n: ?ygdata.Node, err: ?Exception) -> None:
+    if err is not None:
+        cb(None, err)
+    elif n is not None:
+        cb(root.from_gdata(n), None)
+    else:
         cb(None, None)
 
-proc def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
-    adapter = DstAdapter(cb)
-    return ygdata.Dst(adapter.on_update)
+def dst(cb: action(?root, ?Exception) -> None) -> ygdata.Dst:
+    """A destination at the top of the tree: cb gets the whole subscribed
+    tree on every delivery."""
+    return ygdata.Dst(lambda n, err: _deliver_root(cb, n, err))

--- a/fleetmgr/src/test_fleetmgr_cfs.act
+++ b/fleetmgr/src/test_fleetmgr_cfs.act
@@ -267,6 +267,9 @@ actor _test_device_transform(t: testing.AsyncT):
         key="device-key",
     ))
     i.mock.enabled = True
+    i.mock.software.upgrade_duration = u64(60)
+    i.mock.software.failure = "commit-failed"
+    i.mock.software.running_release = "17.18.03a"
     module: InputMockModule = i.mock.module.create(
         "ietf-system",
         namespace="urn:ietf:params:xml:ns:yang:ietf-system",
@@ -310,6 +313,10 @@ actor _test_device_transform(t: testing.AsyncT):
          out_module.revision != "2014-08-06" or \
          out_module.feature != ["authentication", "local-users"]:
         t.failure(ValueError("mock module fields were not preserved"))
+    elif dev.mock.software.upgrade_duration != 60 or \
+         dev.mock.software.failure != "commit-failed" or \
+         dev.mock.software.running_release != "17.18.03a":
+        t.failure(ValueError("mock upgrade duration, failure or running release was not preserved"))
     elif not dev.debug.connection! or not dev.feature_flags.runtime_schema_fetch!:
         t.failure(ValueError("debug or feature flags were not preserved"))
     else:

--- a/fleetmgr/src/test_fleetmgr_rfs.act
+++ b/fleetmgr/src/test_fleetmgr_rfs.act
@@ -40,6 +40,9 @@ actor _test_device_transform(t: testing.AsyncT):
         key="fallback-key",
     ))
     i.mock.enabled = True
+    i.mock.software.upgrade_duration = u64(60)
+    i.mock.software.failure = "commit-failed"
+    i.mock.software.running_release = "17.18.03a"
     module: InputMockModule = i.mock.module.create(
         "cpe-device",
         namespace="urn:fleetmgr:cpe-device",
@@ -73,6 +76,10 @@ actor _test_device_transform(t: testing.AsyncT):
         t.failure(ValueError("device policy was not rendered"))
     elif dev.mock.module.get("cpe-device")!.feature != ["feature-a", "feature-b"]:
         t.failure(ValueError("mock features were not rendered"))
+    elif dev.mock.software.upgrade_duration != 60 or \
+         dev.mock.software.failure != "commit-failed" or \
+         dev.mock.software.running_release != "17.18.03a":
+        t.failure(ValueError("mock upgrade duration, failure or running release was not rendered"))
     elif not dev.debug.connection! or not dev.feature_flags.runtime_schema_fetch!:
         t.failure(ValueError("debug or feature flags were not rendered"))
     elif dev.software.upgrade_campaign != "xe-upgrade" or \

--- a/fleetmgr/upgrade.xml
+++ b/fleetmgr/upgrade.xml
@@ -11,6 +11,9 @@
             <device>
                 <name>cpe-02</name>
             </device>
+            <device>
+                <name>cpe-03</name>
+            </device>
             <admin-state>run</admin-state>
         </upgrade-campaign>
     </software>


### PR DESCRIPTION
Set the mock's upgrade duration, failure and running release per device
The transforms copy the three mock/software leaves down to the flotilla,
which builds the IOS XE mock from them instead of a fixed delay and scales
the adapter's poll periods to the slowest mock operation.
