### PR TITLE
Add scaling scenarios for the engine and the yang operations it calls

### DIFF
--- a/src/test_gdata_perf.act
+++ b/src/test_gdata_perf.act
@@ -1,0 +1,432 @@
+"""Scaling scenarios for the acton-yang operations the engine leans on.
+
+    acton test perf  --module test_gdata_perf
+    acton test scale --module test_gdata_perf --name filter_each --end-scale 100000
+
+This mirrors test_gdata_scale in acton-yang, so that what a node pays
+per transaction and per message is visible from this repository. Scale
+is the number of list entries. Every scenario builds its inputs before
+the loop, from t.scale(), so a body measures the operation alone. The
+scenarios named `_each` run an operation that names one entry a fixed
+EACH times per body, so their growth is the growth of one such call
+with the size of the list: flat when the call costs the entry, linear
+when it pays for the whole list, which is then what the transaction
+engine pays on every transaction that calls it. The other scenarios
+run a whole-list operation once per body and are linear at best.
+
+The operations are the ones a node runs per transaction and per
+message: merge, diff, patch, filter and prune of trees; equality and
+key_str of list entries; adata encoding and decoding, which is every
+transform's output and input; XML and JSON encoding and decoding, which
+is every NETCONF and RESTCONF message; and yang-patch conversion, which
+is every RESTCONF edit and every diff pushed to a device.
+"""
+
+import testing
+import std.xml as xml
+
+import yang
+import yang.adata as yadata
+import yang.gdata as ygdata
+import yang.schema as yschema
+import yang.xml as yxml
+import yang.ypatch as ypatch
+
+NS = "urn:test:gdata-perf"
+MODULE = "gdata-perf"
+LEAVES = 4
+
+# One-entry operations per body.
+EACH = 64
+
+
+def _q(name: str) -> ygdata.Id:
+    return ygdata.Id(NS, name)
+
+
+KEY = _q("name")
+KEYS: list[ygdata.Id] = [KEY]
+DEVICE = _q("device")
+
+
+def _dev_name(i: int) -> str:
+    return "dev-" + str(1000000000 + i)[1:]
+
+
+def _elem(i: int, value: int) -> ygdata.Node:
+    """One entry: key `name`, a `value` and LEAVES more leaves."""
+    # Namespace and module on lists and leaves, none on list entries: what
+    # the adata encoder produces, and what the XML and yang-patch
+    # encoders need to qualify names.
+    pairs: list[(ygdata.Id, ygdata.Node)] = [
+        (KEY, ygdata.Leaf(_dev_name(i), ns=NS, module=MODULE)),
+        (_q("value"), ygdata.Leaf(value, ns=NS, module=MODULE)),
+    ]
+    leaves: list[(ygdata.Id, ygdata.Node)] = [(_q("leaf" + str(j)), ygdata.Leaf("value-" + str(j) + "-" + str(value), ns=NS, module=MODULE)) for j in range(LEAVES)]
+    return ygdata.Container(dict(pairs + leaves))
+
+
+def _elements(start: int, count: int, value: int) -> list[ygdata.Node]:
+    return [_elem(i, value) for i in range(start, start + count)]
+
+
+def _tree(elements: list[ygdata.Node]) -> ygdata.Container:
+    return ygdata.Container({DEVICE: ygdata.List(KEYS, elements, ns=NS, module=MODULE)})
+
+
+def _devices(start: int, count: int, value: int) -> ygdata.Container:
+    return _tree(_elements(start, count, value))
+
+
+def _shuffled(elements: list[ygdata.Node]) -> list[ygdata.Node]:
+    """The same elements in a different (stride permuted) order."""
+    n = len(elements)
+    return [elements[(i * 7919) % n] for i in range(n)]
+
+
+def _spread(i: int, n: int) -> int:
+    """Entry i of a walk over `n` entries that does not favour locality."""
+    return (i * 7919) % n
+
+
+def _device_list(tree: ?ygdata.Node) -> ygdata.List:
+    if tree is not None:
+        l = tree.children.get(DEVICE)
+        if isinstance(l, ygdata.List):
+            return l
+    raise ValueError("expected a /device list")
+
+
+def _key_pred(i: int) -> ygdata.FNode:
+    """A root filter selecting /device[name=...] for entry i."""
+    return ygdata.FNode(children=[ygdata.FNode(DEVICE, children=[ygdata.FNode(KEY, value_match=_dev_name(i))])])
+
+
+def _count(tree: ?ygdata.Node, expected: int) -> None:
+    n = len(_device_list(tree).elements)
+    if n != expected:
+        raise ValueError("expected {expected} entries, got {n}")
+
+
+def _one_changed(elements: list[ygdata.Node], i: int) -> ygdata.Container:
+    """The list with entry i given a new value."""
+    b = list(elements)
+    b[i] = _elem(i, 2)
+    return _tree(b)
+
+
+# The schema of the list, as ayangc would compile it.
+
+YANG = r"""module gdata-perf {
+  namespace "urn:test:gdata-perf";
+  prefix gp;
+  list device {
+    key name;
+    leaf name { type string; }
+    leaf value { type int32; }
+    leaf leaf0 { type string; }
+    leaf leaf1 { type string; }
+    leaf leaf2 { type string; }
+    leaf leaf3 { type string; }
+  }
+}"""
+
+
+def _schema() -> yschema.DRoot:
+    return yang.compile([YANG])
+
+
+# Whole-list operations: one per body, linear at best.
+
+def _test_key_str_all(t: testing.SyncT):
+    """key_str of every entry"""
+    elements = _elements(0, t.scale(), 1)
+    for n in t.loop():
+        count = 0
+        for e in elements:
+            if len(e.key_str(KEYS)) > 0:
+                count += 1
+        assert count == n
+
+
+def _test_merge_disjoint(t: testing.SyncT):
+    """merge of two lists with disjoint keys"""
+    a = _devices(0, t.scale(), 1)
+    b = _devices(t.scale(), t.scale(), 1)
+    for n in t.loop():
+        _count(ygdata.merge(a, b), 2 * n)
+
+
+def _test_merge_same(t: testing.SyncT):
+    """merge of two lists with the same keys and values"""
+    a = _devices(0, t.scale(), 1)
+    b = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        _count(ygdata.merge(a, b), n)
+
+
+def _test_diff_one(t: testing.SyncT):
+    """diff of two lists differing in one entry"""
+    a = _elements(0, t.scale(), 1)
+    ta = _tree(a)
+    tb = _one_changed(a, 0)
+    for n in t.loop():
+        _count(ygdata.diff(ta, tb), 1)
+
+
+def _test_diff_equal(t: testing.SyncT):
+    """diff of two equal lists"""
+    a = _devices(0, t.scale(), 1)
+    b = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        assert ygdata.diff(a, b) is None
+
+
+def _test_eq_same_order(t: testing.SyncT):
+    """equality of two equal lists in the same order"""
+    a = _devices(0, t.scale(), 1)
+    b = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        assert a == b
+
+
+def _test_eq_shuffled(t: testing.SyncT):
+    """equality of two equal lists in different orders"""
+    a = _elements(0, t.scale(), 1)
+    ta = _tree(a)
+    tb = _tree(_shuffled(a))
+    for n in t.loop():
+        assert ta == tb
+
+
+def _test_to_xmlstr(t: testing.SyncT):
+    """XML encoding of a list to a string"""
+    a = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        assert len(a.to_xmlstr(pretty=False)) > n
+
+
+def _test_xml_roundtrip(t: testing.SyncT):
+    """XML encoding of a list and its schema-aware decoding, as a NETCONF message"""
+    schema = _schema()
+    a = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        wrapper = xml.Node("data", children=a.to_xml())
+        _count(yxml.from_xml(schema, wrapper, loose=True), n)
+
+
+def _test_to_json_str(t: testing.SyncT):
+    """JSON encoding of a list"""
+    a = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        assert len(a.to_json_str(pretty=False)) > n
+
+
+def _test_to_yang_jsonstr(t: testing.SyncT):
+    """YANG JSON encoding of a list, as a RESTCONF reply"""
+    a = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        assert len(a.to_yang_jsonstr(pretty=False)) > n
+
+
+def _test_json_roundtrip(t: testing.SyncT):
+    """JSON encoding and decoding of a list, as a persisted node"""
+    a = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        _count(ygdata.Node.from_json_str(a.to_json_str(pretty=False)), n)
+
+
+def _test_patch_edits_all(t: testing.SyncT):
+    """yang-patch edits for a diff changing every entry, and back to gdata"""
+    schema = _schema()
+    d = ygdata.diff(_devices(0, t.scale(), 1), _devices(0, t.scale(), 2))
+    for n in t.loop():
+        p = ypatch.diff_to_patch(d, "p")
+        count = 0
+        for e in p.edits:
+            ypatch.edit_to_gdata(schema, e)
+            count += 1
+        assert count >= n
+
+
+# Operations naming one entry, EACH per body against the loaded list.
+
+def _test_filter_each(t: testing.SyncT):
+    """filter selecting one entry"""
+    tree = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        for i in range(EACH):
+            _count(ygdata.filter(tree, _key_pred(_spread(i, n))), 1)
+
+
+def _test_prune_each(t: testing.SyncT):
+    """prune removing one entry"""
+    tree = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        for i in range(EACH):
+            res = ygdata.prune(tree, _key_pred(_spread(i, n)))
+            if n > 1:
+                _count(res, n - 1)
+
+
+def _test_patch_each(t: testing.SyncT):
+    """patch changing one entry"""
+    tree = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        for i in range(EACH):
+            _count(ygdata.patch(tree, _devices(_spread(i, n), 1, 2)), n)
+
+
+def _test_merge_each(t: testing.SyncT):
+    """merge of the list with a one entry list"""
+    tree = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        for i in range(EACH):
+            _count(ygdata.merge(tree, _devices(_spread(i, n), 1, 1)), n)
+
+
+def _test_diff_each(t: testing.SyncT):
+    """diff against the list with one entry changed"""
+    a = _elements(0, t.scale(), 1)
+    tree = _tree(a)
+    changed: list[ygdata.Node] = []
+    for i in range(EACH):
+        changed.append(_one_changed(a, _spread(i, t.scale())))
+    for n in t.loop():
+        for tb in changed:
+            _count(ygdata.diff(tree, tb), 1)
+
+
+def _test_patch_edits_each(t: testing.SyncT):
+    """yang-patch edits for a one entry diff, and back to gdata"""
+    schema = _schema()
+    a = _elements(0, t.scale(), 1)
+    tree = _tree(a)
+    diffs: list[?ygdata.Node] = []
+    for i in range(EACH):
+        diffs.append(ygdata.diff(tree, _one_changed(a, _spread(i, t.scale()))))
+    for n in t.loop():
+        for d in diffs:
+            p = ypatch.diff_to_patch(d, "p")
+            for e in p.edits:
+                ypatch.edit_to_gdata(schema, e)
+
+
+# adata: a hand written equivalent of what ayangc generates for the
+# schema above, so the encoder and decoder run without a generated
+# module.
+
+class _device_entry(yadata.MNode):
+    name: str
+    value: ?int
+    leaf0: ?str
+    leaf1: ?str
+    leaf2: ?str
+    leaf3: ?str
+
+    mut def __init__(self, name: str, value: ?int=None, leaf0: ?str=None, leaf1: ?str=None, leaf2: ?str=None, leaf3: ?str=None) -> None:
+        self.name = name
+        self.value = value
+        self.leaf0 = leaf0
+        self.leaf1 = leaf1
+        self.leaf2 = leaf2
+        self.leaf3 = leaf3
+
+    mut def to_gdata(self) -> ygdata.Node:
+        raise NotImplementedError("to_gdata")
+
+    @staticmethod
+    mut def from_gdata(n: ygdata.Node) -> _device_entry:
+        return _device_entry(name=n.get_str(_q("name")), value=n.get_opt_int(_q("value")), leaf0=n.get_opt_str(_q("leaf0")), leaf1=n.get_opt_str(_q("leaf1")), leaf2=n.get_opt_str(_q("leaf2")), leaf3=n.get_opt_str(_q("leaf3")))
+
+    mut def copy(self) -> _device_entry:
+        return _device_entry(self.name, self.value, self.leaf0, self.leaf1, self.leaf2, self.leaf3)
+
+
+class _device(yadata.MKeyedList[str, _device_entry]):
+    mut def __init__(self, elements: list[_device_entry]=[]) -> None:
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+
+    mut def create(self, key: str, value: ?int=None) -> _device_entry:
+        e = self.get(key)
+        if e is not None:
+            if value is not None:
+                e.value = value
+            return e
+        res = _device_entry(name=key, value=value)
+        self._append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.List) -> list[_device_entry]:
+        if n is not None:
+            return [_device_entry.from_gdata(e) for e in n.elements]
+        return []
+
+    mut def copy(self) -> _device:
+        copied_elements = []
+        for e in self._elements:
+            copied_elements.append(e.copy())
+        return _device(copied_elements)
+
+
+class _root(yadata.MNode):
+    device: _device
+
+    mut def __init__(self, device: ?_device=None) -> None:
+        self.device = device if device is not None else _device()
+
+    mut def to_gdata(self) -> ygdata.Node:
+        raise NotImplementedError("to_gdata")
+
+    mut def encode(self, schema: yschema.DRoot) -> ygdata.Node:
+        return yadata.from_adata(schema, self, loose=False, root_path=[])
+
+    @staticmethod
+    mut def from_gdata(n: ygdata.Node) -> _root:
+        return _root(device=_device(_device.from_gdata(n.get_opt_list(DEVICE))))
+
+    mut def copy(self) -> _root:
+        return _root(device=self.device.copy())
+
+
+def _test_adata_create(t: testing.SyncT):
+    """build an adata keyed list through create()"""
+    for n in t.loop():
+        r = _root()
+        for i in range(n):
+            r.device.create(_dev_name(i), value=1)
+        assert len(r.device) == n
+
+
+def _test_adata_decode(t: testing.SyncT):
+    """from_gdata of a list, as a transform decodes its input"""
+    tree = _devices(0, t.scale(), 1)
+    for n in t.loop():
+        assert len(_root.from_gdata(tree).device) == n
+
+
+def _test_adata_encode(t: testing.SyncT):
+    """from_adata of a list, as a transform encodes its output"""
+    schema = _schema()
+    r = _root.from_gdata(_devices(0, t.scale(), 1))
+    for n in t.loop():
+        _count(r.encode(schema), n)
+
+
+def _test_adata_copy(t: testing.SyncT):
+    """copy() of an adata list, as generated copy() methods do"""
+    r = _root.from_gdata(_devices(0, t.scale(), 1))
+    for n in t.loop():
+        assert len(r.copy().device) == n
+
+
+def _test_adata_get_each(t: testing.SyncT):
+    """get() of EACH keys of an adata keyed list"""
+    r = _root.from_gdata(_devices(0, t.scale(), 1))
+    for n in t.loop():
+        found = 0
+        for i in range(EACH):
+            if r.device.get(_dev_name(_spread(i, n))) is not None:
+                found += 1
+        assert found == EACH

--- a/src/test_ttt_perf.act
+++ b/src/test_ttt_perf.act
@@ -1,20 +1,17 @@
 """Scaling scenarios for the transaction engine.
 
-    acton test perf --module test_ttt_perf --jobs 1 --record
+    acton test perf  --module test_ttt_perf
+    acton test scale --module test_ttt_perf --name list_touch --end-scale 100000
 
-Each scenario builds a layer stack of its own, drives a fixed number of
-transactions through it and finishes when the last one has committed, so
-`acton test perf` times the whole scenario, and --record keeps the times
-and the heap each one allocated for the next run to be read against.
-
---jobs 1 matters. The runner otherwise runs several of these at once,
-which inflates the times and mixes up the allocation each is charged
-with, since that is read off one counter for the whole process. Build
-before recording, since compiling the rest of the project alongside the
-first scenario distorts it in the same way.
-
-SCALE below sets how large the scenarios are; raising it needs
---max-time raised with it, since the test timeout follows from that.
+Scale is the number of list entries. Each scenario builds its layer
+stack and loads the entries before the loop, from t.scale(), and each
+loop body then commits a fixed number of transactions against that
+list, or reads it a fixed number of times. So a body's growth is the
+growth of one transaction with the size of the list it runs against:
+flat when a small transaction costs the same whatever the list holds,
+linear when it pays for the whole list. The load scenarios are the
+exception: their body is the load itself, so linear is the best they
+can do.
 
 The shapes are what a fleet manager does at scale, with no generated
 adata or devices in the way:
@@ -25,47 +22,44 @@ adata or devices in the way:
   merges N sources, as the device layer of a shard does.
 - reshard: N transforms that each route their entry to
   /rfs{shard}/device{name} in a second layer, the shape of the top node.
+- shard: N transforms routed into SHARDS transforms of a second layer,
+  each of which merges its N/SHARDS sources, as the flotilla's device
+  config at the top node merges every device the flotilla manages.
 - links: N publishers and one subscriber linked to every one of them,
   the shape of an upgrade campaign.
+- db: the list shape with an LMDB store under the layer, so every
+  transaction is also written through persistence.
 
-Every shape is measured twice: loading it, and then touching one entry
-at a time, since the cost of one small transaction against a large list
-is what decides whether a fleet can be managed at all.
+Every transaction waits for the one before it to complete, not merely
+to report done: done fires before a commit has reached every node, and
+a read or a transaction that follows it straight away can see entries
+that are still provisional. An ordinary `acton test` run measures one
+entry, enough to keep the shapes honest but nothing about scale.
 """
 
+import file
 import testing
 
+import db as swdb
+import db.lmdb as swlmdb
 import ttt
 import yang.gdata as gdata
 
 
 NS = "urn:test:ttt-perf"
 
-# How large each scenario is. A scenario has to finish inside the test
-# timeout, which `acton test perf` derives from --max-time and which is
-# 3 seconds by default, so the sizes below are what today's engine
-# manages in about a second.
-#
-# SCALE multiplies all of them, for the closer look a change that only
-# pays off further up the curve needs. The scenarios that touch one
-# entry at a time grow with its square, since both the list and the
-# number of transactions against it grow, so --max-time has to grow
-# faster than SCALE does.
-SCALE = 1
+# Transactions or reads per loop body. Fixed, so that a body's growth
+# is the growth of one of them with the size of the list.
+TOUCHES = 16
+READS = 64
 
-LIST_N = 2000 * SCALE
-LIST_TOUCHES = 100 * SCALE
-
-FANIN_LOAD_N = 2000 * SCALE
-FANIN_N = 400 * SCALE
-FANIN_TOUCHES = 8 * SCALE
-
-RESHARD_N = 1000 * SCALE
+# Shards the reshard and shard scenarios spread their entries over.
+# Fixed, so that scale stays the number of entries and the fan-in of one
+# shard grows with it.
 RESHARD_SHARDS = 10
 
-LINKS_N = 200 * SCALE
-LINKS_TOUCH_N = 120 * SCALE
-LINKS_TOUCHES = 3 * SCALE
+# Members of the campaign that stays small while the fleet grows.
+FIXED_CAMPAIGN = 64
 
 # Leaves per entry beyond its key, so an entry is a container worth
 # merging and diffing rather than a single leaf.
@@ -84,7 +78,7 @@ def pad(i: int, width: int) -> str:
 
 
 def dev_name(i: int) -> str:
-    return "dev-" + pad(i, 6)
+    return "dev-" + pad(i, 9)
 
 
 def shard_name(i: int, shards: int) -> str:
@@ -111,13 +105,33 @@ def devices(start: int, count: int, value: int, shards: int) -> gdata.Node:
     return gdata.Container({q("device"): gdata.List([q("name")], elements)})
 
 
-def touches(n: int, count: int, shards: int) -> list[gdata.Node]:
+def devices_absent(start: int, count: int) -> gdata.Node:
+    """A diff deleting `count` /device entries starting at index `start`."""
+    elements: list[gdata.Node] = []
+    for i in range(start, start + count):
+        elements.append(gdata.Absent({q("name"): gdata.Leaf(dev_name(i))}))
+    return gdata.Container({q("device"): gdata.List([q("name")], elements)})
+
+
+def spread(i: int, n: int) -> int:
+    """Entry i of a walk over `n` entries that does not favour locality."""
+    return (i * 7919) % n
+
+
+def touches(n: int, count: int, round: int, shards: int) -> list[gdata.Node]:
     """`count` edits that each set a new value on one entry of `n`."""
     edits: list[gdata.Node] = []
     for i in range(count):
-        # Spread over the list so no edit is served by locality alone.
-        edits.append(devices((i * 7919) % n, 1, 2 + i, shards))
+        edits.append(devices(spread(i + count * round, n), 1, 2 + round, shards))
     return edits
+
+
+def entry_filter(i: int, top: str="device") -> gdata.FNode:
+    """Select /device{name} for entry i, as a read of one device does.
+
+    Below a fan-in of ListOut transforms the entries sit under /out.
+    """
+    return gdata.FNode(q(top), children=[gdata.FNode(q("name"), value_match=dev_name(i))])
 
 
 def campaign(name: str, members: int) -> gdata.Node:
@@ -132,6 +146,12 @@ def campaign(name: str, members: int) -> gdata.Node:
                 q("member"): gdata.List([q("name")], elements),
             })
         ])
+    })
+
+
+def campaign_absent(name: str) -> gdata.Node:
+    return gdata.Container({
+        q("campaign"): gdata.List([q("name")], [gdata.Absent({q("name"): gdata.Leaf(name)})])
     })
 
 
@@ -216,75 +236,397 @@ def reshard_stack() -> ttt.Layer:
     }), rfs, None)
 
 
-def links_stack() -> ttt.Layer:
-    """Publishers under /device and subscribers under /campaign."""
-    return ttt.Layer("top", ttt.Container({
-        q("device"): ttt.List(ttt.Transform(ListOut), [q("name")]),
-        q("campaign"): ttt.List(ttt.Transform(CountLinked, None, campaign_links), [q("name")]),
-    }), ttt.Sink(), None)
+def shard_stack() -> ttt.Layer:
+    """Transforms routed into shard transforms that each merge their share.
 
-
-actor Scenario(t: testing.AsyncT, stack: ttt.Layer, edits: list[gdata.Node]):
-    """Commit the edits through the stack in order, then pass the test.
-
-    Each edit waits for the one before it to commit, so the scenario
-    measures a series of transactions rather than their concurrency.
+    The second layer's /rfs entries are transforms, so each merges the
+    sources routed to its shard: the top node's per flotilla device
+    config, where one flotilla holds a thousand devices. Nothing lies
+    below them, as nothing lies below a device config.
     """
-    var next = 0
+    rfs = ttt.Layer("rfs", ttt.Container({
+        q("rfs"): ttt.List(ttt.Transform(ttt.PassThrough), [q("name")]),
+    }), None, None)
+    return ttt.Layer("top", ttt.Container({
+        q("device"): ttt.List(ttt.Transform(Reshard), [q("name")]),
+    }), rfs, None)
+
+
+def links_stack() -> ttt.Layer:
+    """Publishers under /device and subscribers under /campaign.
+
+    No layer below: with one, every touch also pays a fan-in merge of
+    every publisher there, which the fanin scenarios measure and which
+    would hide what the links themselves cost.
+    """
+    return ttt.Layer("top", ttt.Container({
+        q("device"): ttt.List(ttt.Transform(ttt.PassThrough), [q("name")]),
+        q("campaign"): ttt.List(ttt.Transform(CountLinked, None, campaign_links), [q("name")]),
+    }), None, None)
+
+
+# Setup edits, committed once before the loop.
+
+def no_setup(n: int) -> list[gdata.Node]:
+    return []
+
+
+def load(n: int) -> list[gdata.Node]:
+    return [devices(0, n, 1, 1)]
+
+
+def load_reshard(n: int) -> list[gdata.Node]:
+    return [devices(0, n, 1, RESHARD_SHARDS)]
+
+
+def load_campaign(n: int) -> list[gdata.Node]:
+    return load(n) + [campaign("c1", n)]
+
+
+def load_fixed_campaign(n: int) -> list[gdata.Node]:
+    members = FIXED_CAMPAIGN if n > FIXED_CAMPAIGN else n
+    return load(n) + [campaign("c1", members)]
+
+
+# Body edits, committed in order once per loop body; `round` counts
+# the bodies so each changes something.
+
+def body_load(n: int, round: int) -> list[gdata.Node]:
+    """The whole list in one transaction, changed each round."""
+    return [devices(0, n, 1 + round, 1)]
+
+
+def body_load_reshard(n: int, round: int) -> list[gdata.Node]:
+    return [devices(0, n, 1 + round, RESHARD_SHARDS)]
+
+
+def body_touch(n: int, round: int) -> list[gdata.Node]:
+    """TOUCHES transactions, each naming one entry."""
+    return touches(n, TOUCHES, round, 1)
+
+
+def body_touch_reshard(n: int, round: int) -> list[gdata.Node]:
+    return touches(n, TOUCHES, round, RESHARD_SHARDS)
+
+
+def body_modify_all(n: int, round: int) -> list[gdata.Node]:
+    """One transaction changing every entry."""
+    return [devices(0, n, 2 + round, 1)]
+
+
+def body_delete_add(n: int, round: int) -> list[gdata.Node]:
+    """TOUCHES transactions deleting one entry each, then one adding them back."""
+    edits: list[gdata.Node] = []
+    for i in range(TOUCHES):
+        edits.append(devices_absent(spread(i + TOUCHES * round, n), 1))
+    for i in range(TOUCHES):
+        edits.append(devices(spread(i + TOUCHES * round, n), 1, 1, 1))
+    return edits
+
+
+def body_delete_all_load(n: int, round: int) -> list[gdata.Node]:
+    """One transaction deleting every entry, then one loading them again."""
+    return [devices_absent(0, n), devices(0, n, 1, 1)]
+
+
+def body_campaign_add_delete(n: int, round: int) -> list[gdata.Node]:
+    """A campaign linked to every entry added, then deleted."""
+    return [campaign("c" + str(round), n), campaign_absent("c" + str(round))]
+
+
+actor Scenario(
+    t: testing.AsyncT,
+    make_stack: proc() -> ttt.Layer,
+    setup_edits: proc(int) -> list[gdata.Node],
+    body_edits: proc(int, int) -> list[gdata.Node]
+):
+    """Commit the setup edits, then per loop body the body edits in order.
+
+    A transaction is committed only once the one before it has
+    completed. The loop is driven by hand because the work finishes in
+    a callback: each body ends when its last edit has completed.
+    """
+    scale = t.scale()
+    stack = make_stack()
+    iterations = t.loop()
+    var edits: list[gdata.Node] = setup_edits(scale)
+    var next_edit = 0
+    var round = 0
+    var in_setup = True
+    # An actor variable, not a local: a local bound inside try and read
+    # after the except fails the compiler's back pass.
+    var n = 0
 
     def submit() -> None:
-        if next < len(edits):
-            edit = edits[next]
-            next += 1
-            stack.edit_config(edit, step, None)
+        if next_edit < len(edits):
+            edit = edits[next_edit]
+            next_edit += 1
+            stack.edit_config(edit, None, completed)
+        elif in_setup:
+            in_setup = False
+            body()
         else:
-            t.success()
+            round += 1
+            body()
 
-    def step(result: value) -> None:
+    def completed(result: value) -> None:
         if isinstance(result, Exception):
             t.failure(result)
             return
         submit()
 
+    def body() -> None:
+        try:
+            n = next(iterations)
+        except StopIteration:
+            t.success()
+            return
+        edits = body_edits(n, round)
+        next_edit = 0
+        submit()
+
     submit()
 
 
+actor Burst(t: testing.AsyncT):
+    """Load N entries, then per body touch every one of them at once.
+
+    What a fleet sees when many clients change one device each without
+    waiting for one another: the transactions contend for the same list
+    and queue on its lock. Both the list and the number of concurrent
+    transactions grow with scale.
+    """
+    scale = t.scale()
+    stack = list_stack()
+    iterations = t.loop()
+    var pending = 0
+    var failed = False
+    var round = 0
+    var n = 0
+
+    def loaded(result: value) -> None:
+        if isinstance(result, Exception):
+            t.failure(result)
+            return
+        body()
+
+    def body() -> None:
+        try:
+            n = next(iterations)
+        except StopIteration:
+            t.success()
+            return
+        edits = touches(n, n, round, 1)
+        round += 1
+        failed = False
+        pending = len(edits)
+        for edit in edits:
+            stack.edit_config(edit, None, completed)
+
+    def completed(result: value) -> None:
+        if isinstance(result, Exception) and not failed:
+            failed = True
+            t.failure(result)
+            return
+        pending -= 1
+        if pending == 0 and not failed:
+            body()
+
+    stack.edit_config(devices(0, scale, 1, 1), None, loaded)
+
+
+actor Reader(t: testing.AsyncT, make_stack: proc() -> ttt.Layer, read_below: bool):
+    """Load N entries, then per body read READS of them alone through a filter.
+
+    A read of one device out of a fleet, as a RESTCONF GET does. With
+    `read_below` the reads go to the layer below, through the transform
+    that merges every entry.
+    """
+    scale = t.scale()
+    stack = make_stack()
+    iterations = t.loop()
+    var round = 0
+    var n = 0
+
+    def loaded(result: value) -> None:
+        if isinstance(result, Exception):
+            t.failure(result)
+            return
+        body()
+
+    def body() -> None:
+        try:
+            n = next(iterations)
+        except StopIteration:
+            t.success()
+            return
+        layer = stack.below() if read_below else stack
+        top = "out" if read_below else "device"
+        found = 0
+        for i in range(READS):
+            got = layer.get_data(entry_filter(spread(i + READS * round, n), top))
+            if got is not None:
+                found += 1
+        round += 1
+        if found != READS:
+            t.failure(ValueError("read {found} of {READS} entries"))
+            return
+        body()
+
+    stack.edit_config(devices(0, scale, 1, 1), None, loaded)
+
+
+actor DbScenario(t: testing.EnvT):
+    """The list touch scenario over a layer with an LMDB store.
+
+    The store lives in a directory of its own, opened before the loop
+    and removed after it.
+    """
+    scale = t.scale()
+    fc = file.FileCap(t.env.cap)
+    fs = file.FS(fc)
+    db_path = fs.mktmpdir("test_ttt_perf_db_")
+    # The map size the application uses; the LMDB default fills at a
+    # few thousand entries.
+    store = swlmdb.LmdbStore(file.WriteFileCap(fc), db_path, 1 << 40)
+    stack = ttt.Layer("top", ttt.Container({
+        q("device"): ttt.List(ttt.Transform(ttt.PassThrough), [q("name")]),
+    }), None, store)
+    iterations = t.loop()
+    var edits: list[gdata.Node] = []
+    var next_edit = 0
+    var round = 0
+    var n = 0
+
+    def loaded(result: value) -> None:
+        if isinstance(result, Exception):
+            t.failure(result)
+            return
+        body()
+
+    def body() -> None:
+        try:
+            n = next(iterations)
+        except StopIteration:
+            store.close(closed)
+            return
+        edits = body_touch(n, round)
+        round += 1
+        next_edit = 0
+        submit()
+
+    def submit() -> None:
+        if next_edit < len(edits):
+            edit = edits[next_edit]
+            next_edit += 1
+            stack.edit_config(edit, None, completed)
+        else:
+            body()
+
+    def completed(result: value) -> None:
+        if isinstance(result, Exception):
+            t.failure(result)
+            return
+        submit()
+
+    def closed(error: ?Exception) -> None:
+        if error is not None:
+            t.failure(error)
+            return
+        await async fs.rmtree(db_path)
+        await async fs.rmdir(db_path)
+        t.success()
+
+    stack.edit_config(devices(0, scale, 1, 1), None, loaded)
+
+
+# Loads: the body is the load, so linear is the best case.
+
 actor list_load(t: testing.AsyncT):
-    """One transaction adding LIST_N transform entries to a list"""
-    Scenario(t, list_stack(), [devices(0, LIST_N, 1, 1)])
-
-
-actor list_touch_one(t: testing.AsyncT):
-    """LIST_TOUCHES transactions that each touch one entry of LIST_N"""
-    Scenario(t, list_stack(), [devices(0, LIST_N, 1, 1)] + touches(LIST_N, LIST_TOUCHES, 1))
+    """Add N transform entries to a list in one transaction"""
+    Scenario(t, list_stack, no_setup, body_load)
 
 
 actor fanin_load(t: testing.AsyncT):
-    """One transaction adding FANIN_LOAD_N sources of one transform below"""
-    Scenario(t, fanin_stack(), [devices(0, FANIN_LOAD_N, 1, 1)])
-
-
-actor fanin_touch_one(t: testing.AsyncT):
-    """FANIN_TOUCHES transactions that each touch one of FANIN_N sources"""
-    Scenario(t, fanin_stack(), [devices(0, FANIN_N, 1, 1)] + touches(FANIN_N, FANIN_TOUCHES, 1))
+    """Add N sources of one transform below in one transaction"""
+    Scenario(t, fanin_stack, no_setup, body_load)
 
 
 actor reshard_load(t: testing.AsyncT):
-    """One transaction routing RESHARD_N entries into RESHARD_SHARDS shards"""
-    Scenario(t, reshard_stack(), [devices(0, RESHARD_N, 1, RESHARD_SHARDS)])
+    """Route N entries into RESHARD_SHARDS shards of a second layer"""
+    Scenario(t, reshard_stack, no_setup, body_load_reshard)
 
 
-actor links_campaign_add(t: testing.AsyncT):
-    """One transaction linking a subscriber to every one of LINKS_N publishers"""
-    Scenario(t, links_stack(), [
-        devices(0, LINKS_N, 1, 1),
-        campaign("c1", LINKS_N),
-    ])
+actor shard_load(t: testing.AsyncT):
+    """Route N entries into RESHARD_SHARDS shard transforms"""
+    Scenario(t, shard_stack, no_setup, body_load_reshard)
 
 
-actor links_touch_one(t: testing.AsyncT):
-    """LINKS_TOUCHES transactions that each touch one of LINKS_TOUCH_N linked publishers"""
-    Scenario(t, links_stack(), [
-        devices(0, LINKS_TOUCH_N, 1, 1),
-        campaign("c1", LINKS_TOUCH_N),
-    ] + touches(LINKS_TOUCH_N, LINKS_TOUCHES, 1))
+actor list_modify_all(t: testing.AsyncT):
+    """With N entries loaded, change every one of them in one transaction"""
+    Scenario(t, list_stack, load, body_modify_all)
+
+
+actor list_delete_all(t: testing.AsyncT):
+    """With N entries loaded, delete all of them in one transaction, then load again"""
+    Scenario(t, list_stack, load, body_delete_all_load)
+
+
+actor links_campaign(t: testing.AsyncT):
+    """With N publishers loaded, add a campaign linked to every one, then delete it"""
+    Scenario(t, links_stack, load, body_campaign_add_delete)
+
+
+# Touches: the body is TOUCHES single-entry transactions against the
+# loaded list, so flat is the good case and linear the bad one.
+
+actor list_touch(t: testing.AsyncT):
+    """With N entries loaded, touch TOUCHES of them one transaction each"""
+    Scenario(t, list_stack, load, body_touch)
+
+
+actor list_delete_each(t: testing.AsyncT):
+    """With N entries loaded, delete TOUCHES of them one transaction each, then add them back"""
+    Scenario(t, list_stack, load, body_delete_add)
+
+
+actor fanin_touch(t: testing.AsyncT):
+    """With N sources loaded, touch TOUCHES of them one transaction each"""
+    Scenario(t, fanin_stack, load, body_touch)
+
+
+actor shard_touch(t: testing.AsyncT):
+    """With N entries loaded into shards, touch TOUCHES of them one transaction each"""
+    Scenario(t, shard_stack, load_reshard, body_touch_reshard)
+
+
+actor links_touch(t: testing.AsyncT):
+    """With N publishers linked to a campaign, touch TOUCHES of them one transaction each"""
+    Scenario(t, links_stack, load_campaign, body_touch)
+
+
+actor links_fixed_touch(t: testing.AsyncT):
+    """With a FIXED_CAMPAIGN member campaign over N publishers, touch TOUCHES of them"""
+    Scenario(t, links_stack, load_fixed_campaign, body_touch)
+
+
+actor list_burst(t: testing.AsyncT):
+    """With N entries loaded, touch every one of them in N transactions at once"""
+    Burst(t)
+
+
+actor list_touch_db(t: testing.EnvT):
+    """With N entries loaded into a persisted list, touch TOUCHES of them one transaction each"""
+    DbScenario(t)
+
+
+# Reads: READS single-entry reads per body.
+
+actor list_get_one(t: testing.AsyncT):
+    """With N entries loaded, read READS of them alone through a filter"""
+    Reader(t, list_stack, False)
+
+
+actor fanin_get_one(t: testing.AsyncT):
+    """With N sources loaded, read READS of them alone from below the fan-in transform"""
+    Reader(t, fanin_stack, True)


### PR DESCRIPTION
Two test modules mean to be used with `acton test perf` and `acton test scale`.

`src/test_ttt_perf.act` drives the shapes fleetmgr builds: a list of transforms, the same list feeding one transform that merges every source as a flotilla's device config does, entries routed into per-shard transforms, a subscriber linked to every publisher as a campaign is, and the list over an LMDB store. Each scenario builds and loads its layer stack before the loop from `t.scale()`, and each body is a fixed number of transactions or reads against it, so a body's growth is the growth of one transaction with the size of the list: flat is the good case, linear the bad one. The load scenarios are the exception, their body being the load. Transactions are chained on `complete`, not `done`, since `done` fires before a commit has reached every node.

`src/test_gdata_perf.act` mirrors `test_gdata_scale` in acton-yang so that what a node pays per transaction and per message is visible from here: merge, diff, patch, filter and prune; equality and `key_str`; adata encoding, decoding and copying; XML and JSON encoding and decoding; yang-patch conversion. The trees carry namespace and module the way the adata encoder sets them.

An ordinary `acton test` run measures every scenario at scale 1, 43 scenarios in under six seconds. The modules need the Acton that has `t.scale()` and `t.loop()`.

Typical use:

    acton test scale --module test_ttt_perf --name fanin_touch --end-scale 16384
    acton test scale --module test_ttt_perf --name fanin_touch --end-scale 16384 --compare <journal>

What these have shown so far, measured on main: touches against a plain list are flat to 65536 entries; a touch below a fan-in of N sources is linear in N (67 ms and 89 MB at 1000 sources, from merging every source twice per commit); a campaign linked to N publishers is quadratic (21 ms and 27 MB per member at 2048); filter, prune, patch, merge and diff of one entry are all linear in the list; list equality is quadratic when element order differs.